### PR TITLE
Honor configured subscription access levels

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -140,7 +140,7 @@ struct URLSessionWriter {
             ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
             ///   in the "accept" header.
             ///   - decoder: The function used to turn response data into an Subscription.Data instance.
-            public func subscribe<Subscription: GraphQLSubscription>(
+            \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
                 decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder()
             ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {


### PR DESCRIPTION
## What changed

Generate `URLSession.subscribe` with the configured API access level.

## Why

The subscription method was hard-coded `public`, which made default internal generated APIs fail to compile because a public method exposed internal generated types.

## Validation

- `swift build -Xswiftc -warnings-as-errors`

Stacked on #25.
