### PR TITLE
Reuse one GraphQL JavaScript runtime

### DIFF
--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -22,14 +22,14 @@ public struct Codegen: Sendable {
             graphQLJS: graphQLJS,
             urlSession: urlSession
         ).load()
-        let documents = try await DocumentsLoader(
+        let documents = try DocumentsLoader(
             configuration: configuration,
             graphQLJS: graphQLJS
         ).load()
 
         // Validation
         if configuration.validation {
-            try await DocumentsValidator(
+            try DocumentsValidator(
                 schema: schema,
                 documents: documents,
                 graphQLJS: graphQLJS

--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -16,14 +16,23 @@ public struct Codegen: Sendable {
     public func run() async throws {
         // Input
         let start = Date()
-        let schema = try await SchemaLoader(configuration: configuration, urlSession: urlSession).load()
-        let documents = try DocumentsLoader(configuration: configuration).load()
+        let graphQLJS = try GraphQLJS()
+        let schema = try await SchemaLoader(
+            configuration: configuration,
+            graphQLJS: graphQLJS,
+            urlSession: urlSession
+        ).load()
+        let documents = try await DocumentsLoader(
+            configuration: configuration,
+            graphQLJS: graphQLJS
+        ).load()
 
         // Validation
         if configuration.validation {
-            try DocumentsValidator(
+            try await DocumentsValidator(
                 schema: schema,
-                documents: documents
+                documents: documents,
+                graphQLJS: graphQLJS
             ).validate()
         }
 

--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
@@ -4,8 +4,8 @@ struct DocumentASTParser {
     let graphQLJS: GraphQLJS
     let sourceText: String
 
-    func parse() async throws -> AST.Document {
-        let astJSON = try await graphQLJS.parse(sourceText)
+    func parse() throws -> AST.Document {
+        let astJSON = try graphQLJS.parse(sourceText)
         return try JSONDecoder().decode(AST.Document.self, from: astJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentASTParser.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 struct DocumentASTParser {
+    let graphQLJS: GraphQLJS
     let sourceText: String
 
-    func parse() throws -> AST.Document {
-        let astJSON = try GraphQLJS(sourceText: sourceText).parsed()
+    func parse() async throws -> AST.Document {
+        let astJSON = try await graphQLJS.parse(sourceText)
         return try JSONDecoder().decode(AST.Document.self, from: astJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import JavaScriptCore
 
-actor GraphQLJS {
+struct GraphQLJS {
     enum Error: Swift.Error, CustomStringConvertible {
         case bundleEvaluationFailed(String)
         case bundleReadFailed(URL, String)

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
@@ -1,7 +1,7 @@
 import Foundation
 @preconcurrency import JavaScriptCore
 
-struct GraphQLJS {
+actor GraphQLJS {
     enum Error: Swift.Error, CustomStringConvertible {
         case bundleEvaluationFailed(String)
         case bundleReadFailed(URL, String)
@@ -45,12 +45,10 @@ struct GraphQLJS {
         }
     }()
 
-    let sourceText: String
-
     private let context: JSContext
     private let library: JSValue
 
-    init(sourceText: String) throws {
+    init() throws {
         let bundleContents = try Self.bundleContents.get()
         guard let context = JSContext() else {
             throw Error.contextCreationFailed
@@ -67,14 +65,16 @@ struct GraphQLJS {
         }
         self.context = context
         self.library = library
-        self.sourceText = sourceText
     }
 
-    func canonicalized() throws -> String {
+    func canonicalize(_ sourceText: String) throws -> String {
         try stringResult(function: "canonicalizeDocument", arguments: [sourceText])
     }
 
-    func convertedSDLSchema(introspectionQuery: String) throws -> (data: Data, text: String) {
+    func convertSDLSchema(
+        _ sourceText: String,
+        introspectionQuery: String
+    ) throws -> (data: Data, text: String) {
         let text = try stringResult(
             function: "convertSDLSchema",
             arguments: [sourceText, introspectionQuery]
@@ -82,15 +82,15 @@ struct GraphQLJS {
         return (Data(text.utf8), text)
     }
 
-    func parsed() throws -> Data {
+    func parse(_ sourceText: String) throws -> Data {
         Data(try stringResult(function: "parseGraphQL", arguments: [sourceText]).utf8)
     }
 
-    func validated(schemaJSONString: String) throws -> Data {
+    func validate(_ sourceText: String, schemaJSON: String) throws -> Data {
         Data(
             try stringResult(
                 function: "validateDocument",
-                arguments: [sourceText, schemaJSONString]
+                arguments: [sourceText, schemaJSON]
             ).utf8
         )
     }

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -26,7 +26,7 @@ struct Document: Sendable {
     struct Operation: Sendable {
         let ast: AST.OperationDefinition
         let sourceText: Substring
-        let resolvedText: String?
+        let resolvedText: String
         let hash: String?
     }
 

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -12,13 +12,13 @@ struct DocumentsLoader {
         }
     }
 
-    func load() async throws -> Documents {
+    func load() throws -> Documents {
         let scan = try DocumentScanner(directories: configuration.input.documentDirectories).scan()
         var documents: [Document] = []
         var fragmentLookup: [String: Document.Fragment] = [:]
         for documentURL in scan.documentFileURLs {
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
-            let ast = try await DocumentASTParser(
+            let ast = try DocumentASTParser(
                 graphQLJS: graphQLJS,
                 sourceText: documentText
             ).parse()
@@ -72,7 +72,7 @@ struct DocumentsLoader {
         }
         return Documents(
             previouslyGenerated: scan.generatedFileURLs,
-            documents: try await resolvedDocuments(documents, fragmentLookup: fragmentLookup),
+            documents: try resolvedDocuments(documents, fragmentLookup: fragmentLookup),
             fragmentLookup: fragmentLookup
         )
     }
@@ -80,14 +80,14 @@ struct DocumentsLoader {
     private func resolvedDocuments(
         _ documents: [Document],
         fragmentLookup: [String: Document.Fragment]
-    ) async throws -> [Document] {
+    ) throws -> [Document] {
         var updatedDocuments: [Document] = []
         for document in documents {
             var updatedDefinitions: [Document.Definition] = []
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    let resolvedText = try await graphQLJS.canonicalize(
+                    let resolvedText = try graphQLJS.canonicalize(
                         try OperationTextResolver(
                             operation: operation,
                             fragmentLookup: fragmentLookup

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -3,10 +3,7 @@ import Foundation
 
 struct DocumentsLoader {
     let configuration: Configuration
-
-    private var shouldResolve: Bool {
-        configuration.validation || shouldHash
-    }
+    let graphQLJS: GraphQLJS
 
     private var shouldHash: Bool {
         switch configuration.output.documents.operations.persistedOperations {
@@ -15,13 +12,16 @@ struct DocumentsLoader {
         }
     }
 
-    func load() throws -> Documents {
+    func load() async throws -> Documents {
         let scan = try DocumentScanner(directories: configuration.input.documentDirectories).scan()
         var documents: [Document] = []
         var fragmentLookup: [String: Document.Fragment] = [:]
         for documentURL in scan.documentFileURLs {
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
-            let ast = try DocumentASTParser(sourceText: documentText).parse()
+            let ast = try await DocumentASTParser(
+                graphQLJS: graphQLJS,
+                sourceText: documentText
+            ).parse()
             var definitions: [Document.Definition] = []
             for definition in ast.definitions {
                 switch definition {
@@ -72,7 +72,7 @@ struct DocumentsLoader {
         }
         return Documents(
             previouslyGenerated: scan.generatedFileURLs,
-            documents: shouldResolve ? try resolvedDocuments(documents, fragmentLookup: fragmentLookup) : documents,
+            documents: try await resolvedDocuments(documents, fragmentLookup: fragmentLookup),
             fragmentLookup: fragmentLookup
         )
     }
@@ -80,19 +80,19 @@ struct DocumentsLoader {
     private func resolvedDocuments(
         _ documents: [Document],
         fragmentLookup: [String: Document.Fragment]
-    ) throws -> [Document] {
+    ) async throws -> [Document] {
         var updatedDocuments: [Document] = []
         for document in documents {
             var updatedDefinitions: [Document.Definition] = []
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    let resolvedText = try GraphQLJS(
-                        sourceText: try OperationTextResolver(
+                    let resolvedText = try await graphQLJS.canonicalize(
+                        try OperationTextResolver(
                             operation: operation,
                             fragmentLookup: fragmentLookup
                         ).expandSourceText { $0.sourceText }
-                    ).canonicalized()
+                    )
                     updatedDefinitions.append(
                         .operation(
                             Document.Operation(

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -2,6 +2,13 @@ import CryptoKit
 import Foundation
 
 struct DocumentsLoader {
+    private struct ParsedDocument {
+        let url: URL
+        let sourceText: String
+        let ast: AST.Document
+        let relativePath: String
+    }
+
     let configuration: Configuration
     let graphQLJS: GraphQLJS
 
@@ -14,7 +21,7 @@ struct DocumentsLoader {
 
     func load() throws -> Documents {
         let scan = try DocumentScanner(directories: configuration.input.documentDirectories).scan()
-        var documents: [Document] = []
+        var parsedDocuments: [ParsedDocument] = []
         var fragmentLookup: [String: Document.Fragment] = [:]
         for documentURL in scan.documentFileURLs {
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
@@ -22,100 +29,88 @@ struct DocumentsLoader {
                 graphQLJS: graphQLJS,
                 sourceText: documentText
             ).parse()
-            var definitions: [Document.Definition] = []
             for definition in ast.definitions {
-                switch definition {
-                case .operation(let operation):
-                    definitions.append(
-                        .operation(
-                            Document.Operation(
-                                ast: operation,
-                                sourceText: documentText[utf16Range: operation.loc.utf16Range],
-                                resolvedText: nil,
-                                hash: nil
-                            )
-                        )
-                    )
-                case .fragment(let fragment):
-                    if let existing = fragmentLookup[fragment.name.value] {
-                        throw Codegen.Error(description: """
-                        Duplicate fragment name found:
-                        Name: \(fragment.name.value)
-                        Files:
-                        \(existing.file)
-                        and
-                        \(documentURL)
+                guard case .fragment(let fragment) = definition else { continue }
+                if let existing = fragmentLookup[fragment.name.value] {
+                    throw Codegen.Error(description: """
+                    Duplicate fragment name found:
+                    Name: \(fragment.name.value)
+                    Files:
+                    \(existing.file)
+                    and
+                    \(documentURL)
 
-                        Note: The GraphQL spec requires fragment names to be unique within a document,
-                        however, this codegen requires fragment names to be univerally unique.
-                        This allows reusing fragments declared in other .graphql files.
-                        If you think this is the wrong decision, please open an issue on github
-                        and explain your use-case.
-                        https://spec.graphql.org/October2021/#sel-IALVDDFDABhCBrE77W
-                        """)
-                    }
-                    definitions.append(.fragment(fragment.name.value))
-                    fragmentLookup[fragment.name.value] = Document.Fragment(
-                        file: documentURL,
-                        ast: fragment,
-                        sourceText: documentText[utf16Range: fragment.loc.utf16Range]
-                    )
+                    Note: The GraphQL spec requires fragment names to be unique within a document,
+                    however, this codegen requires fragment names to be univerally unique.
+                    This allows reusing fragments declared in other .graphql files.
+                    If you think this is the wrong decision, please open an issue on github
+                    and explain your use-case.
+                    https://spec.graphql.org/October2021/#sel-IALVDDFDABhCBrE77W
+                    """)
                 }
+                fragmentLookup[fragment.name.value] = Document.Fragment(
+                    file: documentURL,
+                    ast: fragment,
+                    sourceText: documentText[utf16Range: fragment.loc.utf16Range]
+                )
             }
-            documents.append(
-                Document(
+            parsedDocuments.append(
+                ParsedDocument(
                     url: documentURL,
-                    definitions: definitions,
+                    sourceText: documentText,
+                    ast: ast,
                     relativePath: try relativePath(for: documentURL)
                 )
             )
         }
         return Documents(
             previouslyGenerated: scan.generatedFileURLs,
-            documents: try resolvedDocuments(documents, fragmentLookup: fragmentLookup),
+            documents: try resolvedDocuments(parsedDocuments, fragmentLookup: fragmentLookup),
             fragmentLookup: fragmentLookup
         )
     }
 
     private func resolvedDocuments(
-        _ documents: [Document],
+        _ documents: [ParsedDocument],
         fragmentLookup: [String: Document.Fragment]
     ) throws -> [Document] {
-        var updatedDocuments: [Document] = []
+        var resolvedDocuments: [Document] = []
         for document in documents {
-            var updatedDefinitions: [Document.Definition] = []
-            for definition in document.definitions {
+            var resolvedDefinitions: [Document.Definition] = []
+            for definition in document.ast.definitions {
                 switch definition {
                 case .operation(let operation):
+                    let sourceText = document.sourceText[utf16Range: operation.loc.utf16Range]
                     let resolvedText = try graphQLJS.canonicalize(
                         try OperationTextResolver(
                             operation: operation,
+                            sourceText: sourceText,
                             fragmentLookup: fragmentLookup
                         ).expandSourceText { $0.sourceText }
                     )
-                    updatedDefinitions.append(
+                    resolvedDefinitions.append(
                         .operation(
                             Document.Operation(
-                                ast: operation.ast,
-                                sourceText: operation.sourceText,
+                                ast: operation,
+                                sourceText: sourceText,
                                 resolvedText: resolvedText,
                                 hash: shouldHash ? hash(resolvedText) : nil
                             )
                         )
                     )
-                case .fragment:
-                    updatedDefinitions.append(definition)
+                case .fragment(let fragment):
+                    resolvedDefinitions.append(.fragment(fragment.name.value))
                 }
             }
-            updatedDocuments.append(
+            resolvedDocuments.append(
                 Document(
                     url: document.url,
-                    definitions: updatedDefinitions,
+                    definitions: resolvedDefinitions,
                     relativePath: document.relativePath
                 )
             )
         }
-        return updatedDocuments
+        return resolvedDocuments
     }
 
     private func relativePath(for documentURL: URL) throws -> String {

--- a/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
@@ -1,14 +1,15 @@
 import OrderedCollections
 
 struct OperationTextResolver {
-    let operation: Document.Operation
+    let operation: AST.OperationDefinition
+    let sourceText: Substring
     let fragmentLookup: [String: Document.Fragment]
 
     func expandSourceText(
         mapFragmentSpread: (Document.Fragment) -> Substring
     ) throws -> String {
         var text = """
-        \(operation.sourceText)
+        \(sourceText)
         """
         let fragmentSpreads = try fragmentSpreadsDeep().compactMap(mapFragmentSpread)
         if !fragmentSpreads.isEmpty {
@@ -21,7 +22,7 @@ struct OperationTextResolver {
     private func fragmentSpreadsDeep() throws -> [Document.Fragment] {
         var result: [Document.Fragment] = []
         var visited: Set<String> = []
-        var stack: [AST.SelectionSet] = [operation.ast.selectionSet]
+        var stack: [AST.SelectionSet] = [operation.selectionSet]
         while let current = stack.popLast() {
             for selection in current.selections {
                 switch selection {
@@ -33,7 +34,7 @@ struct OperationTextResolver {
                         guard let fragment = fragmentLookup[fragmentSpread.name.value] else {
                             throw Codegen.Error(description: """
                             Fragment spread '...\(fragmentSpread.name.value)' used in operation \
-                            \(operation.ast.name?.value ?? "")
+                            \(operation.name?.value ?? "")
                             but no definition was found for the fragment.
                             """)
                         }

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -75,6 +75,7 @@ struct TypeCache {
 
 struct SchemaLoader {
     let configuration: Configuration
+    let graphQLJS: GraphQLJS
     let urlSession: URLSession
 
     func load() async throws -> Schema {
@@ -109,7 +110,7 @@ struct SchemaLoader {
             let includeDeprecatedFields,
             let includeDeprecatedEnumValues
         ):
-            try loadSchemaFromSDLFile(
+            try await loadSchemaFromSDLFile(
                 schemaFile,
                 includeDeprecatedFields: includeDeprecatedFields,
                 includeDeprecatedEnumValues: includeDeprecatedEnumValues
@@ -154,14 +155,16 @@ struct SchemaLoader {
         _ schemaFile: URL,
         includeDeprecatedFields: Bool,
         includeDeprecatedEnumValues: Bool
-    ) throws -> (String?, __Schema) {
+    ) async throws -> (String?, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
         let introspectionQuery = IntrospectionQuery(
             includeDeprecatedFields: includeDeprecatedFields,
             includeDeprecatedEnumValues: includeDeprecatedEnumValues
         ).query
-        let jsonSchema = try GraphQLJS(sourceText: sdlSchemaString)
-            .convertedSDLSchema(introspectionQuery: introspectionQuery)
+        let jsonSchema = try await graphQLJS.convertSDLSchema(
+            sdlSchemaString,
+            introspectionQuery: introspectionQuery
+        )
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: jsonSchema.data).__schema
         return (configuration.validation ? jsonSchema.text : nil, __schema)
     }

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -110,7 +110,7 @@ struct SchemaLoader {
             let includeDeprecatedFields,
             let includeDeprecatedEnumValues
         ):
-            try await loadSchemaFromSDLFile(
+            try loadSchemaFromSDLFile(
                 schemaFile,
                 includeDeprecatedFields: includeDeprecatedFields,
                 includeDeprecatedEnumValues: includeDeprecatedEnumValues
@@ -155,13 +155,13 @@ struct SchemaLoader {
         _ schemaFile: URL,
         includeDeprecatedFields: Bool,
         includeDeprecatedEnumValues: Bool
-    ) async throws -> (String?, __Schema) {
+    ) throws -> (String?, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
         let introspectionQuery = IntrospectionQuery(
             includeDeprecatedFields: includeDeprecatedFields,
             includeDeprecatedEnumValues: includeDeprecatedEnumValues
         ).query
-        let jsonSchema = try await graphQLJS.convertSDLSchema(
+        let jsonSchema = try graphQLJS.convertSDLSchema(
             sdlSchemaString,
             introspectionQuery: introspectionQuery
         )

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -120,10 +120,6 @@ struct OperationBuilder {
                 name: "document",
                 value: .assigned(SwiftSource(value: expandedSourceText).multilineStringLiteral, type: nil)
             )
-            let resolvedSourceText = try OperationTextResolver(
-                operation: operation,
-                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment)
-            ).expandSourceText(mapFragmentSpread: \.sourceText)
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -133,7 +129,7 @@ struct OperationBuilder {
                 name: "minifiedDocument",
                 value: .assigned(
                     SwiftSource(
-                        value: try GraphQLJS(sourceText: resolvedSourceText).canonicalized()
+                        value: operation.resolvedText!
                     ).multilineStringLiteral,
                     type: nil
                 )

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -108,7 +108,8 @@ struct OperationBuilder {
         case .registered: break
         case .automatic, .none:
             let expandedSourceText = try OperationTextResolver(
-                operation: operation,
+                operation: operation.ast,
+                sourceText: operation.sourceText,
                 fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment)
             ).expandSourceText { fragment in "\\(\(fragment.ast.name.value.capitalizedFirst).source)" }
             operationStruct.addProperty(
@@ -129,7 +130,7 @@ struct OperationBuilder {
                 name: "minifiedDocument",
                 value: .assigned(
                     SwiftSource(
-                        value: operation.resolvedText!
+                        value: operation.resolvedText
                     ).multilineStringLiteral,
                     type: nil
                 )

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -13,7 +13,7 @@ struct PersistedOperationManifestWriter {
                     operations.append(
                         PersistedOperationManifest.Operation(
                             id: operation.hash!,
-                            body: operation.resolvedText!,
+                            body: operation.resolvedText,
                             name: operation.ast.name?.value,
                             type: operation.ast.operation.rawValue
                         )

--- a/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
@@ -23,12 +23,11 @@ struct DocumentValidator {
     }
 
     let documentText: String
+    let graphQLJS: GraphQLJS
     let schemaJSONString: String
 
-    func validate() throws -> [Error] {
-        let errorsJSON = try GraphQLJS(sourceText: documentText).validated(
-            schemaJSONString: schemaJSONString
-        )
+    func validate() async throws -> [Error] {
+        let errorsJSON = try await graphQLJS.validate(documentText, schemaJSON: schemaJSONString)
         return try JSONDecoder().decode([Error].self, from: errorsJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
@@ -26,8 +26,8 @@ struct DocumentValidator {
     let graphQLJS: GraphQLJS
     let schemaJSONString: String
 
-    func validate() async throws -> [Error] {
-        let errorsJSON = try await graphQLJS.validate(documentText, schemaJSON: schemaJSONString)
+    func validate() throws -> [Error] {
+        let errorsJSON = try graphQLJS.validate(documentText, schemaJSON: schemaJSONString)
         return try JSONDecoder().decode([Error].self, from: errorsJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -40,7 +40,7 @@ struct DocumentsValidator {
                 switch definition {
                 case .operation(let operation):
                     let errors = try DocumentValidator(
-                        documentText: operation.resolvedText!,
+                        documentText: operation.resolvedText,
                         graphQLJS: graphQLJS,
                         schemaJSONString: schemaJSONString
                     ).validate()

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -29,8 +29,9 @@ struct DocumentsValidator {
 
     let schema: Schema
     let documents: Documents
+    let graphQLJS: GraphQLJS
 
-    func validate() throws {
+    func validate() async throws {
         var documentErrors: [DocumentError] = []
         let schemaJSONString = schema.jsonString!
         for document in documents.documents {
@@ -38,8 +39,9 @@ struct DocumentsValidator {
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    let errors = try DocumentValidator(
+                    let errors = try await DocumentValidator(
                         documentText: operation.resolvedText!,
+                        graphQLJS: graphQLJS,
                         schemaJSONString: schemaJSONString
                     ).validate()
                     if !errors.isEmpty {

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -31,7 +31,7 @@ struct DocumentsValidator {
     let documents: Documents
     let graphQLJS: GraphQLJS
 
-    func validate() async throws {
+    func validate() throws {
         var documentErrors: [DocumentError] = []
         let schemaJSONString = schema.jsonString!
         for document in documents.documents {
@@ -39,7 +39,7 @@ struct DocumentsValidator {
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    let errors = try await DocumentValidator(
+                    let errors = try DocumentValidator(
                         documentText: operation.resolvedText!,
                         graphQLJS: graphQLJS,
                         schemaJSONString: schemaJSONString


### PR DESCRIPTION
## What changed

Create one actor-isolated `GraphQLJS` runtime per codegen run and pass it through schema loading, document parsing/canonicalization, and validation.

## Why

The generator previously created and evaluated a JavaScript bundle in a new `JSContext` for each operation and validation pass. Reuse makes JavaScriptCore confinement explicit and removes the dominant time and memory cost.

## Performance

For a release-build 100-operation generation run, warm elapsed time fell from about 1.95 seconds to 0.13–0.14 seconds and maximum RSS fell from about 731 MB to about 21.7 MB.

## Validation

- `swift test -Xswiftc -warnings-as-errors`

Stacked on #28.
