### PR TITLE
Harden codegen correctness, maintainability, and scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The code generator runs on macOS 14 or newer because it uses JavaScriptCore to e
 
 ## Upgrade Note: Generated HTTP Operations
 
-Generated HTTP support now requires `GraphQLOperation.minifiedDocument`. Regenerate the API and operation files together when upgrading. If your application defines a custom `GraphQLOperation` conformer, add a precomputed `minifiedDocument` that is lexically equivalent to `document` with ignored GraphQL characters removed. This is a source-breaking generated-API change intended for the next minor release.
+Generated HTTP support now requires `GraphQLOperation.minifiedDocument`. Automatic persisted operations also require `GraphQLOperation.documentHash` and `GraphQLOperation.minifiedDocumentHash`, the precomputed SHA-256 hashes of `document` and `minifiedDocument`. Generated operation documents now embed their fragment definitions directly, and generated fragment types no longer expose a `source` property. Regenerate the API and operation files together when upgrading. If your application defines a custom `GraphQLOperation` conformer, add the new properties with the same semantics. This is a source-breaking generated-API change intended for the next minor release.
 
 ---
 

--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -16,20 +16,30 @@ public struct Codegen: Sendable {
     public func run() async throws {
         // Input
         let start = Date()
-        let schema = try await SchemaLoader(configuration: configuration, urlSession: urlSession).load()
-        let documents = try DocumentsLoader(configuration: configuration).load()
+        let graphQLJS = try GraphQLJS()
+        let loadedSchema = try await SchemaLoader(
+            configuration: configuration,
+            graphQLJS: graphQLJS,
+            urlSession: urlSession
+        ).load()
+        let documents = try await DocumentsLoader(
+            configuration: configuration,
+            graphQLJS: graphQLJS
+        ).load()
 
         // Validation
         if configuration.validation {
-            try DocumentsValidator(
-                schema: schema,
-                documents: documents
+            try await DocumentsValidator(
+                schema: loadedSchema.schema,
+                schemaJSON: loadedSchema.validationJSON,
+                documents: documents,
+                graphQLJS: graphQLJS
             ).validate()
         }
 
         // Resolution
         let resolvedDocuments = try DocumentsResolver(
-            schema: schema,
+            schema: loadedSchema.schema,
             documents: documents
         ).resolve()
 
@@ -42,7 +52,7 @@ public struct Codegen: Sendable {
             ).write(using: fileOutput)
             try await SchemaWriter(
                 configuration: configuration,
-                schema: schema,
+                schema: loadedSchema.schema,
                 resolvedDocuments: resolvedDocuments
             ).write(using: fileOutput)
             try await APIWriter(

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,8 +1,31 @@
 extension String {
-    subscript(_ range: Range<Int>) -> Substring {
-        self[
-            index(startIndex, offsetBy: range.startIndex)..<index(startIndex, offsetBy: range.endIndex)
-        ]
+    struct InvalidUTF16Range: Error, CustomStringConvertible {
+        let range: Range<Int>
+
+        var description: String {
+            "The UTF-16 range \(range) does not identify valid String boundaries."
+        }
+    }
+
+    func substring(utf16Range range: Range<Int>) throws -> Substring {
+        let utf16 = utf16
+        guard range.lowerBound >= 0,
+              range.upperBound >= range.lowerBound,
+              let utf16Start = utf16.index(
+                  utf16.startIndex,
+                  offsetBy: range.lowerBound,
+                  limitedBy: utf16.endIndex
+              ),
+              let utf16End = utf16.index(
+                  utf16.startIndex,
+                  offsetBy: range.upperBound,
+                  limitedBy: utf16.endIndex
+              ),
+              let start = String.Index(utf16Start, within: self),
+              let end = String.Index(utf16End, within: self) else {
+            throw InvalidUTF16Range(range: range)
+        }
+        return self[start..<end]
     }
 
     var capitalizedFirst: String {

--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
@@ -337,7 +337,7 @@ enum AST {
             switch self {
             case .named(let namedType): return .optional(
                 .name(
-                    SourceTypeName.swiftNativeScalar(graphQLScalarName: namedType.name.value) ?? namedType.name.value
+                    SourceTypeName(nativeGraphQLScalarName: namedType.name.value)?.formatted() ?? namedType.name.value
                 )
             )
             case .list(let innerType): return .optional(.list(innerType.type.typeName))

--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 struct DocumentASTParser {
+    let graphQLJS: GraphQLJS
     let sourceText: String
 
-    func parse() throws -> AST.Document {
-        let astJSON = try GraphQLJS(sourceText: sourceText).parsed()
+    func parse() async throws -> AST.Document {
+        let astJSON = try await graphQLJS.parse(sourceText)
         return try JSONDecoder().decode(AST.Document.self, from: astJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import JavaScriptCore
 
-struct GraphQLJS {
+actor GraphQLJS {
     enum Error: Swift.Error, CustomStringConvertible {
         case bundleEvaluationFailed(String)
         case bundleReadFailed(URL, String)
@@ -45,12 +45,10 @@ struct GraphQLJS {
         }
     }()
 
-    let sourceText: String
-
     private let context: JSContext
     private let library: JSValue
 
-    init(sourceText: String) throws {
+    init() throws {
         let bundleContents = try Self.bundleContents.get()
         guard let context = JSContext() else {
             throw Error.contextCreationFailed
@@ -67,14 +65,16 @@ struct GraphQLJS {
         }
         self.context = context
         self.library = library
-        self.sourceText = sourceText
     }
 
-    func canonicalized() throws -> String {
+    func canonicalize(_ sourceText: String) throws -> String {
         try stringResult(function: "canonicalizeDocument", arguments: [sourceText])
     }
 
-    func convertedSDLSchema(introspectionQuery: String) throws -> (data: Data, text: String) {
+    func convertSDLSchema(
+        _ sourceText: String,
+        introspectionQuery: String
+    ) throws -> (data: Data, text: String) {
         let text = try stringResult(
             function: "convertSDLSchema",
             arguments: [sourceText, introspectionQuery]
@@ -82,15 +82,15 @@ struct GraphQLJS {
         return (Data(text.utf8), text)
     }
 
-    func parsed() throws -> Data {
+    func parse(_ sourceText: String) throws -> Data {
         Data(try stringResult(function: "parseGraphQL", arguments: [sourceText]).utf8)
     }
 
-    func validated(schemaJSONString: String) throws -> Data {
+    func validate(_ sourceText: String, schemaJSON: String) throws -> Data {
         Data(
             try stringResult(
                 function: "validateDocument",
-                arguments: [sourceText, schemaJSONString]
+                arguments: [sourceText, schemaJSON]
             ).utf8
         )
     }

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -25,9 +25,10 @@ struct Document: Sendable {
 
     struct Operation: Sendable {
         let ast: AST.OperationDefinition
-        let sourceText: Substring
-        let resolvedText: String?
-        let hash: String?
+        let canonicalText: String
+        let canonicalHash: String
+        let documentText: String
+        let documentHash: String
     }
 
     struct Fragment {
@@ -38,15 +39,15 @@ struct Document: Sendable {
 
     let url: URL
     let definitions: [Definition]
+    let relativePath: String
 
     func outputURL(_ configuration: Configuration) -> URL {
-        let outputURL = url.appendingPathExtension("swift")
-        return switch configuration.output.documents.directory {
+        switch configuration.output.documents.directory {
         case .definition:
-            outputURL
+            url.appendingPathExtension("swift")
         case .directory(let outputDirectory):
             outputDirectory.appending(
-                path: outputURL.lastPathComponent,
+                path: relativePath + ".swift",
                 directoryHint: .notDirectory
             )
         }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -2,40 +2,55 @@ import CryptoKit
 import Foundation
 
 struct DocumentsLoader {
+    private enum ParsedDefinition {
+        case fragment(String)
+        case operation(ast: AST.OperationDefinition, sourceText: Substring)
+    }
+
+    private struct ParsedDocument {
+        let definitions: [ParsedDefinition]
+        let relativePath: String
+        let url: URL
+    }
+
     let configuration: Configuration
+    let graphQLJS: GraphQLJS
 
-    private var shouldResolve: Bool {
-        configuration.validation || shouldHash
-    }
-
-    private var shouldHash: Bool {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: true
-        case .automatic, .none: false
-        }
-    }
-
-    func load() throws -> Documents {
+    func load() async throws -> Documents {
         let scan = try DocumentScanner(directories: configuration.input.documentDirectories).scan()
-        var documents: [Document] = []
         var fragmentLookup: [String: Document.Fragment] = [:]
-        for documentURL in scan.documentFileURLs {
+        let parsedDocuments = try await parse(
+            scan.documentFileURLs,
+            fragmentLookup: &fragmentLookup
+        )
+        return Documents(
+            previouslyGenerated: scan.generatedFileURLs,
+            documents: try await prepare(parsedDocuments, fragmentLookup: fragmentLookup),
+            fragmentLookup: fragmentLookup
+        )
+    }
+
+    private func parse(
+        _ documentURLs: [URL],
+        fragmentLookup: inout [String: Document.Fragment]
+    ) async throws -> [ParsedDocument] {
+        var documents: [ParsedDocument] = []
+        documents.reserveCapacity(documentURLs.count)
+        for documentURL in documentURLs {
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
-            let ast = try DocumentASTParser(sourceText: documentText).parse()
-            var definitions: [Document.Definition] = []
+            let ast = try await DocumentASTParser(
+                graphQLJS: graphQLJS,
+                sourceText: documentText
+            ).parse()
+            var definitions: [ParsedDefinition] = []
+            definitions.reserveCapacity(ast.definitions.count)
             for definition in ast.definitions {
                 switch definition {
                 case .operation(let operation):
-                    definitions.append(
-                        .operation(
-                            Document.Operation(
-                                ast: operation,
-                                sourceText: documentText[operation.loc.range],
-                                resolvedText: nil,
-                                hash: nil
-                            )
-                        )
-                    )
+                    definitions.append(.operation(
+                        ast: operation,
+                        sourceText: try documentText.substring(utf16Range: operation.loc.range)
+                    ))
                 case .fragment(let fragment):
                     if let existing = fragmentLookup[fragment.name.value] {
                         throw Codegen.Error(description: """
@@ -58,63 +73,86 @@ struct DocumentsLoader {
                     fragmentLookup[fragment.name.value] = Document.Fragment(
                         file: documentURL,
                         ast: fragment,
-                        sourceText: documentText[fragment.loc.range]
+                        sourceText: try documentText.substring(utf16Range: fragment.loc.range)
                     )
                 }
             }
-            documents.append(Document(url: documentURL, definitions: definitions))
+            documents.append(
+                ParsedDocument(
+                    definitions: definitions,
+                    relativePath: try relativePath(for: documentURL),
+                    url: documentURL
+                )
+            )
         }
-        return Documents(
-            previouslyGenerated: scan.generatedFileURLs,
-            documents: shouldResolve ? try resolvedDocuments(documents, fragmentLookup: fragmentLookup) : documents,
-            fragmentLookup: fragmentLookup
-        )
+        return documents
     }
 
-    private func resolvedDocuments(
-        _ documents: [Document],
+    private func prepare(
+        _ documents: [ParsedDocument],
         fragmentLookup: [String: Document.Fragment]
-    ) throws -> [Document] {
+    ) async throws -> [Document] {
         var updatedDocuments: [Document] = []
+        updatedDocuments.reserveCapacity(documents.count)
         for document in documents {
             var updatedDefinitions: [Document.Definition] = []
+            updatedDefinitions.reserveCapacity(document.definitions.count)
             for definition in document.definitions {
                 switch definition {
-                case .operation(let operation):
-                    let resolvedText = try GraphQLJS(
-                        sourceText: try OperationTextResolver(
-                            operation: operation,
-                            fragmentLookup: fragmentLookup
-                        ).expandSourceText { $0.sourceText }
-                    ).canonicalized()
+                case .operation(let operationAST, let operationSourceText):
+                    let expandedText = try OperationTextResolver(
+                        fragmentLookup: fragmentLookup,
+                        operationAST: operationAST,
+                        operationSourceText: operationSourceText
+                    ).expandSourceText { $0.sourceText }
+                    let canonicalText = try await graphQLJS.canonicalize(expandedText)
                     updatedDefinitions.append(
                         .operation(
                             Document.Operation(
-                                ast: operation.ast,
-                                sourceText: operation.sourceText,
-                                resolvedText: resolvedText,
-                                hash: shouldHash ? hash(resolvedText) : nil
+                                ast: operationAST,
+                                canonicalText: canonicalText,
+                                canonicalHash: hash(canonicalText),
+                                documentText: expandedText,
+                                documentHash: hash(expandedText),
                             )
                         )
                     )
-                case .fragment:
-                    updatedDefinitions.append(definition)
+                case .fragment(let name):
+                    updatedDefinitions.append(.fragment(name))
                 }
             }
-            updatedDocuments.append(Document(url: document.url, definitions: updatedDefinitions))
+            updatedDocuments.append(
+                Document(
+                    url: document.url,
+                    definitions: updatedDefinitions,
+                    relativePath: document.relativePath
+                )
+            )
         }
         return updatedDocuments
+    }
+
+    private func relativePath(for documentURL: URL) throws -> String {
+        let documentComponents = documentURL.standardizedFileURL.pathComponents
+        let sourceRoot = configuration.input.documentDirectories
+            .map(\.standardizedFileURL.pathComponents)
+            .filter { documentComponents.starts(with: $0) }
+            .max { $0.count < $1.count }
+        guard let sourceRoot else {
+            throw Codegen.Error(description: "Document is outside the configured input directories: \(documentURL)")
+        }
+        return documentComponents.dropFirst(sourceRoot.count).joined(separator: "/")
     }
 
     private func hash(_ sourceText: String) -> String {
         let digits = Array("0123456789abcdef".utf8)
         let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
+        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+            var index = 0
             for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0F)]
-                p += 2
+                buffer[index] = digits[Int(byte >> 4)]
+                buffer[index + 1] = digits[Int(byte & 0x0F)]
+                index += 2
             }
             return capacity
         }

--- a/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
@@ -1,14 +1,15 @@
 import OrderedCollections
 
 struct OperationTextResolver {
-    let operation: Document.Operation
     let fragmentLookup: [String: Document.Fragment]
+    let operationAST: AST.OperationDefinition
+    let operationSourceText: Substring
 
     func expandSourceText(
         mapFragmentSpread: (Document.Fragment) -> Substring
     ) throws -> String {
         var text = """
-        \(operation.sourceText)
+        \(operationSourceText)
         """
         let fragmentSpreads = try fragmentSpreadsDeep().compactMap(mapFragmentSpread)
         if !fragmentSpreads.isEmpty {
@@ -21,7 +22,7 @@ struct OperationTextResolver {
     private func fragmentSpreadsDeep() throws -> [Document.Fragment] {
         var result: [Document.Fragment] = []
         var visited: Set<String> = []
-        var stack: [AST.SelectionSet] = [operation.ast.selectionSet]
+        var stack: [AST.SelectionSet] = [operationAST.selectionSet]
         while let current = stack.popLast() {
             for selection in current.selections {
                 switch selection {
@@ -33,7 +34,7 @@ struct OperationTextResolver {
                         guard let fragment = fragmentLookup[fragmentSpread.name.value] else {
                             throw Codegen.Error(description: """
                             Fragment spread '...\(fragmentSpread.name.value)' used in operation \
-                            \(operation.ast.name?.value ?? "")
+                            \(operationAST.name?.value ?? "")
                             but no definition was found for the fragment.
                             """)
                         }

--- a/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
@@ -16,8 +16,8 @@ struct DocumentScanner {
                 result.generatedFileURLs.append(contentsOf: scan.generatedFileURLs)
             }
         return DocumentScan(
-            documentFileURLs: scan.documentFileURLs.sorted { $0.path < $1.path },
-            generatedFileURLs: scan.generatedFileURLs.sorted { $0.path < $1.path }
+            documentFileURLs: Set(scan.documentFileURLs).sorted { $0.path < $1.path },
+            generatedFileURLs: Set(scan.generatedFileURLs).sorted { $0.path < $1.path }
         )
     }
 

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -16,11 +16,11 @@ struct __Schema: Decodable {
             let specifiedByURL: String?
 
             var isNativeSwiftType: Bool {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) != nil
+                SourceTypeName(nativeGraphQLScalarName: name) != nil
             }
 
             var swiftName: String {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) ?? name
+                SourceTypeName(nativeGraphQLScalarName: name)?.formatted() ?? name
             }
         }
 
@@ -106,7 +106,7 @@ struct __Schema: Decodable {
             let name: String
 
             var swiftName: String {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) ?? name
+                SourceTypeName(nativeGraphQLScalarName: name)?.formatted() ?? name
             }
 
             init(from decoder: Decoder) throws {

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -2,7 +2,6 @@ import Foundation
 import OrderedCollections
 
 struct Schema {
-    let jsonString: String?
     let queryTypeRef: __Schema.__TypeRef.Object
     let mutationTypeRef: __Schema.__TypeRef.Object?
     let subscriptionTypeRef: __Schema.__TypeRef.Object?

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct LoadedSchema {
+    let schema: Schema
+    let validationJSON: String
+}
+
 // Type names are guaranteed to be unique
 // https://spec.graphql.org/October2021/#sel-FAHTLABDBEmrR
 struct TypeASTCache {
@@ -23,6 +28,19 @@ struct TypeASTCache {
             }
         }
     }
+
+    func inheritedInterfaces(_ directInterfaces: [__Schema.__TypeRef.Interface]) -> Set<String> {
+        var inherited: Set<String> = []
+        var remaining = directInterfaces.map(\.name)
+        while let name = remaining.popLast() {
+            guard inherited.insert(name).inserted,
+                  let interface = interfaces[name] else {
+                continue
+            }
+            remaining.append(contentsOf: interface.interfaces.map(\.name))
+        }
+        return inherited
+    }
 }
 
 struct TypeCache {
@@ -36,33 +54,17 @@ struct TypeCache {
     init(_ cache: TypeASTCache) {
         scalars = cache.scalars.mapValues { Schema.Scalar(ast: $0) }
         for (name, ast) in cache.objects {
-            var implements: Set<String> = []
-            var interfaces = ast.interfaces.map(\.name)
-            while let interface = interfaces.popLast() {
-                implements.insert(interface)
-                if let interface = cache.interfaces[interface] {
-                    interfaces.append(contentsOf: interface.interfaces.map(\.name))
-                }
-            }
             objects[name] = Schema.Object(
                 ast: ast,
                 fields: ast.fields.reduce(into: [:]) { fields, field in fields[field.name] = field },
-                implements: implements
+                implements: cache.inheritedInterfaces(ast.interfaces)
             )
         }
         for (name, ast) in cache.interfaces {
-            var implements: Set<String> = []
-            var _interfaces = ast.interfaces.map(\.name)
-            while let interface = _interfaces.popLast() {
-                implements.insert(interface)
-                if let interface = cache.interfaces[interface] {
-                    _interfaces.append(contentsOf: interface.interfaces.map(\.name))
-                }
-            }
             interfaces[name] = Schema.Interface(
                 ast: ast,
                 fields: ast.fields.reduce(into: [:]) { fields, field in fields[field.name] = field },
-                implements: implements
+                implements: cache.inheritedInterfaces(ast.interfaces)
             )
         }
         for (name, ast) in cache.unions {
@@ -78,20 +80,23 @@ struct TypeCache {
 
 struct SchemaLoader {
     let configuration: Configuration
+    let graphQLJS: GraphQLJS
     let urlSession: URLSession
 
-    func load() async throws -> Schema {
-        let (jsonString, typedSchema) = try await loadIntrospection()
-        return Schema(
-            jsonString: jsonString,
-            queryTypeRef: typedSchema.queryType,
-            mutationTypeRef: typedSchema.mutationType,
-            subscriptionTypeRef: typedSchema.subscriptionType,
-            typeCache: TypeCache(TypeASTCache(typedSchema))
+    func load() async throws -> LoadedSchema {
+        let (validationJSON, typedSchema) = try await loadIntrospection()
+        return LoadedSchema(
+            schema: Schema(
+                queryTypeRef: typedSchema.queryType,
+                mutationTypeRef: typedSchema.mutationType,
+                subscriptionTypeRef: typedSchema.subscriptionType,
+                typeCache: TypeCache(TypeASTCache(typedSchema))
+            ),
+            validationJSON: validationJSON
         )
     }
 
-    private func loadIntrospection() async throws -> (String?, __Schema) {
+    private func loadIntrospection() async throws -> (String, __Schema) {
         switch configuration.input.schemaSource {
         case .introspectionEndpoint(
             let endpoint,
@@ -112,7 +117,7 @@ struct SchemaLoader {
             let includeDeprecatedFields,
             let includeDeprecatedEnumValues
         ):
-            try loadSchemaFromSDLFile(
+            try await loadSchemaFromSDLFile(
                 schemaFile,
                 includeDeprecatedFields: includeDeprecatedFields,
                 includeDeprecatedEnumValues: includeDeprecatedEnumValues
@@ -125,7 +130,7 @@ struct SchemaLoader {
         headers: [String: String],
         includeDeprecatedFields: Bool = false,
         includeDeprecatedEnumValues: Bool = false
-    ) async throws -> (String?, __Schema) {
+    ) async throws -> (String, __Schema) {
         let data = try await IntrospectionRunner(
             endpoint: endpoint,
             headers: headers,
@@ -134,38 +139,42 @@ struct SchemaLoader {
             urlSession: urlSession
         ).run()
         let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
-        var schemaString: String?
-        if configuration.validation {
-            let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            let schemaJSONData = try JSONSerialization.data(withJSONObject: obj["data"] as Any)
-            schemaString = String(data: schemaJSONData, encoding: .utf8)!
+        guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let schemaObject = response["data"] else {
+            throw Codegen.Error(description: "The introspection endpoint returned an invalid GraphQL response.")
         }
-        return (schemaString, __schema)
+        let schemaJSON = try JSONSerialization.data(withJSONObject: schemaObject)
+        return (try decodeUTF8(schemaJSON, source: endpoint), __schema)
     }
 
-    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (String?, __Schema) {
+    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (String, __Schema) {
         let data = try Data(contentsOf: schemaFile)
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: data).__schema
-        var schemaString: String?
-        if configuration.validation {
-            schemaString = String(data: data, encoding: .utf8)!
-        }
-        return (schemaString, __schema)
+        return (try decodeUTF8(data, source: schemaFile), __schema)
     }
 
     private func loadSchemaFromSDLFile(
         _ schemaFile: URL,
         includeDeprecatedFields: Bool,
         includeDeprecatedEnumValues: Bool
-    ) throws -> (String?, __Schema) {
+    ) async throws -> (String, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
         let introspectionQuery = IntrospectionQuery(
             includeDeprecatedFields: includeDeprecatedFields,
             includeDeprecatedEnumValues: includeDeprecatedEnumValues
         ).query
-        let jsonSchema = try GraphQLJS(sourceText: sdlSchemaString)
-            .convertedSDLSchema(introspectionQuery: introspectionQuery)
+        let jsonSchema = try await graphQLJS.convertSDLSchema(
+            sdlSchemaString,
+            introspectionQuery: introspectionQuery
+        )
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: jsonSchema.data).__schema
-        return (configuration.validation ? jsonSchema.text : nil, __schema)
+        return (jsonSchema.text, __schema)
+    }
+
+    private func decodeUTF8(_ data: Data, source: URL) throws -> String {
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw Codegen.Error(description: "Schema source is not valid UTF-8: \(source)")
+        }
+        return string
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/APIWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIWriter.swift
@@ -5,7 +5,7 @@ struct APIWriter {
     let hasMutation: Bool
     let hasSubscription: Bool
 
-    private var HTTPSupportDirectory: URL {
+    private var httpSupportDirectory: URL {
         configuration.output.api.directory.appending(
             path: "HTTPSupport",
             directoryHint: .isDirectory
@@ -25,7 +25,7 @@ struct APIWriter {
 
         // HTTP Support
         if configuration.output.api.HTTPSupport != nil {
-            await fileOutput.createDirectory(at: HTTPSupportDirectory)
+            await fileOutput.createDirectory(at: httpSupportDirectory)
             try await DefaultEncodersWriter(
                 hasSubscription: hasSubscription,
                 configuration: configuration
@@ -48,7 +48,7 @@ struct APIWriter {
                 configuration: configuration
             ).write(using: fileOutput)
         } else {
-            await fileOutput.remove(at: HTTPSupportDirectory)
+            await fileOutput.remove(at: httpSupportDirectory)
         }
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
@@ -15,11 +15,11 @@ struct AnyEncodableWriter {
         \(header)\(accessLevel)struct AnyEncodable: Encodable, Sendable {
             private let encoder: @Sendable (Encoder) throws -> Void
             \(accessLevel)init<T: Encodable & Sendable>(_ value: T) {
-                self.encoder = value.encode(to:)
+                self.encoder = { encoder in try value.encode(to: encoder) }
             }
             \(accessLevel)init?<T: Encodable & Sendable>(_ value: T?) {
                 guard let value else { return nil }
-                self.encoder = value.encode(to:)
+                self.encoder = { encoder in try value.encode(to: encoder) }
             }
             \(accessLevel)func encode(to encoder: Encoder) throws {
                 try self.encoder(encoder)

--- a/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
@@ -12,7 +12,7 @@ struct GraphQLNullableWriter {
 
     func write(using fileOutput: FileOutput) async throws {
         try await """
-        \(header)\(accessLevel)enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
+        \(header)\(accessLevel)indirect enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
             case null
             case value(T)
 

--- a/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
@@ -38,7 +38,7 @@ struct GraphQLResponseWriter {
                 let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
                 let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
                 if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-                    guard errors == nil || !errors!.isEmpty else {
+                    guard errors?.isEmpty != true else {
                         throw DecodingError.dataCorruptedError(
                             forKey: .errors,
                             in: container,

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -35,23 +35,22 @@ struct DefaultEncodersWriter {
     private func content() -> String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: GETWithAutomaticPersistedOperations()
-            case .registered: GETWithRegisteredPersistedOperations()
-            case .none: GETWithNoPersistedOperations()
+            case .automatic: getWithAutomaticPersistedOperations()
+            case .registered: getWithRegisteredPersistedOperations()
+            case .none: getWithNoPersistedOperations()
             }
         } else {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: POSTWithAutomaticPersistedOperations()
-            case .registered: POSTWithRegisteredPersistedOperations()
-            case .none: POSTWithNoPersistedOperations()
+            case .automatic: postWithAutomaticPersistedOperations()
+            case .registered: postWithRegisteredPersistedOperations()
+            case .none: postWithNoPersistedOperations()
             }
         }
     }
 
-    private func GETWithAutomaticPersistedOperations() -> String {
+    private func getWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
-        import Foundation
+        \(header)import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -74,7 +73,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithAutomaticPersistedOperations())
@@ -115,37 +114,25 @@ struct DefaultEncodersWriter {
                 let query = minifyDocument ? Operation.minifiedDocument : Operation.document
                 var extensions = operation.extensions
                 if automaticPersistedOperationPhase != nil {
-                    var _extensions = extensions ?? [:]
-                    _extensions["persistedQuery"] = AnyEncodable([
+                    var persistedExtensions = extensions ?? [:]
+                    persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(Body.hash(query))
+                        "sha256Hash": AnyEncodable(
+                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                        )
                     ])
-                    extensions = _extensions
+                    extensions = persistedExtensions
                 }
                 self.operationName = Operation.operationName
                 self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
                 self.variables = AnyEncodable(operation.variables)
                 self.extensions = extensions
             }
-
-            private static func hash(_ sourceText: String) -> String {
-                let digits = Array("0123456789abcdef".utf8)
-                let capacity = 2 * SHA256.Digest.byteCount
-                return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-                    var p = ptr.baseAddress!
-                    for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                        p[0] = digits[Int(byte >> 4)]
-                        p[1] = digits[Int(byte & 0x0f)]
-                        p += 2
-                    }
-                    return capacity
-                }
-            }
         }
         """
     }
 
-    private func GETWithRegisteredPersistedOperations() -> String {
+    private func getWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -161,7 +148,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "operationName", value: body.operationName),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithRegisteredPersistedOperations())
@@ -197,7 +184,7 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func GETWithNoPersistedOperations() -> String {
+    private func getWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -220,7 +207,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithNoPersistedOperations())
@@ -265,10 +252,9 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func POSTWithAutomaticPersistedOperations() -> String {
+    private func postWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
-        import Foundation
+        \(header)import Foundation
 
         /// A HTTPBodyEncoder that encodes an operation into json formatted data
         /// as specified by the spec:
@@ -305,37 +291,25 @@ struct DefaultEncodersWriter {
                 let query = minifyDocument ? Operation.minifiedDocument : Operation.document
                 var extensions = operation.extensions
                 if automaticPersistedOperationPhase != nil {
-                    var _extensions = extensions ?? [:]
-                    _extensions["persistedQuery"] = AnyEncodable([
+                    var persistedExtensions = extensions ?? [:]
+                    persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(Body.hash(query))
+                        "sha256Hash": AnyEncodable(
+                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                        )
                     ])
-                    extensions = _extensions
+                    extensions = persistedExtensions
                 }
                 self.operationName = Operation.operationName
                 self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
                 self.variables = AnyEncodable(operation.variables)
                 self.extensions = extensions
             }
-
-            private static func hash(_ sourceText: String) -> String {
-                let digits = Array("0123456789abcdef".utf8)
-                let capacity = 2 * SHA256.Digest.byteCount
-                return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-                    var p = ptr.baseAddress!
-                    for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                        p[0] = digits[Int(byte >> 4)]
-                        p[1] = digits[Int(byte & 0x0f)]
-                        p += 2
-                    }
-                    return capacity
-                }
-            }
         }
         """
     }
 
-    private func POSTWithRegisteredPersistedOperations() -> String {
+    private func postWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -369,7 +343,7 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func POSTWithNoPersistedOperations() -> String {
+    private func postWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -433,7 +407,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }
@@ -452,7 +426,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "operationName", value: body.operationName),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }
@@ -478,7 +452,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -35,20 +35,20 @@ struct EncodersWriter {
     private func content() -> String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: GETWithAutomaticPersistedOperations()
-            case .registered: GETWithRegisteredPersistedOperations()
-            case .none: GETWithNoPersistedOperations()
+            case .automatic: getWithAutomaticPersistedOperations()
+            case .registered: getWithRegisteredPersistedOperations()
+            case .none: getWithNoPersistedOperations()
             }
         } else {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: POSTWithAutomaticPersistedOperations()
-            case .registered: POSTWithRegisteredPersistedOperations()
-            case .none: POSTWithNoPersistedOperations()
+            case .automatic: postWithAutomaticPersistedOperations()
+            case .registered: postWithRegisteredPersistedOperations()
+            case .none: postWithNoPersistedOperations()
             }
         }
     }
 
-    private func GETWithAutomaticPersistedOperations() -> String {
+    private func getWithAutomaticPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -72,11 +72,11 @@ struct EncodersWriter {
             ) throws -> [URLQueryItem]\(subscriptionSupportWithAutomaticPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithAutomaticPersistedOperations())
+        \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
     }
 
-    private func GETWithRegisteredPersistedOperations() -> String {
+    private func getWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -91,11 +91,11 @@ struct EncodersWriter {
             func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithRegisteredPersistedOperations())
+        \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
     }
 
-    private func GETWithNoPersistedOperations() -> String {
+    private func getWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -114,35 +114,35 @@ struct EncodersWriter {
             ) throws -> [URLQueryItem]\(subscriptionSupportWithNoPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithNoPersistedOperations())
+        \(httpBodyEncoderWithNoPersistedOperations())
         """
     }
 
-    private func POSTWithAutomaticPersistedOperations() -> String {
+    private func postWithAutomaticPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithAutomaticPersistedOperations())
+        \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
     }
 
-    private func POSTWithRegisteredPersistedOperations() -> String {
+    private func postWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithRegisteredPersistedOperations())
+        \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
     }
 
-    private func POSTWithNoPersistedOperations() -> String {
+    private func postWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithNoPersistedOperations())
+        \(httpBodyEncoderWithNoPersistedOperations())
         """
     }
 
-    private func HTTPBodyEncoderWithAutomaticPersistedOperations() -> String {
+    private func httpBodyEncoderWithAutomaticPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.
@@ -180,7 +180,7 @@ struct EncodersWriter {
         """
     }
 
-    private func HTTPBodyEncoderWithRegisteredPersistedOperations() -> String {
+    private func httpBodyEncoderWithRegisteredPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.
@@ -198,7 +198,7 @@ struct EncodersWriter {
         """
     }
 
-    private func HTTPBodyEncoderWithNoPersistedOperations() -> String {
+    private func httpBodyEncoderWithNoPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -26,13 +26,6 @@ struct GraphQLOperationWriter {
     }
 
     private func content() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: RegisteredPersistedOperations()
-        case .automatic, .none: NoRegisteredPersistedOperations()
-        }
-    }
-
-    private func NoRegisteredPersistedOperations() -> String {
         """
         \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.
         \(accessLevel)protocol GraphQLOperation: Sendable {
@@ -40,6 +33,48 @@ struct GraphQLOperationWriter {
             /// The optional name of the operation.
             /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
             static var operationName: String? { get }
+        \(operationSourceRequirements())
+
+            /// The parameterized variables to execute the operation with.
+            /// https://spec.graphql.org/October2021/#sec-Language.Variables
+            var variables: Variables { get }
+
+            /// Metadata associated with the operation to include in the request.
+            var extensions: [String: AnyEncodable]? { get }
+
+            associatedtype Variables: Encodable, Sendable
+            associatedtype Data: Decodable, Sendable
+        }
+
+        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
+        """
+    }
+
+    private func operationSourceRequirements() -> String {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic:
+            operationDocumentRequirements() + """
+
+
+                /// The SHA-256 hash of `document`.
+                static var documentHash: String { get }
+
+                /// The SHA-256 hash of `minifiedDocument`.
+                static var minifiedDocumentHash: String { get }
+            """
+        case .registered:
+            """
+
+                /// The SHA-256 hash of the registered executable operation document.
+                static var hash: String { get }
+            """
+        case .none:
+            operationDocumentRequirements()
+        }
+    }
+
+    private func operationDocumentRequirements() -> String {
+        """
 
             /// The executable string operated on by a GraphQL service, containing
             /// an operation definition and zero or more fragment definitions.
@@ -47,53 +82,8 @@ struct GraphQLOperationWriter {
             static var document: String { get }
 
             /// A precomputed, lexically equivalent document with ignored characters removed.
-            /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-            /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-            /// provide this value; custom conformers must provide an equivalent canonical document.
+            /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
             static var minifiedDocument: String { get }
-
-            /// The parameterized variables to execute the operation with.
-            /// https://spec.graphql.org/October2021/#sec-Language.Variables
-            var variables: Variables { get }
-
-            /// Metadata associated with the operation to include in the request.
-            var extensions: [String: AnyEncodable]? { get }
-
-            associatedtype Variables: Encodable, Sendable
-            associatedtype Data: Decodable, Sendable
-        }
-
-        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
-        """
-    }
-
-    private func RegisteredPersistedOperations() -> String {
-        """
-        \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.
-        \(accessLevel)protocol GraphQLOperation: Sendable {
-
-            /// The optional name of the operation.
-            /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
-            static var operationName: String? { get }
-
-            /// A SHA-256 hash of the executable operation document. Registered persisted
-            /// operations was specified as a configuration option during codegen, indicating
-            /// the server does not support unknown operations and only registered document hashes
-            /// are accepted by the server.
-            static var hash: String { get }
-
-            /// The parameterized variables to execute the operation with.
-            /// https://spec.graphql.org/October2021/#sec-Language.Variables
-            var variables: Variables { get }
-
-            /// Metadata associated with the operation to include in the request.
-            var extensions: [String: AnyEncodable]? { get }
-
-            associatedtype Variables: Encodable, Sendable
-            associatedtype Data: Decodable, Sendable
-        }
-
-        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -35,55 +35,168 @@ struct GraphQLRequestWriter {
     private func content() -> String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: GETWithAutomaticPersistedOperations()
-            case .registered: GETWithRegisteredPersistedOperations()
-            case .none: GETWithNoPersistedOperations()
+            case .automatic: getWithAutomaticPersistedOperations()
+            case .registered: getWithRegisteredPersistedOperations()
+            case .none: getWithNoPersistedOperations()
             }
         } else {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: POSTWithAutomaticPersistedOperations()
-            case .registered: POSTWithRegisteredPersistedOperations()
-            case .none: POSTWithNoPersistedOperations()
+            case .automatic: postWithAutomaticPersistedOperations()
+            case .registered: postWithRegisteredPersistedOperations()
+            case .none: postWithNoPersistedOperations()
             }
         }
     }
 
-    private func GETWithAutomaticPersistedOperations() -> String {
+    private func requestDeclaration() -> String {
         """
-        \(header)import Foundation
-
         /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
         \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
 
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
+            /// The `URLRequest` used to execute a GraphQL request. Callers may mutate this property
+            /// after initialization to set authorization headers, timeouts, and other request options.
             \(accessLevel)var urlRequest: URLRequest
 
             /// The GraphQL endpoint the request will be made to.
             \(accessLevel)let endpoint: URL
 
             /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-
-            /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-            /// sent
-            \(accessLevel)let minifyDocument: Bool
-
-            /// The object used to encode the operation into HTTP body data if this request
-            /// is sending the operation's hash and the server responds saying the hash is not recognized,
-            /// indicating the request should be sent again, but with the full operation document.
-            \(accessLevel)let persistedOperationBodyEncoder: HTTPBodyEncoder?
+            \(accessLevel)let operation: Operation\(requestStateProperties())
         }
+        """
+    }
 
-        extension GraphQLRequest {
+    private func requestStateProperties() -> String {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic:
+            """
 
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+
+                /// Whether the request uses the operation's precomputed canonical document.
+                \(accessLevel)let minifyDocument: Bool
+
+                /// The encoder used to retry an unknown persisted operation with its full document.
+                \(accessLevel)let persistedOperationBodyEncoder: HTTPBodyEncoder?
+            """
+        case .registered:
+            ""
+        case .none:
+            """
+
+
+                /// Whether the request uses the operation's precomputed canonical document.
+                \(accessLevel)let minifyDocument: Bool
+            """
+        }
+    }
+
+    private func defaultDecoderDeclaration() -> String {
+        """
+
+            /// The decoding function used by default for a GraphQL response.
+            \(accessLevel)static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
                 { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
             }
+        """
+    }
+
+    private func operationInitializer() -> String {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic: automaticOperationInitializer()
+        case .registered: registeredOperationInitializer()
+        case .none: operationInitializerWithoutPersistence()
+        }
+    }
+
+    private func automaticOperationInitializer() -> String {
+        """
+
+
+            /// Initializes a POST request for a GraphQL operation.
+            \(accessLevel)init(
+                operation: Operation,
+                endpoint: Foundation.URL,
+                automaticPersistedOperations: Bool = true,
+                minifyDocument: Bool = true,
+                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+                accept: String = "application/graphql-response+json"
+            ) throws {
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(
+                    operation: operation,
+                    automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
+                    minifyDocument: minifyDocument
+                )
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = operation
+                self.minifyDocument = minifyDocument
+                self.persistedOperationBodyEncoder = automaticPersistedOperations ? bodyEncoder : nil
+            }
+        """
+    }
+
+    private func registeredOperationInitializer() -> String {
+        """
+
+
+            /// Initializes a POST request for a registered GraphQL operation.
+            \(accessLevel)init(
+                operation: Operation,
+                endpoint: Foundation.URL,
+                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+                accept: String = "application/graphql-response+json"
+            ) throws {
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation)
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = operation
+            }
+        """
+    }
+
+    private func operationInitializerWithoutPersistence() -> String {
+        """
+
+
+            /// Initializes a POST request for a GraphQL operation.
+            \(accessLevel)init(
+                operation: Operation,
+                endpoint: Foundation.URL,
+                minifyDocument: Bool = true,
+                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+                accept: String = "application/graphql-response+json"
+            ) throws {
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(
+                    operation: operation,
+                    minifyDocument: minifyDocument
+                )
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = operation
+                self.minifyDocument = minifyDocument
+            }
+        """
+    }
+
+    private func getWithAutomaticPersistedOperations() -> String {
+        requestContent(
+            querySupport: automaticQuerySupport(),
+            subscriptionSupport: subscriptionSupportGetWithAutomaticPersistedOperations()
+        )
+    }
+
+    private func automaticQuerySupport() -> String {
+        """
+
 
             /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`
             \(accessLevel)enum QueryStrategy {
@@ -174,74 +287,20 @@ struct GraphQLRequestWriter {
                 self.operation = query
                 self.minifyDocument = minifyDocument
                 self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
-            }\(subscriptionSupportGETWithAutomaticPersistedOperations())
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - automaticPersistedOperations: Whether automatic persisted operations is enabled.
-            ///   By default this is `true` meaning a subsequent request will be executed with the full
-            ///   query document if this initial request results in a "PersistedQueryNotFound" error.
-            ///   - minifyDocument: Whether the query document text should be minified
-            ///   (unnecessary whitespace removed) when sent. `true` by default.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                automaticPersistedOperations: Bool = true,
-                minifyDocument: Bool = true,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(
-                    operation: operation,
-                    automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
-                    minifyDocument: minifyDocument
-                )
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
-                self.minifyDocument = minifyDocument
-                self.persistedOperationBodyEncoder = automaticPersistedOperations ? bodyEncoder : nil
             }
-        }
         """
     }
 
-    private func GETWithRegisteredPersistedOperations() -> String {
+    private func getWithRegisteredPersistedOperations() -> String {
+        requestContent(
+            querySupport: registeredQuerySupport(),
+            subscriptionSupport: subscriptionSupportGetWithRegisteredPersistedOperations()
+        )
+    }
+
+    private func registeredQuerySupport() -> String {
         """
-        \(header)import Foundation
 
-        /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
-        \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
-
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
-            \(accessLevel)var urlRequest: URLRequest
-
-            /// The GraphQL endpoint the request will be made to.
-            \(accessLevel)let endpoint: URL
-
-            /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-        }
-
-        extension GraphQLRequest {
-
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
-            }
 
             /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.
             \(accessLevel)enum QueryStrategy {
@@ -281,65 +340,20 @@ struct GraphQLRequestWriter {
                 self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
                 self.endpoint = endpoint
                 self.operation = query
-            }\(subscriptionSupportGETWithRegisteredPersistedOperations())
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation)
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
             }
-        }
         """
     }
 
-    private func GETWithNoPersistedOperations() -> String {
+    private func getWithNoPersistedOperations() -> String {
+        requestContent(
+            querySupport: querySupportWithoutPersistence(),
+            subscriptionSupport: subscriptionSupportGetWithNoPersistedOperations()
+        )
+    }
+
+    private func querySupportWithoutPersistence() -> String {
         """
-        \(header)import Foundation
 
-        /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
-        \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
-
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
-            \(accessLevel)var urlRequest: URLRequest
-
-            /// The GraphQL endpoint the request will be made to.
-            \(accessLevel)let endpoint: URL
-
-            /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-
-            /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-            /// sent
-            \(accessLevel)let minifyDocument: Bool
-        }
-
-        extension GraphQLRequest {
-
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
-            }
 
             /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.
             \(accessLevel)enum QueryStrategy {
@@ -383,232 +397,37 @@ struct GraphQLRequestWriter {
                 self.endpoint = endpoint
                 self.operation = query
                 self.minifyDocument = minifyDocument
-            }\(subscriptionSupportGETWithNoPersistedOperations())
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - minifyDocument: Whether the query document text should be minified
-            ///   (unnecessary whitespace removed) when sent. `true` by default.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                minifyDocument: Bool = true,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation, minifyDocument: minifyDocument)
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
-                self.minifyDocument = minifyDocument
             }
-        }
         """
     }
 
-    private func POSTWithAutomaticPersistedOperations() -> String {
+    private func postWithAutomaticPersistedOperations() -> String {
+        requestContent(subscriptionSupport: subscriptionSupportPostWithAutomaticPersistedOperations())
+    }
+
+    private func postWithRegisteredPersistedOperations() -> String {
+        requestContent(subscriptionSupport: subscriptionSupportPostWithRegisteredPersistedOperations())
+    }
+
+    private func postWithNoPersistedOperations() -> String {
+        requestContent(subscriptionSupport: subscriptionSupportPostWithNoPersistedOperations())
+    }
+
+    private func requestContent(
+        querySupport: String = "",
+        subscriptionSupport: String
+    ) -> String {
         """
         \(header)import Foundation
 
-        /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
-        \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
+        \(requestDeclaration())
 
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
-            \(accessLevel)var urlRequest: URLRequest
-
-            /// The GraphQL endpoint the request will be made to.
-            \(accessLevel)let endpoint: URL
-
-            /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-
-            /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-            /// sent
-            \(accessLevel)let minifyDocument: Bool
-
-            /// The object used to encode the operation into HTTP body data if this request
-            /// is sending the operation's hash and the server responds saying the hash is not recognized,
-            /// indicating the request should be sent again, but with the full operation document.
-            \(accessLevel)let persistedOperationBodyEncoder: HTTPBodyEncoder?
-        }
-
-        extension GraphQLRequest {
-
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
-            }
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - automaticPersistedOperations: Whether automatic persisted operations is enabled.
-            ///   By default this is `true` meaning a subsequent request will be executed with the full
-            ///   query document if this initial request results in a "PersistedQueryNotFound" error.
-            ///   - minifyDocument: Whether the query document text should be minified
-            ///   (unnecessary whitespace removed) when sent. `true` by default.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                automaticPersistedOperations: Bool = true,
-                minifyDocument: Bool = true,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(
-                    operation: operation,
-                    automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
-                    minifyDocument: minifyDocument
-                )
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
-                self.minifyDocument = minifyDocument
-                self.persistedOperationBodyEncoder = automaticPersistedOperations ? bodyEncoder : nil
-            }\(subscriptionSupportPOSTWithAutomaticPersistedOperations())
+        extension GraphQLRequest {\(defaultDecoderDeclaration())\(querySupport)\(operationInitializer())\(subscriptionSupport)
         }
         """
     }
 
-    private func POSTWithRegisteredPersistedOperations() -> String {
-        """
-        \(header)import Foundation
-
-        /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
-        \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
-
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
-            \(accessLevel)var urlRequest: URLRequest
-
-            /// The GraphQL endpoint the request will be made to.
-            \(accessLevel)let endpoint: URL
-
-            /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-        }
-
-        extension GraphQLRequest {
-
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
-            }
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation)
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
-            }\(subscriptionSupportPOSTWithRegisteredPersistedOperations())
-        }
-        """
-    }
-
-    private func POSTWithNoPersistedOperations() -> String {
-        """
-        \(header)import Foundation
-
-        /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
-        \(accessLevel)struct GraphQLRequest<Operation: GraphQLOperation> {
-
-            /// The `URLRequest` used to execute a GraphQL request. This property
-            /// is not modified after initialization, but callers my mutate this property
-            /// to provide further customization such as setting authorization headers, timeouts, etc.
-            \(accessLevel)var urlRequest: URLRequest
-
-            /// The GraphQL endpoint the request will be made to.
-            \(accessLevel)let endpoint: URL
-
-            /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation
-
-            /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-            /// sent
-            \(accessLevel)let minifyDocument: Bool
-        }
-
-
-        extension GraphQLRequest {
-
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
-            }
-
-            /// Initializes a new `GraphQLRequest` with an operation
-            /// - Parameters:
-            ///   - operation: The GraphQLOperation operation the request is for.
-            ///   - endpoint: The GraphQL server endpoint.
-            ///   - minifyDocument: Whether the query document text should be minified
-            ///   (unnecessary whitespace removed) when sent. `true` by default.
-            ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-            ///   - accept: The value to use in the "accept" header field. By default this is
-            ///   "application/graphql-response+json". This field is required by the spec:
-            ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
-            \(accessLevel)init(
-                operation: Operation,
-                endpoint: Foundation.URL,
-                minifyDocument: Bool = true,
-                bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-                accept: String = "application/graphql-response+json"
-            ) throws {
-                self.urlRequest = URLRequest(url: endpoint)
-                self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation, minifyDocument: minifyDocument)
-                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
-                self.endpoint = endpoint
-                self.operation = operation
-                self.minifyDocument = minifyDocument
-            }\(subscriptionSupportPOSTWithNoPersistedOperations())
-        }
-        """
-    }
-
-    private func subscriptionSupportGETWithAutomaticPersistedOperations() -> String {
+    private func subscriptionSupportGetWithAutomaticPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 
@@ -683,7 +502,7 @@ struct GraphQLRequestWriter {
         """
     }
 
-    private func subscriptionSupportGETWithRegisteredPersistedOperations() -> String {
+    private func subscriptionSupportGetWithRegisteredPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 
@@ -716,7 +535,7 @@ struct GraphQLRequestWriter {
         """
     }
 
-    private func subscriptionSupportGETWithNoPersistedOperations() -> String {
+    private func subscriptionSupportGetWithNoPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 
@@ -755,7 +574,7 @@ struct GraphQLRequestWriter {
         """
     }
 
-    private func subscriptionSupportPOSTWithAutomaticPersistedOperations() -> String {
+    private func subscriptionSupportPostWithAutomaticPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 
@@ -789,7 +608,7 @@ struct GraphQLRequestWriter {
         """
     }
 
-    private func subscriptionSupportPOSTWithRegisteredPersistedOperations() -> String {
+    private func subscriptionSupportPostWithRegisteredPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 
@@ -814,7 +633,7 @@ struct GraphQLRequestWriter {
         """
     }
 
-    private func subscriptionSupportPOSTWithNoPersistedOperations() -> String {
+    private func subscriptionSupportPostWithNoPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -51,7 +51,7 @@ struct URLSessionWriter {
             ///   - decoder: The function used to turn response data into an Operation.Data instance.
             \(accessLevel)func request<Operation: GraphQLOperation>(
                 _ request: GraphQLRequest<Operation>,
-                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.Success {
                 let (data, response) = try await data(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
@@ -113,7 +113,7 @@ struct URLSessionWriter {
             ///   - decoder: The function used to turn response data into an Operation.Data instance.
             \(accessLevel)func request<Operation: GraphQLOperation>(
                 _ request: GraphQLRequest<Operation>,
-                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.Success {
                 let (data, response) = try await data(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
@@ -140,9 +140,9 @@ struct URLSessionWriter {
             ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
             ///   in the "accept" header.
             ///   - decoder: The function used to turn response data into an Subscription.Data instance.
-            public func subscribe<Subscription: GraphQLSubscription>(
+            \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
-                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder()
+                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder
             ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
                 let (asyncBytes, response) = try await bytes(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
@@ -150,16 +150,20 @@ struct URLSessionWriter {
                 }
                 return AsyncThrowingStream { continuation in
                     let task = Task {
-                        var buffer = ServerSentEventBuffer()
-                        for try await byte in asyncBytes {
-                            if let messageData = buffer.append(byte) {
-                                switch try decoder(messageData) {
-                                case .success(let success): continuation.yield(success)
-                                case .requestError(let requestError): throw requestError
+                        do {
+                            var buffer = ServerSentEventBuffer()
+                            for try await byte in asyncBytes {
+                                if let messageData = buffer.append(byte) {
+                                    switch try decoder(messageData) {
+                                    case .success(let success): continuation.yield(success)
+                                    case .requestError(let requestError): throw requestError
+                                    }
                                 }
                             }
+                            continuation.finish()
+                        } catch {
+                            continuation.finish(throwing: error)
                         }
-                        continuation.finish()
                     }
                     continuation.onTermination = { _ in
                         task.cancel()

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
@@ -37,7 +37,6 @@ struct FragmentBuilder {
 
     mutating func buildable() throws -> SwiftTypeBuildable {
         startFragmentStruct()
-        addSourceProperty()
         if isFulfilled {
             try addSelectionSet()
         }
@@ -81,24 +80,5 @@ struct FragmentBuilder {
             structName: fragment.ast.name.value.capitalizedFirst,
             conformances: isFulfilled ? configuration.output.documents.fragments.conformances : []
         )
-    }
-
-    private mutating func addSourceProperty() {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: break
-        case .automatic, .none:
-            fragmentStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "source",
-                value: .assigned(
-                    SwiftSource(value: String(fragment.sourceText)).multilineStringLiteral,
-                    type: nil
-                )
-            )
-        }
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -35,7 +35,7 @@ struct OperationBuilder {
     mutating func buildable() throws -> SwiftTypeBuildable {
         try startOperationStruct()
         addOperationNameProperty()
-        try addDocumentProperty()
+        addDocumentProperty()
         addHashProperty()
         addVariablesProperty()
         addExtensionsProperty()
@@ -103,14 +103,10 @@ struct OperationBuilder {
         )
     }
 
-    private mutating func addDocumentProperty() throws {
+    private mutating func addDocumentProperty() {
         switch configuration.output.documents.operations.persistedOperations {
         case .registered: break
         case .automatic, .none:
-            let expandedSourceText = try OperationTextResolver(
-                operation: operation,
-                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment)
-            ).expandSourceText { fragment in "\\(\(fragment.ast.name.value.capitalizedFirst).source)" }
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -118,12 +114,8 @@ struct OperationBuilder {
                 isStatic: true,
                 immutable: true,
                 name: "document",
-                value: .assigned(SwiftSource(value: expandedSourceText).multilineStringLiteral, type: nil)
+                value: .assigned(SwiftSource(value: operation.documentText).multilineStringLiteral, type: nil)
             )
-            let resolvedSourceText = try OperationTextResolver(
-                operation: operation,
-                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment)
-            ).expandSourceText(mapFragmentSpread: \.sourceText)
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -133,7 +125,7 @@ struct OperationBuilder {
                 name: "minifiedDocument",
                 value: .assigned(
                     SwiftSource(
-                        value: try GraphQLJS(sourceText: resolvedSourceText).canonicalized()
+                        value: operation.canonicalText
                     ).multilineStringLiteral,
                     type: nil
                 )
@@ -142,7 +134,27 @@ struct OperationBuilder {
     }
 
     private mutating func addHashProperty() {
-        if let hash = operation.hash {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic:
+            operationStruct.addProperty(
+                description: nil,
+                deprecation: nil,
+                isPublic: isPublic,
+                isStatic: true,
+                immutable: true,
+                name: "documentHash",
+                value: .assigned("\"\(operation.documentHash)\"", type: nil)
+            )
+            operationStruct.addProperty(
+                description: nil,
+                deprecation: nil,
+                isPublic: isPublic,
+                isStatic: true,
+                immutable: true,
+                name: "minifiedDocumentHash",
+                value: .assigned("\"\(operation.canonicalHash)\"", type: nil)
+            )
+        case .registered:
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -150,8 +162,9 @@ struct OperationBuilder {
                 isStatic: true,
                 immutable: true,
                 name: "hash",
-                value: .assigned("\"\(hash)\"", type: nil)
+                value: .assigned("\"\(operation.canonicalHash)\"", type: nil)
             )
+        case .none: break
         }
     }
 

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -6,6 +6,7 @@ struct DocumentsWriter {
     let resolvedDocuments: ResolvedDocuments
 
     func write(using fileOutput: FileOutput) async throws {
+        try validateOutputURLs()
         switch configuration.output.documents.directory {
         case .definition: break
         case .directory(let url):
@@ -40,6 +41,24 @@ struct DocumentsWriter {
         let generated = resolvedDocuments.documents.map { $0.document.outputURL(configuration) }
         let removed = Set(resolvedDocuments.previouslyGenerated).subtracting(generated)
         await fileOutput.remove(at: removed)
+    }
+
+    private func validateOutputURLs() throws {
+        var sourceByOutputURL: [URL: URL] = [:]
+        for resolvedDocument in resolvedDocuments.documents {
+            let document = resolvedDocument.document
+            let outputURL = document.outputURL(configuration).standardizedFileURL
+            if let existingSource = sourceByOutputURL[outputURL] {
+                throw Codegen.Error(description: """
+                Multiple GraphQL documents resolve to the same generated output file:
+                Output: \(outputURL)
+                Sources:
+                \(existingSource)
+                \(document.url)
+                """)
+            }
+            sourceByOutputURL[outputURL] = document.url
+        }
     }
 
     private func buildOperation(

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -277,11 +277,22 @@ actor FileOutput {
     }
 
     private func minimalRemovalRoots() -> [URL] {
-        urlsToRemove
-            .filter { candidate in
-                !urlsToRemove.contains { other in other != candidate && contains(other, candidate) }
+        let candidates = urlsToRemove
+            .map { url in
+                (url: url, components: url.standardizedFileURL.pathComponents)
             }
-            .sorted(by: pathOrder)
+            .sorted { lhs, rhs in
+                lhs.components.lexicographicallyPrecedes(rhs.components)
+            }
+        var roots: [(url: URL, components: [String])] = []
+        for candidate in candidates {
+            if let currentRoot = roots.last,
+               candidate.components.starts(with: currentRoot.components) {
+                continue
+            }
+            roots.append(candidate)
+        }
+        return roots.map(\.url).sorted(by: pathOrder)
     }
 
     private func contains(_ parent: URL, _ child: URL) -> Bool {

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -12,8 +12,8 @@ struct PersistedOperationManifestWriter {
                 case .operation(let operation):
                     operations.append(
                         PersistedOperationManifest.Operation(
-                            id: operation.hash!,
-                            body: operation.resolvedText!,
+                            id: operation.canonicalHash,
+                            body: operation.canonicalText,
                             name: operation.ast.name?.value,
                             type: operation.ast.operation.rawValue
                         )

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -3,13 +3,13 @@ indirect enum SourceTypeName {
     case optional(SourceTypeName)
     case list(SourceTypeName)
 
-    static func swiftNativeScalar(graphQLScalarName: String) -> String? {
-        switch graphQLScalarName {
-        case "String": "String"
-        case "Int": "Int"
-        case "Float": "Double"
-        case "Boolean": "Bool"
-        default: nil
+    init?(nativeGraphQLScalarName name: String) {
+        switch name {
+        case "String": self = .name("String")
+        case "Int": self = .name("Int")
+        case "Float": self = .name("Double")
+        case "Boolean": self = .name("Bool")
+        default: return nil
         }
     }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
@@ -92,9 +92,11 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
     }
 
     func build(configuration: Configuration) -> [String] {
-        precondition(started)
+        guard let declaration else {
+            preconditionFailure("A Swift type must be started before it can be built")
+        }
         let indentation = configuration.output.indentation.string
-        var lines = declaration!
+        var lines = declaration
         lines.append(contentsOf: contents.map { $0.isWhiteSpace ? "" : indentation + $0 })
         lines.append(contentsOf: buildInitializers(indentation: indentation))
         for nested in nestedTypes {

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -5,10 +5,10 @@ struct DocumentsResolver {
     let documents: Documents
 
     func resolve() throws -> ResolvedDocuments {
-        let usedFragments = usedFragments()
+        let usedFragments = try usedFragments()
         let resolvedFragments = try resolveFragments(usedFragments)
         let resolvedDocuments = try resolveDocuments(documents)
-        let fulfilledFragments = fulfilledFragments(
+        let fulfilledFragments = try fulfilledFragments(
             resolvedFragments: resolvedFragments,
             resolvedDocuments: resolvedDocuments
         )
@@ -23,7 +23,7 @@ struct DocumentsResolver {
         )
     }
 
-    private func usedFragments() -> [String: Document.Fragment] {
+    private func usedFragments() throws -> [String: Document.Fragment] {
         var selectionSets: [AST.SelectionSet] = []
         for document in documents.documents {
             for definition in document.definitions {
@@ -43,8 +43,8 @@ struct DocumentsResolver {
                     }
                 case .fragmentSpread(let fragmentSpread):
                     let fragmentSpreadName = fragmentSpread.name.value
-                    if !usedFragments.keys.contains(fragmentSpreadName) {
-                        let fragment = documents.fragmentLookup[fragmentSpreadName]!
+                    if usedFragments[fragmentSpreadName] == nil {
+                        let fragment = try documents.fragment(fragmentSpreadName)
                         usedFragments[fragmentSpreadName] = fragment
                         selectionSets.append(fragment.ast.selectionSet)
                     }
@@ -60,8 +60,7 @@ struct DocumentsResolver {
         _ usedFragments: [String: Document.Fragment]
     ) throws -> [String: ResolvedFragment] {
         var resolvedFragments: [String: ResolvedFragment] = [:]
-        for name in usedFragments.keys.sorted() {
-            let fragment = usedFragments[name]!
+        for (name, fragment) in usedFragments.sorted(by: { $0.key < $1.key }) {
             let selectionSet = try SelectionSetResolver(
                 onType: try schema.fragmentType(fragment.ast),
                 selectionSet: fragment.ast.selectionSet,
@@ -110,7 +109,7 @@ struct DocumentsResolver {
     private func fulfilledFragments(
         resolvedFragments: [String: ResolvedFragment],
         resolvedDocuments: [ResolvedDocument]
-    ) -> Set<String> {
+    ) throws -> Set<String> {
         var fulfilledFragments: Set<String> = []
         var selectionSets: [ResolvedSelectionSet] = resolvedFragments.values.map(\.resolvedSelectionSet)
         for resolvedDocument in resolvedDocuments {
@@ -132,7 +131,9 @@ struct DocumentsResolver {
                 case .fragmentSpread(let name, _):
                     let result = fulfilledFragments.insert(name)
                     if result.inserted {
-                        let fragment = resolvedFragments[name]!
+                        guard let fragment = resolvedFragments[name] else {
+                            throw Codegen.Error(description: "Resolved fragment is missing: \(name)")
+                        }
                         selectionSets.append(fragment.resolvedSelectionSet)
                     }
                 }
@@ -152,7 +153,7 @@ struct DocumentsResolver {
                 switch definition {
                 case .operation(let resolvedOperation):
                     usedTypes.formUnion(
-                        usedScalarTypes(
+                        try usedScalarTypes(
                             resolvedOperation.resolvedSelectionSet,
                             resolvedFragments: resolvedFragments,
                             seenFragmentSpreads: &seenFragmentSpreads
@@ -177,7 +178,7 @@ struct DocumentsResolver {
             case .SCALAR(let scalar): usedTypes.insert(scalar.ast.name)
             case .ENUM(let `enum`): usedTypes.insert(`enum`.ast.name)
             case .INPUT_OBJECT(let inputObject):
-                usedTypes.insert(inputObject.ast.name)
+                guard usedTypes.insert(inputObject.ast.name).inserted else { continue }
                 stack.append(contentsOf: try inputObject.ast.inputFields.map { try schema.inputType($0) })
             case .LIST(let innerType): stack.append(innerType)
             case .NON_NULL(let innerType): stack.append(innerType)
@@ -190,7 +191,7 @@ struct DocumentsResolver {
         _ selectionSet: ResolvedSelectionSet,
         resolvedFragments: [String: ResolvedFragment],
         seenFragmentSpreads: inout Set<String>
-    ) -> Set<String> {
+    ) throws -> Set<String> {
         var usedTypes: Set<String> = []
         var stack: [ResolvedSelectionSet] = [selectionSet]
         while let selectionSet = stack.popLast() {
@@ -199,7 +200,9 @@ struct DocumentsResolver {
                 case .fragmentSpread(let name, _):
                     let result = seenFragmentSpreads.insert(name)
                     if result.inserted {
-                        let resolvedFragment = resolvedFragments[name]!
+                        guard let resolvedFragment = resolvedFragments[name] else {
+                            throw Codegen.Error(description: "Resolved fragment is missing: \(name)")
+                        }
                         stack.append(resolvedFragment.resolvedSelectionSet)
                     }
                 case .field(let field, _):

--- a/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
@@ -23,12 +23,11 @@ struct DocumentValidator {
     }
 
     let documentText: String
-    let schemaJSONString: String
+    let graphQLJS: GraphQLJS
+    let schemaJSON: String
 
-    func validate() throws -> [Error] {
-        let errorsJSON = try GraphQLJS(sourceText: documentText).validated(
-            schemaJSONString: schemaJSONString
-        )
+    func validate() async throws -> [Error] {
+        let errorsJSON = try await graphQLJS.validate(documentText, schemaJSON: schemaJSON)
         return try JSONDecoder().decode([Error].self, from: errorsJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -28,19 +28,21 @@ struct DocumentsValidator {
     }
 
     let schema: Schema
+    let schemaJSON: String
     let documents: Documents
+    let graphQLJS: GraphQLJS
 
-    func validate() throws {
+    func validate() async throws {
         var documentErrors: [DocumentError] = []
-        let schemaJSONString = schema.jsonString!
         for document in documents.documents {
             var operationErrors: [OperationError] = []
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    let errors = try DocumentValidator(
-                        documentText: operation.resolvedText!,
-                        schemaJSONString: schemaJSONString
+                    let errors = try await DocumentValidator(
+                        documentText: operation.canonicalText,
+                        graphQLJS: graphQLJS,
+                        schemaJSON: schemaJSON
                     ).validate()
                     if !errors.isEmpty {
                         operationErrors.append(

--- a/Sources/GraphQLCodegenTests/Integration/CodegenHardeningTests.swift
+++ b/Sources/GraphQLCodegenTests/Integration/CodegenHardeningTests.swift
@@ -1,0 +1,486 @@
+import Dispatch
+import Foundation
+import GraphQLCodegen
+import Testing
+
+struct CodegenHardeningTests {
+    private struct ProbeTimeout: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    private enum Persistence: CaseIterable {
+        case automatic
+        case none
+        case registered
+
+        func configuration(manifestURL: URL) -> Configuration.Output.Documents.Operations.PersistedOperations? {
+            switch self {
+            case .automatic: .automatic
+            case .none: nil
+            case .registered: .registered(manifestJSONFileOutput: manifestURL)
+            }
+        }
+    }
+
+    private struct Workspace {
+        let root: URL
+
+        var documents: URL {
+            root.appending(path: "Documents", directoryHint: .isDirectory)
+        }
+
+        var schema: URL {
+            root.appending(path: "schema.sdl", directoryHint: .notDirectory)
+        }
+
+        func output(_ name: String) -> URL {
+            root.appending(path: "Generated/\(name)", directoryHint: .isDirectory)
+        }
+
+        func write(_ contents: String, to relativePath: String) throws {
+            let url = root.appending(path: relativePath, directoryHint: .notDirectory)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    @Test
+    func generatedHTTPConfigurationsCompile() async throws {
+        let workspace = try makeWorkspace()
+        defer { remove(workspace) }
+        try workspace.write(
+            """
+            type Query {
+              search(filter: Filter): SearchResult!
+            }
+
+            type Mutation {
+              update: String!
+            }
+
+            type Subscription {
+              updates: String!
+            }
+
+            input Filter {
+              nested: Filter
+              children: [Filter!]
+            }
+
+            type SearchResult {
+              value: String!
+            }
+            """,
+            to: "schema.sdl"
+        )
+        try workspace.write(
+            """
+            # 😀 exercises graphql-js UTF-16 source locations.
+            query Search($filter: Filter) {
+              search(filter: $filter) {
+                ...SearchResultFields
+              }
+            }
+
+            fragment SearchResultFields on SearchResult {
+              value
+            }
+
+            mutation Update {
+              update
+            }
+
+            subscription Updates {
+              updates
+            }
+            """,
+            to: "Documents/Feature/Operations.graphql"
+        )
+
+        for enableGETQueries in [false, true] {
+            for persistence in Persistence.allCases {
+                let name = "\(enableGETQueries ? "GET" : "POST")-\(persistence)"
+                let output = workspace.output(name)
+                try await Codegen(
+                    try configuration(
+                        workspace: workspace,
+                        output: output,
+                        enableGETQueries: enableGETQueries,
+                        persistence: persistence
+                    )
+                ).run()
+                let operationOutput = output.appending(
+                    path: "Documents/Feature/Operations.graphql.swift",
+                    directoryHint: .notDirectory
+                )
+                #expect(FileManager.default.fileExists(atPath: operationOutput.path(percentEncoded: false)))
+                try typecheckSwiftSources(in: output)
+                if !enableGETQueries, persistence == .automatic {
+                    try verifyAutomaticPersistedOperationHashes(in: output)
+                }
+                if !enableGETQueries, persistence == .none {
+                    try verifySubscriptionErrorsPropagate(in: output)
+                }
+            }
+        }
+    }
+
+    @Test
+    func missingFragmentWithoutValidationThrows() async throws {
+        let workspace = try makeWorkspace()
+        defer { remove(workspace) }
+        try workspace.write("type Query { value: String! }", to: "schema.sdl")
+        try workspace.write("query Missing { ...Unknown }", to: "Documents/Missing.graphql")
+
+        await expectFailure {
+            try await Codegen(
+                .configuration(
+                    input: .input(
+                        schemaSource: .SDLSchemaFile(workspace.schema),
+                        documentDirectories: [workspace.documents]
+                    ),
+                    validation: false,
+                    output: .output(
+                        schema: .schema(directory: workspace.output("Schema")),
+                        api: .api(directory: workspace.output("API"))
+                    )
+                )
+            ).run()
+        }
+    }
+
+    @Test
+    func collidingDocumentOutputsThrow() async throws {
+        let workspace = try makeWorkspace()
+        defer { remove(workspace) }
+        let firstDocuments = workspace.root.appending(path: "First", directoryHint: .isDirectory)
+        let secondDocuments = workspace.root.appending(path: "Second", directoryHint: .isDirectory)
+        try workspace.write("type Query { value: String! }", to: "schema.sdl")
+        try workspace.write("query First { value }", to: "First/Operation.graphql")
+        try workspace.write("query Second { value }", to: "Second/Operation.graphql")
+
+        await expectFailure {
+            try await Codegen(
+                .configuration(
+                    input: .input(
+                        schemaSource: .SDLSchemaFile(workspace.schema),
+                        documentDirectories: [firstDocuments, secondDocuments]
+                    ),
+                    output: .output(
+                        schema: .schema(directory: workspace.output("Schema")),
+                        documents: .documents(
+                            directory: .directory(workspace.output("Documents"))
+                        ),
+                        api: .api(directory: workspace.output("API"))
+                    )
+                )
+            ).run()
+        }
+    }
+
+    @Test
+    func failedOutputCommitRestoresExistingGeneratedFiles() async throws {
+        let workspace = try makeWorkspace()
+        defer { remove(workspace) }
+        let existingOutput = "// existing generated output\n"
+        let blockedAPIRoot = workspace.root.appending(path: "Blocked", directoryHint: .notDirectory)
+        try workspace.write("type Query { value: String! }", to: "schema.sdl")
+        try workspace.write("query Operation { value }", to: "Documents/Operation.graphql")
+        try workspace.write(existingOutput, to: "Documents/Operation.graphql.swift")
+        try workspace.write("not a directory", to: "Blocked")
+
+        await expectFailure {
+            try await Codegen(
+                .configuration(
+                    input: .input(
+                        schemaSource: .SDLSchemaFile(workspace.schema),
+                        documentDirectories: [workspace.documents]
+                    ),
+                    output: .output(
+                        schema: .schema(directory: workspace.output("Schema")),
+                        api: .api(directory: blockedAPIRoot.appending(path: "API"))
+                    )
+                )
+            ).run()
+        }
+
+        let restoredOutput = try String(
+            contentsOf: workspace.documents.appending(path: "Operation.graphql.swift"),
+            encoding: .utf8
+        )
+        #expect(restoredOutput == existingOutput)
+    }
+
+    private func configuration(
+        workspace: Workspace,
+        output: URL,
+        enableGETQueries: Bool,
+        persistence: Persistence
+    ) throws -> Configuration {
+        try .configuration(
+            input: .input(
+                schemaSource: .SDLSchemaFile(workspace.schema),
+                documentDirectories: [workspace.documents]
+            ),
+            output: .output(
+                schema: .schema(directory: output.appending(path: "Schema")),
+                documents: .documents(
+                    directory: .directory(output.appending(path: "Documents")),
+                    operations: .operations(
+                        persistedOperations: persistence.configuration(
+                            manifestURL: output.appending(path: "manifest.json")
+                        )
+                    )
+                ),
+                api: .api(
+                    directory: output.appending(path: "API"),
+                    HTTPSupport: .httpSupport(
+                        enableGETQueries: enableGETQueries,
+                        subscriptionSupport: true
+                    )
+                )
+            )
+        )
+    }
+
+    private func expectFailure(_ operation: () async throws -> Void) async {
+        do {
+            try await operation()
+            Issue.record("Expected code generation to fail")
+        } catch {
+            // Failure is the behavior under test.
+        }
+    }
+
+    private func makeWorkspace() throws -> Workspace {
+        let workspace = Workspace(
+            root: FileManager.default.temporaryDirectory
+                .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+        )
+        try FileManager.default.createDirectory(at: workspace.root, withIntermediateDirectories: true)
+        return workspace
+    }
+
+    private func remove(_ workspace: Workspace) {
+        do {
+            try FileManager.default.removeItem(at: workspace.root)
+        } catch {
+            Issue.record("Failed to remove test workspace at \(workspace.root): \(error)")
+        }
+    }
+
+    private func typecheckSwiftSources(in directory: URL) throws {
+        let sources = try swiftSources(in: directory)
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.arguments = ["swiftc", "-swift-version", "6", "-warnings-as-errors", "-typecheck"] +
+            sources.map { $0.path(percentEncoded: false) }
+        process.standardError = output
+        process.standardOutput = output
+        try process.run()
+        process.waitUntilExit()
+        let compilerOutput = try #require(
+            String(
+                data: try output.fileHandleForReading.readToEnd() ?? Data(),
+                encoding: .utf8
+            )
+        )
+        #expect(process.terminationStatus == 0, "Generated source failed to compile:\n\(compilerOutput)")
+    }
+
+    private func verifySubscriptionErrorsPropagate(in directory: URL) throws {
+        try compileAndRunProbe(
+            named: "SubscriptionErrorProbe",
+            source: """
+        import Foundation
+
+        private struct ExpectedError: Error {}
+        private struct InvalidEndpoint: Error {}
+        private struct UnexpectedCompletion: Error {}
+
+        private final class EventProtocol: URLProtocol {
+            override class func canInit(with request: URLRequest) -> Bool { true }
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+            override func startLoading() {
+                guard let url = request.url,
+                      let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["content-type": "text/event-stream"]
+                ) else {
+                    client?.urlProtocol(self, didFailWithError: InvalidEndpoint())
+                    return
+                }
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: Data("data: {}\\n\\n".utf8))
+                client?.urlProtocolDidFinishLoading(self)
+            }
+
+            override func stopLoading() {}
+        }
+
+        @main
+        private struct SubscriptionErrorProbe {
+            static func main() async throws {
+                let configuration = URLSessionConfiguration.ephemeral
+                configuration.protocolClasses = [EventProtocol.self]
+                let session = URLSession(configuration: configuration)
+                guard let endpoint = URL(string: "https://example.com/graphql") else {
+                    throw InvalidEndpoint()
+                }
+                let request = try GraphQLRequest(
+                    subscription: UpdatesSubscription(),
+                    endpoint: endpoint
+                )
+                let stream = try await session.subscribe(request) { _ in throw ExpectedError() }
+                do {
+                    for try await _ in stream {}
+                    throw UnexpectedCompletion()
+                } catch is ExpectedError {
+                    return
+                }
+            }
+        }
+        """,
+            in: directory,
+            timeoutMessage: "Subscription stream did not propagate its decoder error"
+        )
+    }
+
+    private func verifyAutomaticPersistedOperationHashes(in directory: URL) throws {
+        try compileAndRunProbe(
+            named: "AutomaticHashProbe",
+            source: """
+        import CryptoKit
+        import Foundation
+
+        private struct HashMismatch: Error {}
+
+        @main
+        private struct AutomaticHashProbe {
+            static func main() throws {
+                guard SearchQuery.documentHash == hash(SearchQuery.document),
+                      SearchQuery.minifiedDocumentHash == hash(SearchQuery.minifiedDocument) else {
+                    let diagnostics =
+                        "document: \\(SearchQuery.document.debugDescription)\\n" +
+                        "generated document hash: \\(SearchQuery.documentHash)\\n" +
+                        "runtime document hash: \\(hash(SearchQuery.document))\\n"
+                    FileHandle.standardError.write(Data(diagnostics.utf8))
+                    throw HashMismatch()
+                }
+
+                let operation = SearchQuery()
+                try verifyEncodedHash(
+                    operation: operation,
+                    minifyDocument: false,
+                    expected: SearchQuery.documentHash
+                )
+                try verifyEncodedHash(
+                    operation: operation,
+                    minifyDocument: true,
+                    expected: SearchQuery.minifiedDocumentHash
+                )
+            }
+
+            private static func verifyEncodedHash(
+                operation: SearchQuery,
+                minifyDocument: Bool,
+                expected: String
+            ) throws {
+                let data = try JSONBodyEncoder().encode(
+                    operation: operation,
+                    automaticPersistedOperationPhase: .initialRequestWithHash,
+                    minifyDocument: minifyDocument
+                )
+                guard let body = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let extensions = body["extensions"] as? [String: Any],
+                      let persistedQuery = extensions["persistedQuery"] as? [String: Any],
+                      let encodedHash = persistedQuery["sha256Hash"] as? String,
+                      encodedHash == expected else {
+                    throw HashMismatch()
+                }
+            }
+
+            private static func hash(_ source: String) -> String {
+                SHA256.hash(data: Data(source.utf8))
+                    .map { String(format: "%02x", $0) }
+                    .joined()
+            }
+        }
+        """,
+            in: directory,
+            timeoutMessage: "Automatic persisted operation hash probe timed out"
+        )
+    }
+
+    private func compileAndRunProbe(
+        named name: String,
+        source: String,
+        in directory: URL,
+        timeoutMessage: String
+    ) throws {
+        let harness = directory.appending(path: "\(name).swift", directoryHint: .notDirectory)
+        try source.write(to: harness, atomically: true, encoding: .utf8)
+
+        let executable = directory.appending(path: name, directoryHint: .notDirectory)
+        let compiler = Process()
+        let compilerOutput = Pipe()
+        compiler.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        compiler.arguments = [
+            "swiftc",
+            "-swift-version", "6",
+            "-warnings-as-errors",
+            "-o", executable.path(percentEncoded: false),
+        ] + (try swiftSources(in: directory)).map { $0.path(percentEncoded: false) }
+        compiler.standardError = compilerOutput
+        compiler.standardOutput = compilerOutput
+        try compiler.run()
+        compiler.waitUntilExit()
+        let compilation = try #require(
+            String(
+                data: try compilerOutput.fileHandleForReading.readToEnd() ?? Data(),
+                encoding: .utf8
+            )
+        )
+        #expect(compiler.terminationStatus == 0, "Generated probe failed to compile:\n\(compilation)")
+        guard compiler.terminationStatus == 0 else { return }
+
+        let probe = Process()
+        let exited = DispatchSemaphore(value: 0)
+        probe.executableURL = executable
+        probe.terminationHandler = { _ in exited.signal() }
+        try probe.run()
+        if exited.wait(timeout: .now() + 5) == .timedOut {
+            probe.terminate()
+            Issue.record(ProbeTimeout(description: timeoutMessage))
+            return
+        }
+        #expect(probe.terminationStatus == 0)
+    }
+
+    private func swiftSources(in directory: URL) throws -> [URL] {
+        let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: Array(resourceKeys)
+        ) else {
+            Issue.record("Could not enumerate generated sources at \(directory)")
+            return []
+        }
+        return try enumerator.compactMap { element -> URL? in
+            guard let url = element as? URL,
+                  url.pathExtension == "swift",
+                  try url.resourceValues(forKeys: resourceKeys).isRegularFile == true else {
+                return nil
+            }
+            return url
+        }
+        .sorted { $0.path < $1.path }
+    }
+}

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/AnyEncodable.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/AnyEncodable.swift
@@ -3,11 +3,11 @@
 struct AnyEncodable: Encodable, Sendable {
     private let encoder: @Sendable (Encoder) throws -> Void
     init<T: Encodable & Sendable>(_ value: T) {
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     init?<T: Encodable & Sendable>(_ value: T?) {
         guard let value else { return nil }
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     func encode(to encoder: Encoder) throws {
         try self.encoder(encoder)

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLNullable.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLNullable.swift
@@ -1,6 +1,6 @@
 // @generated
 
-enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
+indirect enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
     case null
     case value(T)
 

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLResponse.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLResponse.swift
@@ -26,7 +26,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
         let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
         if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-            guard errors == nil || !errors!.isEmpty else {
+            guard errors?.isEmpty != true else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .errors,
                     in: container,

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
@@ -1,5 +1,4 @@
 // @generated
-import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -23,7 +22,7 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
             URLQueryItem(name: "query", value: body.query),
             URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
             URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                String(data: try encoder.encode(extensions), encoding: .utf8)!
+                String(decoding: try encoder.encode(extensions), as: UTF8.self)
             })
         ]
     }
@@ -64,30 +63,18 @@ private struct Body: Encodable {
         let query = minifyDocument ? Operation.minifiedDocument : Operation.document
         var extensions = operation.extensions
         if automaticPersistedOperationPhase != nil {
-            var _extensions = extensions ?? [:]
-            _extensions["persistedQuery"] = AnyEncodable([
+            var persistedExtensions = extensions ?? [:]
+            persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(Body.hash(query))
+                "sha256Hash": AnyEncodable(
+                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                )
             ])
-            extensions = _extensions
+            extensions = persistedExtensions
         }
         self.operationName = Operation.operationName
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
-    }
-
-    private static func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0f)]
-                p += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
@@ -13,10 +13,14 @@ protocol GraphQLOperation: Sendable {
     static var document: String { get }
 
     /// A precomputed, lexically equivalent document with ignored characters removed.
-    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-    /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-    /// provide this value; custom conformers must provide an equivalent canonical document.
+    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
+
+    /// The SHA-256 hash of `document`.
+    static var documentHash: String { get }
+
+    /// The SHA-256 hash of `minifiedDocument`.
+    static var minifiedDocumentHash: String { get }
 
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLRequest.swift
@@ -4,9 +4,8 @@ import Foundation
 /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
 struct GraphQLRequest<Operation: GraphQLOperation> {
 
-    /// The `URLRequest` used to execute a GraphQL request. This property
-    /// is not modified after initialization, but callers my mutate this property
-    /// to provide further customization such as setting authorization headers, timeouts, etc.
+    /// The `URLRequest` used to execute a GraphQL request. Callers may mutate this property
+    /// after initialization to set authorization headers, timeouts, and other request options.
     var urlRequest: URLRequest
 
     /// The GraphQL endpoint the request will be made to.
@@ -15,22 +14,16 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
     /// The GraphQL operation executed in the request.
     let operation: Operation
 
-    /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-    /// sent
+    /// Whether the request uses the operation's precomputed canonical document.
     let minifyDocument: Bool
 
-    /// The object used to encode the operation into HTTP body data if this request
-    /// is sending the operation's hash and the server responds saying the hash is not recognized,
-    /// indicating the request should be sent again, but with the full operation document.
+    /// The encoder used to retry an unknown persisted operation with its full document.
     let persistedOperationBodyEncoder: HTTPBodyEncoder?
 }
 
 extension GraphQLRequest {
-
-    /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-    /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-    /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-    static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+    /// The decoding function used by default for a GraphQL response.
+    static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
@@ -125,19 +118,7 @@ extension GraphQLRequest {
         self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
     }
 
-    /// Initializes a new `GraphQLRequest` with an operation
-    /// - Parameters:
-    ///   - operation: The GraphQLOperation operation the request is for.
-    ///   - endpoint: The GraphQL server endpoint.
-    ///   - automaticPersistedOperations: Whether automatic persisted operations is enabled.
-    ///   By default this is `true` meaning a subsequent request will be executed with the full
-    ///   query document if this initial request results in a "PersistedQueryNotFound" error.
-    ///   - minifyDocument: Whether the query document text should be minified
-    ///   (unnecessary whitespace removed) when sent. `true` by default.
-    ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-    ///   - accept: The value to use in the "accept" header field. By default this is
-    ///   "application/graphql-response+json". This field is required by the spec:
-    ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
+    /// Initializes a POST request for a GraphQL operation.
     init(
         operation: Operation,
         endpoint: Foundation.URL,

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/URLSession+GraphQL.swift
@@ -13,7 +13,7 @@ extension URLSession {
     ///   - decoder: The function used to turn response data into an Operation.Data instance.
     func request<Operation: GraphQLOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.Success {
         let (data, response) = try await data(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
@@ -12,14 +12,28 @@ struct HeroQuery: GraphQLQuery {
         ...droid
       }
     }
-    \(Jedi.source)
-    \(Droid.source)
-    \(Character.source)
+    fragment jedi on Jedi {
+      ...character
+      lightSaberColor
+    }
+    fragment droid on Droid {
+      ...character
+      primaryFunction
+      operator
+    }
+    fragment character on Character {
+      id
+      name
+    }
     """#
 
     static let minifiedDocument = #"""
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
+
+    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
+
+    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
 
     let variables: Variables
 
@@ -67,13 +81,6 @@ struct HeroQuery: GraphQLQuery {
 
 struct Jedi: Decodable, Sendable, Hashable {
 
-    static let source = #"""
-    fragment jedi on Jedi {
-      ...character
-      lightSaberColor
-    }
-    """#
-
     var __character: Character
 
     var lightSaberColor: String
@@ -89,14 +96,6 @@ struct Jedi: Decodable, Sendable, Hashable {
 }
 
 struct Droid: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment droid on Droid {
-      ...character
-      primaryFunction
-      operator
-    }
-    """#
 
     var __character: Character
 
@@ -117,13 +116,6 @@ struct Droid: Decodable, Sendable, Hashable {
 }
 
 struct Character: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment character on Character {
-      id
-      name
-    }
-    """#
 
     var id: ID
 

--- a/Sources/StarwarsExample/API/AnyEncodable.swift
+++ b/Sources/StarwarsExample/API/AnyEncodable.swift
@@ -3,11 +3,11 @@
 struct AnyEncodable: Encodable, Sendable {
     private let encoder: @Sendable (Encoder) throws -> Void
     init<T: Encodable & Sendable>(_ value: T) {
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     init?<T: Encodable & Sendable>(_ value: T?) {
         guard let value else { return nil }
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     func encode(to encoder: Encoder) throws {
         try self.encoder(encoder)

--- a/Sources/StarwarsExample/API/GraphQLNullable.swift
+++ b/Sources/StarwarsExample/API/GraphQLNullable.swift
@@ -1,6 +1,6 @@
 // @generated
 
-enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
+indirect enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
     case null
     case value(T)
 

--- a/Sources/StarwarsExample/API/GraphQLResponse.swift
+++ b/Sources/StarwarsExample/API/GraphQLResponse.swift
@@ -26,7 +26,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
         let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
         if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-            guard errors == nil || !errors!.isEmpty else {
+            guard errors?.isEmpty != true else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .errors,
                     in: container,

--- a/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -1,5 +1,4 @@
 // @generated
-import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -23,7 +22,7 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
             URLQueryItem(name: "query", value: body.query),
             URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
             URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                String(data: try encoder.encode(extensions), encoding: .utf8)!
+                String(decoding: try encoder.encode(extensions), as: UTF8.self)
             })
         ]
     }
@@ -64,30 +63,18 @@ private struct Body: Encodable {
         let query = minifyDocument ? Operation.minifiedDocument : Operation.document
         var extensions = operation.extensions
         if automaticPersistedOperationPhase != nil {
-            var _extensions = extensions ?? [:]
-            _extensions["persistedQuery"] = AnyEncodable([
+            var persistedExtensions = extensions ?? [:]
+            persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(Body.hash(query))
+                "sha256Hash": AnyEncodable(
+                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                )
             ])
-            extensions = _extensions
+            extensions = persistedExtensions
         }
         self.operationName = Operation.operationName
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
-    }
-
-    private static func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0f)]
-                p += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -13,10 +13,14 @@ protocol GraphQLOperation: Sendable {
     static var document: String { get }
 
     /// A precomputed, lexically equivalent document with ignored characters removed.
-    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-    /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-    /// provide this value; custom conformers must provide an equivalent canonical document.
+    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
+
+    /// The SHA-256 hash of `document`.
+    static var documentHash: String { get }
+
+    /// The SHA-256 hash of `minifiedDocument`.
+    static var minifiedDocumentHash: String { get }
 
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
@@ -4,9 +4,8 @@ import Foundation
 /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
 struct GraphQLRequest<Operation: GraphQLOperation> {
 
-    /// The `URLRequest` used to execute a GraphQL request. This property
-    /// is not modified after initialization, but callers my mutate this property
-    /// to provide further customization such as setting authorization headers, timeouts, etc.
+    /// The `URLRequest` used to execute a GraphQL request. Callers may mutate this property
+    /// after initialization to set authorization headers, timeouts, and other request options.
     var urlRequest: URLRequest
 
     /// The GraphQL endpoint the request will be made to.
@@ -15,22 +14,16 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
     /// The GraphQL operation executed in the request.
     let operation: Operation
 
-    /// Whether the operation document text should be minified (stripped of unnecessary whitespace) when
-    /// sent
+    /// Whether the request uses the operation's precomputed canonical document.
     let minifyDocument: Bool
 
-    /// The object used to encode the operation into HTTP body data if this request
-    /// is sending the operation's hash and the server responds saying the hash is not recognized,
-    /// indicating the request should be sent again, but with the full operation document.
+    /// The encoder used to retry an unknown persisted operation with its full document.
     let persistedOperationBodyEncoder: HTTPBodyEncoder?
 }
 
 extension GraphQLRequest {
-
-    /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-    /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-    /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-    static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+    /// The decoding function used by default for a GraphQL response.
+    static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
@@ -125,19 +118,7 @@ extension GraphQLRequest {
         self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
     }
 
-    /// Initializes a new `GraphQLRequest` with an operation
-    /// - Parameters:
-    ///   - operation: The GraphQLOperation operation the request is for.
-    ///   - endpoint: The GraphQL server endpoint.
-    ///   - automaticPersistedOperations: Whether automatic persisted operations is enabled.
-    ///   By default this is `true` meaning a subsequent request will be executed with the full
-    ///   query document if this initial request results in a "PersistedQueryNotFound" error.
-    ///   - minifyDocument: Whether the query document text should be minified
-    ///   (unnecessary whitespace removed) when sent. `true` by default.
-    ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
-    ///   - accept: The value to use in the "accept" header field. By default this is
-    ///   "application/graphql-response+json". This field is required by the spec:
-    ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
+    /// Initializes a POST request for a GraphQL operation.
     init(
         operation: Operation,
         endpoint: Foundation.URL,

--- a/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -13,7 +13,7 @@ extension URLSession {
     ///   - decoder: The function used to turn response data into an Operation.Data instance.
     func request<Operation: GraphQLOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.Success {
         let (data, response) = try await data(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {

--- a/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
+++ b/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
@@ -12,14 +12,28 @@ struct HeroQuery: GraphQLQuery {
         ...droid
       }
     }
-    \(Jedi.source)
-    \(Droid.source)
-    \(Character.source)
+    fragment jedi on Jedi {
+      ...character
+      lightSaberColor
+    }
+    fragment droid on Droid {
+      ...character
+      primaryFunction
+      operator
+    }
+    fragment character on Character {
+      id
+      name
+    }
     """#
 
     static let minifiedDocument = #"""
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
+
+    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
+
+    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
 
     let variables: Variables
 
@@ -67,13 +81,6 @@ struct HeroQuery: GraphQLQuery {
 
 struct Jedi: Decodable, Sendable, Hashable {
 
-    static let source = #"""
-    fragment jedi on Jedi {
-      ...character
-      lightSaberColor
-    }
-    """#
-
     var __character: Character
 
     var lightSaberColor: String
@@ -89,14 +96,6 @@ struct Jedi: Decodable, Sendable, Hashable {
 }
 
 struct Droid: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment droid on Droid {
-      ...character
-      primaryFunction
-      operator
-    }
-    """#
 
     var __character: Character
 
@@ -117,13 +116,6 @@ struct Droid: Decodable, Sendable, Hashable {
 }
 
 struct Character: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment character on Character {
-      id
-      name
-    }
-    """#
 
     var id: ID
 


### PR DESCRIPTION
## Summary

This hardens the generator across the correctness, maintainability, and performance findings from the design review.

### Correctness

- Interpret `graphql-js` source locations as UTF-16 offsets, including documents containing emoji and other non-BMP scalars.
- Expand fragment-bearing operation documents directly instead of emitting interpolation syntax inside raw Swift strings.
- Preserve document subdirectories for custom output roots and reject ambiguous output collisions before staging files.
- Terminate recursive input and inherited-interface traversals, and generate `GraphQLNullable` as an indirect enum for recursive nullable inputs.
- Propagate subscription decoding and request errors through `AsyncThrowingStream`, while honoring the configured API access level.
- Replace correlated optional schema/operation state and force unwraps with explicit loaded/prepared phases and recoverable errors.
- Precompute both full and minified operation hashes so automatic persisted operations remain correct when `minifyDocument` is disabled.

### Maintainability

- Refactor the six large `GraphQLRequestWriter` branches around shared declarations, state, decoder, and POST initializers.
- Keep one actor-isolated `GraphQLJS` runtime for the entire generation run, with explicit methods for schema conversion, parsing, canonicalization, and validation.
- Remove runtime hashing and the generated CryptoKit dependency; generated operations now carry the exact hashes their encoders need.
- Replace non-factory static helpers, misleading temporary names, remaining invariant force unwraps, and uppercase private member names.
- Update generated fixtures, the Star Wars example, and the generated-API upgrade note.

### Performance

- Reuse one evaluated JavaScript bundle and `JSContext` instead of recreating both per operation and validation pass.
- Use set membership for fragment discovery and visit recursive input/interface nodes only once.
- Reduce removal-root selection from quadratic filtering to a sorted prefix scan.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swift build -c release -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `git diff --check`
- Generated source type-checks under Swift 6 for all six GET/POST × automatic/registered/none persistence configurations.
- Executable probes verify automatic-persistence hashes for full and minified fragment-bearing documents and verify subscription decoder errors reach stream consumers.
- Integration coverage verifies UTF-16 locations, recursive inputs, nested output paths, output collisions, missing fragments with validation disabled, and transactional rollback.

## Benchmark

Release-build generation of a 100-operation document, measured with `/usr/bin/time -l` on the same machine:

| Revision | Warm elapsed time | Maximum RSS |
| --- | ---: | ---: |
| `685b04f` | ~1.95 s | ~731 MB |
| This PR | 0.13–0.14 s | ~21.7 MB |

The shared JavaScript runtime is actor-isolated because `JSContext` is not thread-safe. Generation currently drives it sequentially, so this preserves the existing execution model while making confinement explicit.

## Generated API note

Automatic persisted-operation conformers now provide `documentHash` and `minifiedDocumentHash`. Generated fragment types no longer expose `source`; complete fragment definitions are embedded in each operation document. Consumers should regenerate API and operation files together.
