### PR TITLE
Report missing fragment definitions without trapping

### DIFF
--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -5,7 +5,7 @@ struct DocumentsResolver {
     let documents: Documents
 
     func resolve() throws -> ResolvedDocuments {
-        let usedFragments = usedFragments()
+        let usedFragments = try usedFragments()
         let resolvedFragments = try resolveFragments(usedFragments)
         let resolvedDocuments = try resolveDocuments(documents)
         let fulfilledFragments = fulfilledFragments(
@@ -23,7 +23,7 @@ struct DocumentsResolver {
         )
     }
 
-    private func usedFragments() -> [String: Document.Fragment] {
+    private func usedFragments() throws -> [String: Document.Fragment] {
         var selectionSets: [AST.SelectionSet] = []
         for document in documents.documents {
             for definition in document.definitions {
@@ -44,7 +44,7 @@ struct DocumentsResolver {
                 case .fragmentSpread(let fragmentSpread):
                     let fragmentSpreadName = fragmentSpread.name.value
                     if !usedFragments.keys.contains(fragmentSpreadName) {
-                        let fragment = documents.fragmentLookup[fragmentSpreadName]!
+                        let fragment = try documents.fragment(fragmentSpreadName)
                         usedFragments[fragmentSpreadName] = fragment
                         selectionSets.append(fragment.ast.selectionSet)
                     }


### PR DESCRIPTION
## What changed

Resolve fragment spreads through the existing throwing `Documents.fragment(_:)` boundary.

## Why

With validation disabled, an unknown fragment spread reached a force unwrap and terminated the process. Code generation now reports the missing definition as a normal error.

## Validation

- `swift build -Xswiftc -warnings-as-errors`

Stacked on #19.
