### PR TITLE
Require Swift 6.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,11 +6,11 @@ on:
     branches: [ "main" ]
 jobs:
   build-lint-test:
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
     - uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "6.0"
+        swift-version: "6.3"
     - uses: actions/checkout@v4
     - name: Toolchain
       run: swift --version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
   build-lint-test:
     runs-on: macos-latest
     steps:
-    - uses: swift-actions/setup-swift@v2
+    - uses: swift-actions/setup-swift@v3
       with:
         swift-version: "6.3"
     - uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000" alt="MIT license">
   </a>
   <a href="https://github.com/apple/swift">
-    <img src="https://img.shields.io/badge/Swift-6.0-orange.svg" alt="Swift 6.0 supported">
+    <img src="https://img.shields.io/badge/Swift-6.3-orange.svg" alt="Swift 6.3 supported">
   </a>
   <a href="https://swift.org/package-manager/">
     <img src="https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square" alt="Swift Package Manager compatible">
@@ -65,7 +65,7 @@ Below is a simple example demonstrating how you might integrate this library int
 In `Package.swift` create an executable target that depends on this library:
 
 ```swift
-// swift-tools-version:6.0
+// swift-tools-version:6.3
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary

- require SwiftPM and Swift 6.3
- run CI exclusively with Swift 6.3 on the current macOS runner
- update the README badge and integration example to advertise Swift 6.3

## Impact

Consumers now need a Swift 6.3 or newer toolchain to resolve and build the package. This change does not add compatibility modes, CI jobs, or fallbacks for earlier Swift versions.

## Validation

- `swift package dump-package` — tools version 6.3.0
- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict` — 0 violations
- workflow YAML parsing
- `git diff --check`
