### PR TITLE
Propagate subscription stream errors

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -150,16 +150,20 @@ struct URLSessionWriter {
                 }
                 return AsyncThrowingStream { continuation in
                     let task = Task {
-                        var buffer = ServerSentEventBuffer()
-                        for try await byte in asyncBytes {
-                            if let messageData = buffer.append(byte) {
-                                switch try decoder(messageData) {
-                                case .success(let success): continuation.yield(success)
-                                case .requestError(let requestError): throw requestError
+                        do {
+                            var buffer = ServerSentEventBuffer()
+                            for try await byte in asyncBytes {
+                                if let messageData = buffer.append(byte) {
+                                    switch try decoder(messageData) {
+                                    case .success(let success): continuation.yield(success)
+                                    case .requestError(let requestError): throw requestError
+                                    }
                                 }
                             }
+                            continuation.finish()
+                        } catch {
+                            continuation.finish(throwing: error)
                         }
-                        continuation.finish()
                     }
                     continuation.onTermination = { _ in
                         task.cancel()


### PR DESCRIPTION
## What changed

Finish generated subscription streams with their thrown transport, decoding, or GraphQL request error.

## Why

Errors thrown inside the producer task previously ended the task without resuming the `AsyncThrowingStream` consumer, leaving callers waiting indefinitely.

## Validation

- `swift build -Xswiftc -warnings-as-errors`

Stacked on #26.
