### PR TITLE
Model loaded codegen inputs as valid states

### DIFF
--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -28,10 +28,10 @@ public struct Codegen: Sendable {
         ).load()
 
         // Validation
-        if configuration.validation {
+        if case .enabled(let schemaJSON) = loadedSchema.validation {
             try DocumentsValidator(
                 schema: loadedSchema.schema,
-                schemaJSON: loadedSchema.validationJSON,
+                schemaJSON: schemaJSON,
                 documents: documents,
                 graphQLJS: graphQLJS
             ).validate()

--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -30,7 +30,6 @@ public struct Codegen: Sendable {
         // Validation
         if case .enabled(let schemaJSON) = loadedSchema.validation {
             try DocumentsValidator(
-                schema: loadedSchema.schema,
                 schemaJSON: schemaJSON,
                 documents: documents,
                 graphQLJS: graphQLJS

--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -17,7 +17,7 @@ public struct Codegen: Sendable {
         // Input
         let start = Date()
         let graphQLJS = try GraphQLJS()
-        let schema = try await SchemaLoader(
+        let loadedSchema = try await SchemaLoader(
             configuration: configuration,
             graphQLJS: graphQLJS,
             urlSession: urlSession
@@ -30,7 +30,8 @@ public struct Codegen: Sendable {
         // Validation
         if configuration.validation {
             try DocumentsValidator(
-                schema: schema,
+                schema: loadedSchema.schema,
+                schemaJSON: loadedSchema.validationJSON,
                 documents: documents,
                 graphQLJS: graphQLJS
             ).validate()
@@ -38,7 +39,7 @@ public struct Codegen: Sendable {
 
         // Resolution
         let resolvedDocuments = try DocumentsResolver(
-            schema: schema,
+            schema: loadedSchema.schema,
             documents: documents
         ).resolve()
 
@@ -51,7 +52,7 @@ public struct Codegen: Sendable {
             ).write(using: fileOutput)
             try await SchemaWriter(
                 configuration: configuration,
-                schema: schema,
+                schema: loadedSchema.schema,
                 resolvedDocuments: resolvedDocuments
             ).write(using: fileOutput)
             try await APIWriter(

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 struct Documents {
@@ -26,8 +27,21 @@ struct Document: Sendable {
     struct Operation: Sendable {
         let ast: AST.OperationDefinition
         let canonicalText: String
-        let hash: String
         let sourceText: Substring
+
+        var hash: String {
+            let digits = Array("0123456789abcdef".utf8)
+            let capacity = 2 * SHA256.Digest.byteCount
+            return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+                var index = 0
+                for byte in SHA256.hash(data: Data(canonicalText.utf8)) {
+                    buffer[index] = digits[Int(byte >> 4)]
+                    buffer[index + 1] = digits[Int(byte & 0x0F)]
+                    index += 2
+                }
+                return capacity
+            }
+        }
     }
 
     struct Fragment {

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 struct Documents {
@@ -25,23 +24,15 @@ struct Document: Sendable {
     }
 
     struct Operation: Sendable {
+        enum Persistence: Sendable {
+            case standard
+            case registered(hash: String)
+        }
+
         let ast: AST.OperationDefinition
         let canonicalText: String
+        let persistence: Persistence
         let sourceText: Substring
-
-        var hash: String {
-            let digits = Array("0123456789abcdef".utf8)
-            let capacity = 2 * SHA256.Digest.byteCount
-            return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
-                var index = 0
-                for byte in SHA256.hash(data: Data(canonicalText.utf8)) {
-                    buffer[index] = digits[Int(byte >> 4)]
-                    buffer[index + 1] = digits[Int(byte & 0x0F)]
-                    index += 2
-                }
-                return capacity
-            }
-        }
     }
 
     struct Fragment {

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -25,9 +25,9 @@ struct Document: Sendable {
 
     struct Operation: Sendable {
         let ast: AST.OperationDefinition
+        let canonicalText: String
+        let hash: String
         let sourceText: Substring
-        let resolvedText: String
-        let hash: String?
     }
 
     struct Fragment {

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -2,115 +2,133 @@ import CryptoKit
 import Foundation
 
 struct DocumentsLoader {
+    private enum ParsedDefinition {
+        case fragment(String)
+        case operation(ast: AST.OperationDefinition, sourceText: Substring)
+    }
+
     private struct ParsedDocument {
-        let url: URL
-        let sourceText: String
-        let ast: AST.Document
+        let definitions: [ParsedDefinition]
         let relativePath: String
+        let url: URL
     }
 
     let configuration: Configuration
     let graphQLJS: GraphQLJS
 
-    private var shouldHash: Bool {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: true
-        case .automatic, .none: false
-        }
-    }
-
     func load() throws -> Documents {
         let scan = try DocumentScanner(directories: configuration.input.documentDirectories).scan()
-        var parsedDocuments: [ParsedDocument] = []
         var fragmentLookup: [String: Document.Fragment] = [:]
-        for documentURL in scan.documentFileURLs {
+        let parsedDocuments = try parse(
+            scan.documentFileURLs,
+            fragmentLookup: &fragmentLookup
+        )
+        return Documents(
+            previouslyGenerated: scan.generatedFileURLs,
+            documents: try prepare(parsedDocuments, fragmentLookup: fragmentLookup),
+            fragmentLookup: fragmentLookup
+        )
+    }
+
+    private func parse(
+        _ documentURLs: [URL],
+        fragmentLookup: inout [String: Document.Fragment]
+    ) throws -> [ParsedDocument] {
+        var documents: [ParsedDocument] = []
+        documents.reserveCapacity(documentURLs.count)
+        for documentURL in documentURLs {
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
             let ast = try DocumentASTParser(
                 graphQLJS: graphQLJS,
                 sourceText: documentText
             ).parse()
+            var definitions: [ParsedDefinition] = []
+            definitions.reserveCapacity(ast.definitions.count)
             for definition in ast.definitions {
-                guard case .fragment(let fragment) = definition else { continue }
-                if let existing = fragmentLookup[fragment.name.value] {
-                    throw Codegen.Error(description: """
-                    Duplicate fragment name found:
-                    Name: \(fragment.name.value)
-                    Files:
-                    \(existing.file)
-                    and
-                    \(documentURL)
+                switch definition {
+                case .operation(let operation):
+                    definitions.append(.operation(
+                        ast: operation,
+                        sourceText: documentText[utf16Range: operation.loc.utf16Range]
+                    ))
+                case .fragment(let fragment):
+                    if let existing = fragmentLookup[fragment.name.value] {
+                        throw Codegen.Error(description: """
+                        Duplicate fragment name found:
+                        Name: \(fragment.name.value)
+                        Files:
+                        \(existing.file)
+                        and
+                        \(documentURL)
 
-                    Note: The GraphQL spec requires fragment names to be unique within a document,
-                    however, this codegen requires fragment names to be univerally unique.
-                    This allows reusing fragments declared in other .graphql files.
-                    If you think this is the wrong decision, please open an issue on github
-                    and explain your use-case.
-                    https://spec.graphql.org/October2021/#sel-IALVDDFDABhCBrE77W
-                    """)
+                        Note: The GraphQL spec requires fragment names to be unique within a document,
+                        however, this codegen requires fragment names to be univerally unique.
+                        This allows reusing fragments declared in other .graphql files.
+                        If you think this is the wrong decision, please open an issue on github
+                        and explain your use-case.
+                        https://spec.graphql.org/October2021/#sel-IALVDDFDABhCBrE77W
+                        """)
+                    }
+                    definitions.append(.fragment(fragment.name.value))
+                    fragmentLookup[fragment.name.value] = Document.Fragment(
+                        file: documentURL,
+                        ast: fragment,
+                        sourceText: documentText[utf16Range: fragment.loc.utf16Range]
+                    )
                 }
-                fragmentLookup[fragment.name.value] = Document.Fragment(
-                    file: documentURL,
-                    ast: fragment,
-                    sourceText: documentText[utf16Range: fragment.loc.utf16Range]
-                )
             }
-            parsedDocuments.append(
+            documents.append(
                 ParsedDocument(
-                    url: documentURL,
-                    sourceText: documentText,
-                    ast: ast,
-                    relativePath: try relativePath(for: documentURL)
+                    definitions: definitions,
+                    relativePath: try relativePath(for: documentURL),
+                    url: documentURL
                 )
             )
         }
-        return Documents(
-            previouslyGenerated: scan.generatedFileURLs,
-            documents: try resolvedDocuments(parsedDocuments, fragmentLookup: fragmentLookup),
-            fragmentLookup: fragmentLookup
-        )
+        return documents
     }
 
-    private func resolvedDocuments(
+    private func prepare(
         _ documents: [ParsedDocument],
         fragmentLookup: [String: Document.Fragment]
     ) throws -> [Document] {
-        var resolvedDocuments: [Document] = []
+        var updatedDocuments: [Document] = []
+        updatedDocuments.reserveCapacity(documents.count)
         for document in documents {
-            var resolvedDefinitions: [Document.Definition] = []
-            for definition in document.ast.definitions {
+            var updatedDefinitions: [Document.Definition] = []
+            updatedDefinitions.reserveCapacity(document.definitions.count)
+            for definition in document.definitions {
                 switch definition {
-                case .operation(let operation):
-                    let sourceText = document.sourceText[utf16Range: operation.loc.utf16Range]
-                    let resolvedText = try graphQLJS.canonicalize(
-                        try OperationTextResolver(
-                            operation: operation,
-                            sourceText: sourceText,
-                            fragmentLookup: fragmentLookup
-                        ).expandSourceText { $0.sourceText }
-                    )
-                    resolvedDefinitions.append(
+                case .operation(let operationAST, let operationSourceText):
+                    let expandedText = try OperationTextResolver(
+                        fragmentLookup: fragmentLookup,
+                        operationAST: operationAST,
+                        operationSourceText: operationSourceText
+                    ).expandSourceText { $0.sourceText }
+                    let canonicalText = try graphQLJS.canonicalize(expandedText)
+                    updatedDefinitions.append(
                         .operation(
                             Document.Operation(
-                                ast: operation,
-                                sourceText: sourceText,
-                                resolvedText: resolvedText,
-                                hash: shouldHash ? hash(resolvedText) : nil
+                                ast: operationAST,
+                                canonicalText: canonicalText,
+                                hash: hash(canonicalText),
+                                sourceText: operationSourceText
                             )
                         )
                     )
-                case .fragment(let fragment):
-                    resolvedDefinitions.append(.fragment(fragment.name.value))
+                case .fragment(let name):
+                    updatedDefinitions.append(.fragment(name))
                 }
             }
-            resolvedDocuments.append(
+            updatedDocuments.append(
                 Document(
                     url: document.url,
-                    definitions: resolvedDefinitions,
+                    definitions: updatedDefinitions,
                     relativePath: document.relativePath
                 )
             )
         }
-        return resolvedDocuments
+        return updatedDocuments
     }
 
     private func relativePath(for documentURL: URL) throws -> String {
@@ -128,12 +146,12 @@ struct DocumentsLoader {
     private func hash(_ sourceText: String) -> String {
         let digits = Array("0123456789abcdef".utf8)
         let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
+        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+            var index = 0
             for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0F)]
-                p += 2
+                buffer[index] = digits[Int(byte >> 4)]
+                buffer[index + 1] = digits[Int(byte & 0x0F)]
+                index += 2
             }
             return capacity
         }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 struct DocumentsLoader {
@@ -111,7 +110,6 @@ struct DocumentsLoader {
                             Document.Operation(
                                 ast: operationAST,
                                 canonicalText: canonicalText,
-                                hash: hash(canonicalText),
                                 sourceText: operationSourceText
                             )
                         )
@@ -141,19 +139,5 @@ struct DocumentsLoader {
             throw Codegen.Error(description: "Document is outside the configured input directories: \(documentURL)")
         }
         return documentComponents.dropFirst(sourceRoot.count).joined(separator: "/")
-    }
-
-    private func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
-            var index = 0
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                buffer[index] = digits[Int(byte >> 4)]
-                buffer[index + 1] = digits[Int(byte & 0x0F)]
-                index += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 struct DocumentsLoader {
@@ -105,11 +106,19 @@ struct DocumentsLoader {
                         operationSourceText: operationSourceText
                     ).expandSourceText { $0.sourceText }
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
+                    let persistence: Document.Operation.Persistence =
+                        switch configuration.output.documents.operations.persistedOperations {
+                        case .registered:
+                            .registered(hash: hash(canonicalText))
+                        case .automatic, .none:
+                            .standard
+                        }
                     updatedDefinitions.append(
                         .operation(
                             Document.Operation(
                                 ast: operationAST,
                                 canonicalText: canonicalText,
+                                persistence: persistence,
                                 sourceText: operationSourceText
                             )
                         )
@@ -139,5 +148,19 @@ struct DocumentsLoader {
             throw Codegen.Error(description: "Document is outside the configured input directories: \(documentURL)")
         }
         return documentComponents.dropFirst(sourceRoot.count).joined(separator: "/")
+    }
+
+    private func hash(_ sourceText: String) -> String {
+        let digits = Array("0123456789abcdef".utf8)
+        let capacity = 2 * SHA256.Digest.byteCount
+        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+            var index = 0
+            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
+                buffer[index] = digits[Int(byte >> 4)]
+                buffer[index + 1] = digits[Int(byte & 0x0F)]
+                index += 2
+            }
+            return capacity
+        }
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
@@ -1,15 +1,15 @@
 import OrderedCollections
 
 struct OperationTextResolver {
-    let operation: AST.OperationDefinition
-    let sourceText: Substring
     let fragmentLookup: [String: Document.Fragment]
+    let operationAST: AST.OperationDefinition
+    let operationSourceText: Substring
 
     func expandSourceText(
         mapFragmentSpread: (Document.Fragment) -> Substring
     ) throws -> String {
         var text = """
-        \(sourceText)
+        \(operationSourceText)
         """
         let fragmentSpreads = try fragmentSpreadsDeep().compactMap(mapFragmentSpread)
         if !fragmentSpreads.isEmpty {
@@ -22,7 +22,7 @@ struct OperationTextResolver {
     private func fragmentSpreadsDeep() throws -> [Document.Fragment] {
         var result: [Document.Fragment] = []
         var visited: Set<String> = []
-        var stack: [AST.SelectionSet] = [operation.selectionSet]
+        var stack: [AST.SelectionSet] = [operationAST.selectionSet]
         while let current = stack.popLast() {
             for selection in current.selections {
                 switch selection {
@@ -34,7 +34,7 @@ struct OperationTextResolver {
                         guard let fragment = fragmentLookup[fragmentSpread.name.value] else {
                             throw Codegen.Error(description: """
                             Fragment spread '...\(fragmentSpread.name.value)' used in operation \
-                            \(operation.name?.value ?? "")
+                            \(operationAST.name?.value ?? "")
                             but no definition was found for the fragment.
                             """)
                         }

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -2,7 +2,6 @@ import Foundation
 import OrderedCollections
 
 struct Schema {
-    let jsonString: String?
     let queryTypeRef: __Schema.__TypeRef.Object
     let mutationTypeRef: __Schema.__TypeRef.Object?
     let subscriptionTypeRef: __Schema.__TypeRef.Object?

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct LoadedSchema {
+    let schema: Schema
+    let validationJSON: String
+}
+
 // Type names are guaranteed to be unique
 // https://spec.graphql.org/October2021/#sel-FAHTLABDBEmrR
 struct TypeASTCache {
@@ -78,18 +83,20 @@ struct SchemaLoader {
     let graphQLJS: GraphQLJS
     let urlSession: URLSession
 
-    func load() async throws -> Schema {
-        let (jsonString, typedSchema) = try await loadIntrospection()
-        return Schema(
-            jsonString: jsonString,
-            queryTypeRef: typedSchema.queryType,
-            mutationTypeRef: typedSchema.mutationType,
-            subscriptionTypeRef: typedSchema.subscriptionType,
-            typeCache: TypeCache(TypeASTCache(typedSchema))
+    func load() async throws -> LoadedSchema {
+        let (validationJSON, typedSchema) = try await loadIntrospection()
+        return LoadedSchema(
+            schema: Schema(
+                queryTypeRef: typedSchema.queryType,
+                mutationTypeRef: typedSchema.mutationType,
+                subscriptionTypeRef: typedSchema.subscriptionType,
+                typeCache: TypeCache(TypeASTCache(typedSchema))
+            ),
+            validationJSON: validationJSON
         )
     }
 
-    private func loadIntrospection() async throws -> (String?, __Schema) {
+    private func loadIntrospection() async throws -> (String, __Schema) {
         switch configuration.input.schemaSource {
         case .introspectionEndpoint(
             let endpoint,
@@ -123,7 +130,7 @@ struct SchemaLoader {
         headers: [String: String],
         includeDeprecatedFields: Bool = false,
         includeDeprecatedEnumValues: Bool = false
-    ) async throws -> (String?, __Schema) {
+    ) async throws -> (String, __Schema) {
         let data = try await IntrospectionRunner(
             endpoint: endpoint,
             headers: headers,
@@ -132,30 +139,25 @@ struct SchemaLoader {
             urlSession: urlSession
         ).run()
         let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
-        var schemaString: String?
-        if configuration.validation {
-            let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
-            let schemaJSONData = try JSONSerialization.data(withJSONObject: obj["data"] as Any)
-            schemaString = String(data: schemaJSONData, encoding: .utf8)!
+        guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let schemaObject = response["data"] else {
+            throw Codegen.Error(description: "The introspection endpoint returned an invalid GraphQL response.")
         }
-        return (schemaString, __schema)
+        let schemaJSON = try JSONSerialization.data(withJSONObject: schemaObject)
+        return (try decodeUTF8(schemaJSON, source: endpoint), __schema)
     }
 
-    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (String?, __Schema) {
+    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (String, __Schema) {
         let data = try Data(contentsOf: schemaFile)
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: data).__schema
-        var schemaString: String?
-        if configuration.validation {
-            schemaString = String(data: data, encoding: .utf8)!
-        }
-        return (schemaString, __schema)
+        return (try decodeUTF8(data, source: schemaFile), __schema)
     }
 
     private func loadSchemaFromSDLFile(
         _ schemaFile: URL,
         includeDeprecatedFields: Bool,
         includeDeprecatedEnumValues: Bool
-    ) throws -> (String?, __Schema) {
+    ) throws -> (String, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
         let introspectionQuery = IntrospectionQuery(
             includeDeprecatedFields: includeDeprecatedFields,
@@ -166,6 +168,13 @@ struct SchemaLoader {
             introspectionQuery: introspectionQuery
         )
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: jsonSchema.data).__schema
-        return (configuration.validation ? jsonSchema.text : nil, __schema)
+        return (jsonSchema.text, __schema)
+    }
+
+    private func decodeUTF8(_ data: Data, source: URL) throws -> String {
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw Codegen.Error(description: "Schema source is not valid UTF-8: \(source)")
+        }
+        return string
     }
 }

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -1,8 +1,13 @@
 import Foundation
 
 struct LoadedSchema {
+    enum Validation {
+        case disabled
+        case enabled(String)
+    }
+
     let schema: Schema
-    let validationJSON: String
+    let validation: Validation
 }
 
 // Type names are guaranteed to be unique
@@ -84,7 +89,7 @@ struct SchemaLoader {
     let urlSession: URLSession
 
     func load() async throws -> LoadedSchema {
-        let (validationJSON, typedSchema) = try await loadIntrospection()
+        let (validation, typedSchema) = try await loadIntrospection()
         return LoadedSchema(
             schema: Schema(
                 queryTypeRef: typedSchema.queryType,
@@ -92,11 +97,11 @@ struct SchemaLoader {
                 subscriptionTypeRef: typedSchema.subscriptionType,
                 typeCache: TypeCache(TypeASTCache(typedSchema))
             ),
-            validationJSON: validationJSON
+            validation: validation
         )
     }
 
-    private func loadIntrospection() async throws -> (String, __Schema) {
+    private func loadIntrospection() async throws -> (LoadedSchema.Validation, __Schema) {
         switch configuration.input.schemaSource {
         case .introspectionEndpoint(
             let endpoint,
@@ -130,7 +135,7 @@ struct SchemaLoader {
         headers: [String: String],
         includeDeprecatedFields: Bool = false,
         includeDeprecatedEnumValues: Bool = false
-    ) async throws -> (String, __Schema) {
+    ) async throws -> (LoadedSchema.Validation, __Schema) {
         let data = try await IntrospectionRunner(
             endpoint: endpoint,
             headers: headers,
@@ -139,25 +144,27 @@ struct SchemaLoader {
             urlSession: urlSession
         ).run()
         let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
+        guard configuration.validation else { return (.disabled, __schema) }
         guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let schemaObject = response["data"] else {
             throw Codegen.Error(description: "The introspection endpoint returned an invalid GraphQL response.")
         }
         let schemaJSON = try JSONSerialization.data(withJSONObject: schemaObject)
-        return (try decodeUTF8(schemaJSON, source: endpoint), __schema)
+        return (.enabled(try decodeUTF8(schemaJSON, source: endpoint)), __schema)
     }
 
-    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (String, __Schema) {
+    private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> (LoadedSchema.Validation, __Schema) {
         let data = try Data(contentsOf: schemaFile)
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: data).__schema
-        return (try decodeUTF8(data, source: schemaFile), __schema)
+        guard configuration.validation else { return (.disabled, __schema) }
+        return (.enabled(try decodeUTF8(data, source: schemaFile)), __schema)
     }
 
     private func loadSchemaFromSDLFile(
         _ schemaFile: URL,
         includeDeprecatedFields: Bool,
         includeDeprecatedEnumValues: Bool
-    ) throws -> (String, __Schema) {
+    ) throws -> (LoadedSchema.Validation, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
         let introspectionQuery = IntrospectionQuery(
             includeDeprecatedFields: includeDeprecatedFields,
@@ -168,7 +175,8 @@ struct SchemaLoader {
             introspectionQuery: introspectionQuery
         )
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: jsonSchema.data).__schema
-        return (jsonSchema.text, __schema)
+        guard configuration.validation else { return (.disabled, __schema) }
+        return (.enabled(jsonSchema.text), __schema)
     }
 
     private func decodeUTF8(_ data: Data, source: URL) throws -> String {

--- a/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
@@ -15,11 +15,11 @@ struct AnyEncodableWriter {
         \(header)\(accessLevel)struct AnyEncodable: Encodable, Sendable {
             private let encoder: @Sendable (Encoder) throws -> Void
             \(accessLevel)init<T: Encodable & Sendable>(_ value: T) {
-                self.encoder = value.encode(to:)
+                self.encoder = { encoder in try value.encode(to: encoder) }
             }
             \(accessLevel)init?<T: Encodable & Sendable>(_ value: T?) {
                 guard let value else { return nil }
-                self.encoder = value.encode(to:)
+                self.encoder = { encoder in try value.encode(to: encoder) }
             }
             \(accessLevel)func encode(to encoder: Encoder) throws {
                 try self.encoder(encoder)

--- a/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
@@ -38,7 +38,7 @@ struct GraphQLResponseWriter {
                 let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
                 let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
                 if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-                    guard errors == nil || !errors!.isEmpty else {
+                    guard errors?.isEmpty != true else {
                         throw DecodingError.dataCorruptedError(
                             forKey: .errors,
                             in: container,

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -108,9 +108,9 @@ struct OperationBuilder {
         case .registered: break
         case .automatic, .none:
             let expandedSourceText = try OperationTextResolver(
-                operation: operation.ast,
-                sourceText: operation.sourceText,
-                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment)
+                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment),
+                operationAST: operation.ast,
+                operationSourceText: operation.sourceText
             ).expandSourceText { fragment in "\\(\(fragment.ast.name.value.capitalizedFirst).source)" }
             operationStruct.addProperty(
                 description: nil,
@@ -130,7 +130,7 @@ struct OperationBuilder {
                 name: "minifiedDocument",
                 value: .assigned(
                     SwiftSource(
-                        value: operation.resolvedText
+                        value: operation.canonicalText
                     ).multilineStringLiteral,
                     type: nil
                 )
@@ -139,7 +139,7 @@ struct OperationBuilder {
     }
 
     private mutating func addHashProperty() {
-        if let hash = operation.hash {
+        if case .registered = configuration.output.documents.operations.persistedOperations {
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -147,7 +147,7 @@ struct OperationBuilder {
                 isStatic: true,
                 immutable: true,
                 name: "hash",
-                value: .assigned("\"\(hash)\"", type: nil)
+                value: .assigned("\"\(operation.hash)\"", type: nil)
             )
         }
     }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -139,7 +139,7 @@ struct OperationBuilder {
     }
 
     private mutating func addHashProperty() {
-        if case .registered = configuration.output.documents.operations.persistedOperations {
+        if case .registered(let hash) = operation.persistence {
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -147,7 +147,7 @@ struct OperationBuilder {
                 isStatic: true,
                 immutable: true,
                 name: "hash",
-                value: .assigned("\"\(operation.hash)\"", type: nil)
+                value: .assigned("\"\(hash)\"", type: nil)
             )
         }
     }

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -10,9 +10,10 @@ struct PersistedOperationManifestWriter {
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
+                    guard case .registered(let hash) = operation.persistence else { continue }
                     operations.append(
                         PersistedOperationManifest.Operation(
-                            id: operation.hash,
+                            id: hash,
                             body: operation.canonicalText,
                             name: operation.ast.name?.value,
                             type: operation.ast.operation.rawValue

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -12,8 +12,8 @@ struct PersistedOperationManifestWriter {
                 case .operation(let operation):
                     operations.append(
                         PersistedOperationManifest.Operation(
-                            id: operation.hash!,
-                            body: operation.resolvedText,
+                            id: operation.hash,
+                            body: operation.canonicalText,
                             name: operation.ast.name?.value,
                             type: operation.ast.operation.rawValue
                         )

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
@@ -92,9 +92,11 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
     }
 
     func build(configuration: Configuration) -> [String] {
-        precondition(started)
+        guard let declaration else {
+            preconditionFailure("A Swift type must be started before it can be built")
+        }
         let indentation = configuration.output.indentation.string
-        var lines = declaration!
+        var lines = declaration
         lines.append(contentsOf: contents.map { $0.isWhiteSpace ? "" : indentation + $0 })
         lines.append(contentsOf: buildInitializers(indentation: indentation))
         for nested in nestedTypes {

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -8,7 +8,7 @@ struct DocumentsResolver {
         let usedFragments = try usedFragments()
         let resolvedFragments = try resolveFragments(usedFragments)
         let resolvedDocuments = try resolveDocuments(documents)
-        let fulfilledFragments = fulfilledFragments(
+        let fulfilledFragments = try fulfilledFragments(
             resolvedFragments: resolvedFragments,
             resolvedDocuments: resolvedDocuments
         )
@@ -62,8 +62,7 @@ struct DocumentsResolver {
         _ usedFragments: [String: Document.Fragment]
     ) throws -> [String: ResolvedFragment] {
         var resolvedFragments: [String: ResolvedFragment] = [:]
-        for name in usedFragments.keys.sorted() {
-            let fragment = usedFragments[name]!
+        for (name, fragment) in usedFragments.sorted(by: { $0.key < $1.key }) {
             let selectionSet = try SelectionSetResolver(
                 onType: try schema.fragmentType(fragment.ast),
                 selectionSet: fragment.ast.selectionSet,
@@ -112,7 +111,7 @@ struct DocumentsResolver {
     private func fulfilledFragments(
         resolvedFragments: [String: ResolvedFragment],
         resolvedDocuments: [ResolvedDocument]
-    ) -> Set<String> {
+    ) throws -> Set<String> {
         var fulfilledFragments: Set<String> = []
         var selectionSets: [ResolvedSelectionSet] = resolvedFragments.values.map(\.resolvedSelectionSet)
         for resolvedDocument in resolvedDocuments {
@@ -134,7 +133,9 @@ struct DocumentsResolver {
                 case .fragmentSpread(let name, _):
                     let result = fulfilledFragments.insert(name)
                     if result.inserted {
-                        let fragment = resolvedFragments[name]!
+                        guard let fragment = resolvedFragments[name] else {
+                            throw Codegen.Error(description: "Resolved fragment is missing: \(name)")
+                        }
                         selectionSets.append(fragment.resolvedSelectionSet)
                     }
                 }
@@ -154,7 +155,7 @@ struct DocumentsResolver {
                 switch definition {
                 case .operation(let resolvedOperation):
                     usedTypes.formUnion(
-                        usedScalarTypes(
+                        try usedScalarTypes(
                             resolvedOperation.resolvedSelectionSet,
                             resolvedFragments: resolvedFragments,
                             seenFragmentSpreads: &seenFragmentSpreads
@@ -228,7 +229,7 @@ struct DocumentsResolver {
         _ selectionSet: ResolvedSelectionSet,
         resolvedFragments: [String: ResolvedFragment],
         seenFragmentSpreads: inout Set<String>
-    ) -> Set<String> {
+    ) throws -> Set<String> {
         var usedTypes: Set<String> = []
         var stack: [ResolvedSelectionSet] = [selectionSet]
         while let selectionSet = stack.popLast() {
@@ -237,7 +238,9 @@ struct DocumentsResolver {
                 case .fragmentSpread(let name, _):
                     let result = seenFragmentSpreads.insert(name)
                     if result.inserted {
-                        let resolvedFragment = resolvedFragments[name]!
+                        guard let resolvedFragment = resolvedFragments[name] else {
+                            throw Codegen.Error(description: "Resolved fragment is missing: \(name)")
+                        }
                         stack.append(resolvedFragment.resolvedSelectionSet)
                     }
                 case .field(let field, _):

--- a/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentValidator.swift
@@ -24,10 +24,10 @@ struct DocumentValidator {
 
     let documentText: String
     let graphQLJS: GraphQLJS
-    let schemaJSONString: String
+    let schemaJSON: String
 
     func validate() throws -> [Error] {
-        let errorsJSON = try graphQLJS.validate(documentText, schemaJSON: schemaJSONString)
+        let errorsJSON = try graphQLJS.validate(documentText, schemaJSON: schemaJSON)
         return try JSONDecoder().decode([Error].self, from: errorsJSON)
     }
 }

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -28,21 +28,21 @@ struct DocumentsValidator {
     }
 
     let schema: Schema
+    let schemaJSON: String
     let documents: Documents
     let graphQLJS: GraphQLJS
 
     func validate() throws {
         var documentErrors: [DocumentError] = []
-        let schemaJSONString = schema.jsonString!
         for document in documents.documents {
             var operationErrors: [OperationError] = []
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
                     let errors = try DocumentValidator(
-                        documentText: operation.resolvedText,
+                        documentText: operation.canonicalText,
                         graphQLJS: graphQLJS,
-                        schemaJSONString: schemaJSONString
+                        schemaJSON: schemaJSON
                     ).validate()
                     if !errors.isEmpty {
                         operationErrors.append(

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -27,7 +27,6 @@ struct DocumentsValidator {
         }
     }
 
-    let schema: Schema
     let schemaJSON: String
     let documents: Documents
     let graphQLJS: GraphQLJS

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/AnyEncodable.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/AnyEncodable.swift
@@ -3,11 +3,11 @@
 struct AnyEncodable: Encodable, Sendable {
     private let encoder: @Sendable (Encoder) throws -> Void
     init<T: Encodable & Sendable>(_ value: T) {
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     init?<T: Encodable & Sendable>(_ value: T?) {
         guard let value else { return nil }
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     func encode(to encoder: Encoder) throws {
         try self.encoder(encoder)

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLResponse.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/GraphQLResponse.swift
@@ -26,7 +26,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
         let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
         if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-            guard errors == nil || !errors!.isEmpty else {
+            guard errors?.isEmpty != true else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .errors,
                     in: container,

--- a/Sources/StarwarsExample/API/AnyEncodable.swift
+++ b/Sources/StarwarsExample/API/AnyEncodable.swift
@@ -3,11 +3,11 @@
 struct AnyEncodable: Encodable, Sendable {
     private let encoder: @Sendable (Encoder) throws -> Void
     init<T: Encodable & Sendable>(_ value: T) {
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     init?<T: Encodable & Sendable>(_ value: T?) {
         guard let value else { return nil }
-        self.encoder = value.encode(to:)
+        self.encoder = { encoder in try value.encode(to: encoder) }
     }
     func encode(to encoder: Encoder) throws {
         try self.encoder(encoder)

--- a/Sources/StarwarsExample/API/GraphQLResponse.swift
+++ b/Sources/StarwarsExample/API/GraphQLResponse.swift
@@ -26,7 +26,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
         let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
         if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
-            guard errors == nil || !errors!.isEmpty else {
+            guard errors?.isEmpty != true else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .errors,
                     in: container,


### PR DESCRIPTION
## What changed

Introduce explicit loaded-schema and parsed/prepared-document phases so validation JSON, canonical operation text, and operation hashes are present whenever their models exist. Remaining invariant force unwraps in the touched generation paths are replaced with total conversions or reported errors.

## Why

The previous models encoded lifecycle as correlated optionals. Callers had to remember which configuration flags made each value non-nil, spreading hidden assumptions and force unwraps across validation and output.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`

Stacked on #29.
