### PR TITLE
Scale output removal-root selection

### DIFF
--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -277,11 +277,22 @@ actor FileOutput {
     }
 
     private func minimalRemovalRoots() -> [URL] {
-        urlsToRemove
-            .filter { candidate in
-                !urlsToRemove.contains { other in other != candidate && contains(other, candidate) }
+        let candidates = urlsToRemove
+            .map { url in
+                (url: url, components: url.standardizedFileURL.pathComponents)
             }
-            .sorted(by: pathOrder)
+            .sorted { lhs, rhs in
+                lhs.components.lexicographicallyPrecedes(rhs.components)
+            }
+        var roots: [(url: URL, components: [String])] = []
+        for candidate in candidates {
+            if let currentRoot = roots.last,
+               candidate.components.starts(with: currentRoot.components) {
+                continue
+            }
+            roots.append(candidate)
+        }
+        return roots.map(\.url).sorted(by: pathOrder)
     }
 
     private func contains(_ parent: URL, _ child: URL) -> Bool {


### PR DESCRIPTION
## What changed

Replace pairwise removal-root filtering with a sorted path-component prefix scan.

## Why

Selecting minimal output removal roots was quadratic in the number of paths. Sorting once and skipping descendants reduces the selection step to O(n log n).

## Validation

- `swift build -Xswiftc -warnings-as-errors`

Stacked on #23.
