### PR TITLE
Correct graphql-js UTF-16 source ranges

### DIFF
--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,8 +1,31 @@
 extension String {
-    subscript(_ range: Range<Int>) -> Substring {
-        self[
-            index(startIndex, offsetBy: range.startIndex)..<index(startIndex, offsetBy: range.endIndex)
-        ]
+    struct InvalidUTF16Range: Error, CustomStringConvertible {
+        let range: Range<Int>
+
+        var description: String {
+            "The UTF-16 range \(range) does not identify valid String boundaries."
+        }
+    }
+
+    func substring(utf16Range range: Range<Int>) throws -> Substring {
+        let utf16 = utf16
+        guard range.lowerBound >= 0,
+              range.upperBound >= range.lowerBound,
+              let utf16Start = utf16.index(
+                  utf16.startIndex,
+                  offsetBy: range.lowerBound,
+                  limitedBy: utf16.endIndex
+              ),
+              let utf16End = utf16.index(
+                  utf16.startIndex,
+                  offsetBy: range.upperBound,
+                  limitedBy: utf16.endIndex
+              ),
+              let start = String.Index(utf16Start, within: self),
+              let end = String.Index(utf16End, within: self) else {
+            throw InvalidUTF16Range(range: range)
+        }
+        return self[start..<end]
     }
 
     var capitalizedFirst: String {

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,8 +1,12 @@
 extension String {
-    subscript(_ range: Range<Int>) -> Substring {
+    subscript(utf16Range range: Range<Int>) -> Substring {
         self[
             String.Index(utf16Offset: range.lowerBound, in: self)..<
             String.Index(utf16Offset: range.upperBound, in: self)
         ]
+    }
+
+    var capitalizedFirst: String {
+        prefix(1).capitalized + dropFirst()
     }
 }

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,34 +1,8 @@
 extension String {
-    struct InvalidUTF16Range: Error, CustomStringConvertible {
-        let range: Range<Int>
-
-        var description: String {
-            "The UTF-16 range \(range) does not identify valid String boundaries."
-        }
-    }
-
-    func substring(utf16Range range: Range<Int>) throws -> Substring {
-        let utf16 = utf16
-        guard range.lowerBound >= 0,
-              range.upperBound >= range.lowerBound,
-              let utf16Start = utf16.index(
-                  utf16.startIndex,
-                  offsetBy: range.lowerBound,
-                  limitedBy: utf16.endIndex
-              ),
-              let utf16End = utf16.index(
-                  utf16.startIndex,
-                  offsetBy: range.upperBound,
-                  limitedBy: utf16.endIndex
-              ),
-              let start = String.Index(utf16Start, within: self),
-              let end = String.Index(utf16End, within: self) else {
-            throw InvalidUTF16Range(range: range)
-        }
-        return self[start..<end]
-    }
-
-    var capitalizedFirst: String {
-        prefix(1).capitalized + dropFirst()
+    subscript(_ range: Range<Int>) -> Substring {
+        self[
+            String.Index(utf16Offset: range.lowerBound, in: self)..<
+            String.Index(utf16Offset: range.upperBound, in: self)
+        ]
     }
 }

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,7 +1,7 @@
 extension String {
     subscript(utf16Range range: Range<Int>) -> Substring {
         self[
-            String.Index(utf16Offset: range.lowerBound, in: self)..<
+            String.Index(utf16Offset: range.lowerBound, in: self) ..<
             String.Index(utf16Offset: range.upperBound, in: self)
         ]
     }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
@@ -2,11 +2,12 @@ import Foundation
 
 /// https://github.com/graphql/graphql-js/blob/16.x.x/src/language/ast.ts
 enum AST {
+    /// Verified against the bundled graphql-js parser: location offsets are UTF-16 code units.
     struct Location: Decodable, Hashable {
         let start: Int
         let end: Int
 
-        var range: Range<Int> {
+        var utf16Range: Range<Int> {
             start..<end
         }
     }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -30,7 +30,7 @@ struct DocumentsLoader {
                         .operation(
                             Document.Operation(
                                 ast: operation,
-                                sourceText: try documentText.substring(utf16Range: operation.loc.range),
+                                sourceText: documentText[utf16Range: operation.loc.utf16Range],
                                 resolvedText: nil,
                                 hash: nil
                             )
@@ -58,7 +58,7 @@ struct DocumentsLoader {
                     fragmentLookup[fragment.name.value] = Document.Fragment(
                         file: documentURL,
                         ast: fragment,
-                        sourceText: try documentText.substring(utf16Range: fragment.loc.range)
+                        sourceText: documentText[utf16Range: fragment.loc.utf16Range]
                     )
                 }
             }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -30,7 +30,7 @@ struct DocumentsLoader {
                         .operation(
                             Document.Operation(
                                 ast: operation,
-                                sourceText: documentText[operation.loc.range],
+                                sourceText: try documentText.substring(utf16Range: operation.loc.range),
                                 resolvedText: nil,
                                 hash: nil
                             )
@@ -58,7 +58,7 @@ struct DocumentsLoader {
                     fragmentLookup[fragment.name.value] = Document.Fragment(
                         file: documentURL,
                         ast: fragment,
-                        sourceText: documentText[fragment.loc.range]
+                        sourceText: try documentText.substring(utf16Range: fragment.loc.range)
                     )
                 }
             }


### PR DESCRIPTION
## What changed

Convert `graphql-js` source ranges through `String.UTF16View` before slicing operation and fragment source text.

## Why

GraphQL locations are JavaScript UTF-16 offsets, while the previous integer `String` subscript advanced Swift `Character` indices. Documents containing emoji or other non-BMP scalars could therefore extract the wrong definition or trap.

## Validation

- `swift build -Xswiftc -warnings-as-errors`

This is the first PR in the design-review fix stack and targets `main`.
