### PR TITLE
Embed fragment definitions in operation documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,14 @@ The code generator runs on macOS 14 or newer because it uses JavaScriptCore to e
 
 ---
 
-## Upgrade Note: Generated HTTP Operations
-
-Generated HTTP support now requires `GraphQLOperation.minifiedDocument`. Generated operation documents embed their fragment definitions directly, and generated fragment types no longer expose a `source` property. Regenerate the API and operation files together when upgrading. If your application defines a custom `GraphQLOperation` conformer, add a precomputed `minifiedDocument` that is lexically equivalent to `document` with ignored GraphQL characters removed. This is a source-breaking generated-API change intended for the next minor release.
-
----
-
 ## Table of Contents
 1. [Platform Support](#platform-support)
-2. [Upgrade Note: Generated HTTP Operations](#upgrade-note-generated-http-operations)
-3. [Getting Started](#getting-started)
-4. [Example](#example-output)
-5. [Motivation](#motivation)
-6. [Design](#design)
-7. [Contributing](#contributing)
-8. [License](#license)
+2. [Getting Started](#getting-started)
+3. [Example](#example-output)
+4. [Motivation](#motivation)
+5. [Design](#design)
+6. [Contributing](#contributing)
+7. [License](#license)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The code generator runs on macOS 14 or newer because it uses JavaScriptCore to e
 
 ## Upgrade Note: Generated HTTP Operations
 
-Generated HTTP support now requires `GraphQLOperation.minifiedDocument`. Regenerate the API and operation files together when upgrading. If your application defines a custom `GraphQLOperation` conformer, add a precomputed `minifiedDocument` that is lexically equivalent to `document` with ignored GraphQL characters removed. This is a source-breaking generated-API change intended for the next minor release.
+Generated HTTP support now requires `GraphQLOperation.minifiedDocument`. Generated operation documents embed their fragment definitions directly, and generated fragment types no longer expose a `source` property. Regenerate the API and operation files together when upgrading. If your application defines a custom `GraphQLOperation` conformer, add a precomputed `minifiedDocument` that is lexically equivalent to `document` with ignored GraphQL characters removed. This is a source-breaking generated-API change intended for the next minor release.
 
 ---
 

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
@@ -37,7 +37,6 @@ struct FragmentBuilder {
 
     mutating func buildable() throws -> SwiftTypeBuildable {
         startFragmentStruct()
-        addSourceProperty()
         if isFulfilled {
             try addSelectionSet()
         }
@@ -81,24 +80,5 @@ struct FragmentBuilder {
             structName: fragment.ast.name.value.capitalizedFirst,
             conformances: isFulfilled ? configuration.output.documents.fragments.conformances : []
         )
-    }
-
-    private mutating func addSourceProperty() {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: break
-        case .automatic, .none:
-            fragmentStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "source",
-                value: .assigned(
-                    SwiftSource(value: String(fragment.sourceText)).multilineStringLiteral,
-                    type: nil
-                )
-            )
-        }
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -111,7 +111,7 @@ struct OperationBuilder {
                 fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment),
                 operationAST: operation.ast,
                 operationSourceText: operation.sourceText
-            ).expandSourceText { fragment in "\\(\(fragment.ast.name.value.capitalizedFirst).source)" }
+            ).expandSourceText { $0.sourceText }
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
@@ -12,9 +12,19 @@ struct HeroQuery: GraphQLQuery {
         ...droid
       }
     }
-    \(Jedi.source)
-    \(Droid.source)
-    \(Character.source)
+    fragment jedi on Jedi {
+      ...character
+      lightSaberColor
+    }
+    fragment droid on Droid {
+      ...character
+      primaryFunction
+      operator
+    }
+    fragment character on Character {
+      id
+      name
+    }
     """#
 
     static let minifiedDocument = #"""
@@ -67,13 +77,6 @@ struct HeroQuery: GraphQLQuery {
 
 struct Jedi: Decodable, Sendable, Hashable {
 
-    static let source = #"""
-    fragment jedi on Jedi {
-      ...character
-      lightSaberColor
-    }
-    """#
-
     var __character: Character
 
     var lightSaberColor: String
@@ -89,14 +92,6 @@ struct Jedi: Decodable, Sendable, Hashable {
 }
 
 struct Droid: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment droid on Droid {
-      ...character
-      primaryFunction
-      operator
-    }
-    """#
 
     var __character: Character
 
@@ -117,13 +112,6 @@ struct Droid: Decodable, Sendable, Hashable {
 }
 
 struct Character: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment character on Character {
-      id
-      name
-    }
-    """#
 
     var id: ID
 

--- a/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
+++ b/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
@@ -12,9 +12,19 @@ struct HeroQuery: GraphQLQuery {
         ...droid
       }
     }
-    \(Jedi.source)
-    \(Droid.source)
-    \(Character.source)
+    fragment jedi on Jedi {
+      ...character
+      lightSaberColor
+    }
+    fragment droid on Droid {
+      ...character
+      primaryFunction
+      operator
+    }
+    fragment character on Character {
+      id
+      name
+    }
     """#
 
     static let minifiedDocument = #"""
@@ -67,13 +77,6 @@ struct HeroQuery: GraphQLQuery {
 
 struct Jedi: Decodable, Sendable, Hashable {
 
-    static let source = #"""
-    fragment jedi on Jedi {
-      ...character
-      lightSaberColor
-    }
-    """#
-
     var __character: Character
 
     var lightSaberColor: String
@@ -89,14 +92,6 @@ struct Jedi: Decodable, Sendable, Hashable {
 }
 
 struct Droid: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment droid on Droid {
-      ...character
-      primaryFunction
-      operator
-    }
-    """#
 
     var __character: Character
 
@@ -117,13 +112,6 @@ struct Droid: Decodable, Sendable, Hashable {
 }
 
 struct Character: Decodable, Sendable, Hashable {
-
-    static let source = #"""
-    fragment character on Character {
-      id
-      name
-    }
-    """#
 
     var id: ID
 


### PR DESCRIPTION
## What changed

Embed expanded fragment definitions directly in generated operation documents and remove the generated fragment `source` property.

## Why

The previous operation template placed `\(Fragment.source)` inside a raw Swift string. Raw strings require hash-qualified interpolation, so the generated request sent the interpolation text literally instead of the fragment definition. Direct embedding is simpler and removes cross-file source coupling.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`

Stacked on #30.
