### PR TITLE
Use constant-time used-fragment lookups

### DIFF
--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -43,7 +43,7 @@ struct DocumentsResolver {
                     }
                 case .fragmentSpread(let fragmentSpread):
                     let fragmentSpreadName = fragmentSpread.name.value
-                    if !usedFragments.keys.contains(fragmentSpreadName) {
+                    if usedFragments[fragmentSpreadName] == nil {
                         let fragment = try documents.fragment(fragmentSpreadName)
                         usedFragments[fragmentSpreadName] = fragment
                         selectionSets.append(fragment.ast.selectionSet)


### PR DESCRIPTION
## What changed

Use direct dictionary membership when discovering used fragments.

## Why

`usedFragments.keys.contains(name)` scanned the dictionary keys for every spread. Dictionary subscripting preserves the behavior with expected constant-time membership checks.

## Validation

- `swift build -Xswiftc -warnings-as-errors`

Stacked on #20.
