### PR TITLE
Preserve nested document output paths

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -38,15 +38,15 @@ struct Document: Sendable {
 
     let url: URL
     let definitions: [Definition]
+    let relativePath: String
 
     func outputURL(_ configuration: Configuration) -> URL {
-        let outputURL = url.appendingPathExtension("swift")
-        return switch configuration.output.documents.directory {
+        switch configuration.output.documents.directory {
         case .definition:
-            outputURL
+            url.appendingPathExtension("swift")
         case .directory(let outputDirectory):
             outputDirectory.appending(
-                path: outputURL.lastPathComponent,
+                path: relativePath + ".swift",
                 directoryHint: .notDirectory
             )
         }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -62,7 +62,13 @@ struct DocumentsLoader {
                     )
                 }
             }
-            documents.append(Document(url: documentURL, definitions: definitions))
+            documents.append(
+                Document(
+                    url: documentURL,
+                    definitions: definitions,
+                    relativePath: try relativePath(for: documentURL)
+                )
+            )
         }
         return Documents(
             previouslyGenerated: scan.generatedFileURLs,
@@ -101,9 +107,27 @@ struct DocumentsLoader {
                     updatedDefinitions.append(definition)
                 }
             }
-            updatedDocuments.append(Document(url: document.url, definitions: updatedDefinitions))
+            updatedDocuments.append(
+                Document(
+                    url: document.url,
+                    definitions: updatedDefinitions,
+                    relativePath: document.relativePath
+                )
+            )
         }
         return updatedDocuments
+    }
+
+    private func relativePath(for documentURL: URL) throws -> String {
+        let documentComponents = documentURL.standardizedFileURL.pathComponents
+        let sourceRoot = configuration.input.documentDirectories
+            .map(\.standardizedFileURL.pathComponents)
+            .filter { documentComponents.starts(with: $0) }
+            .max { $0.count < $1.count }
+        guard let sourceRoot else {
+            throw Codegen.Error(description: "Document is outside the configured input directories: \(documentURL)")
+        }
+        return documentComponents.dropFirst(sourceRoot.count).joined(separator: "/")
     }
 
     private func hash(_ sourceText: String) -> String {

--- a/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
@@ -16,8 +16,8 @@ struct DocumentScanner {
                 result.generatedFileURLs.append(contentsOf: scan.generatedFileURLs)
             }
         return DocumentScan(
-            documentFileURLs: scan.documentFileURLs.sorted { $0.path < $1.path },
-            generatedFileURLs: scan.generatedFileURLs.sorted { $0.path < $1.path }
+            documentFileURLs: Set(scan.documentFileURLs).sorted { $0.path < $1.path },
+            generatedFileURLs: Set(scan.generatedFileURLs).sorted { $0.path < $1.path }
         )
     }
 

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -6,6 +6,7 @@ struct DocumentsWriter {
     let resolvedDocuments: ResolvedDocuments
 
     func write(using fileOutput: FileOutput) async throws {
+        try validateOutputURLs()
         switch configuration.output.documents.directory {
         case .definition: break
         case .directory(let url):
@@ -40,6 +41,24 @@ struct DocumentsWriter {
         let generated = resolvedDocuments.documents.map { $0.document.outputURL(configuration) }
         let removed = Set(resolvedDocuments.previouslyGenerated).subtracting(generated)
         await fileOutput.remove(at: removed)
+    }
+
+    private func validateOutputURLs() throws {
+        var sourceByOutputURL: [URL: URL] = [:]
+        for resolvedDocument in resolvedDocuments.documents {
+            let document = resolvedDocument.document
+            let outputURL = document.outputURL(configuration).standardizedFileURL
+            if let existingSource = sourceByOutputURL[outputURL] {
+                throw Codegen.Error(description: """
+                Multiple GraphQL documents resolve to the same generated output file:
+                Output: \(outputURL)
+                Sources:
+                \(existingSource)
+                \(document.url)
+                """)
+            }
+            sourceByOutputURL[outputURL] = document.url
+        }
     }
 
     private func buildOperation(


### PR DESCRIPTION
## What changed

Preserve each GraphQL document's path relative to its configured input root when writing into a custom output directory. Duplicate scans are deduplicated, and colliding destinations are rejected before staging output.

## Why

The previous implementation flattened every document to its last path component, so same-named files from different feature directories silently overwrote one another.

## Validation

- `swift test -Xswiftc -warnings-as-errors`

Stacked on #24.
