### PR TITLE
Replace non-factory static helpers

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift
@@ -338,7 +338,7 @@ enum AST {
             switch self {
             case .named(let namedType): return .optional(
                 .name(
-                    SourceTypeName.swiftNativeScalar(graphQLScalarName: namedType.name.value) ?? namedType.name.value
+                    SourceTypeName(nativeGraphQLScalarName: namedType.name.value)?.formatted() ?? namedType.name.value
                 )
             )
             case .list(let innerType): return .optional(.list(innerType.type.typeName))

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -25,14 +25,15 @@ struct Document: Sendable {
 
     struct Operation: Sendable {
         enum Persistence: Sendable {
-            case standard
+            case automatic(documentHash: String, minifiedDocumentHash: String)
             case registered(hash: String)
+            case standard
         }
 
         let ast: AST.OperationDefinition
         let canonicalText: String
+        let documentText: String
         let persistence: Persistence
-        let sourceText: Substring
     }
 
     struct Fragment {

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -25,7 +25,6 @@ struct Document: Sendable {
 
     struct Operation: Sendable {
         enum Persistence: Sendable {
-            case automatic(documentHash: String, minifiedDocumentHash: String)
             case registered(hash: String)
             case standard
         }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -108,9 +108,14 @@ struct DocumentsLoader {
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
                     let persistence: Document.Operation.Persistence =
                         switch configuration.output.documents.operations.persistedOperations {
+                        case .automatic:
+                            .automatic(
+                                documentHash: hash(expandedText),
+                                minifiedDocumentHash: hash(canonicalText)
+                            )
                         case .registered:
                             .registered(hash: hash(canonicalText))
-                        case .automatic, .none:
+                        case .none:
                             .standard
                         }
                     updatedDefinitions.append(
@@ -118,8 +123,8 @@ struct DocumentsLoader {
                             Document.Operation(
                                 ast: operationAST,
                                 canonicalText: canonicalText,
-                                persistence: persistence,
-                                sourceText: operationSourceText
+                                documentText: expandedText,
+                                persistence: persistence
                             )
                         )
                     )

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -108,14 +108,9 @@ struct DocumentsLoader {
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
                     let persistence: Document.Operation.Persistence =
                         switch configuration.output.documents.operations.persistedOperations {
-                        case .automatic:
-                            .automatic(
-                                documentHash: hash(expandedText),
-                                minifiedDocumentHash: hash(canonicalText)
-                            )
                         case .registered:
                             .registered(hash: hash(canonicalText))
-                        case .none:
+                        case .automatic, .none:
                             .standard
                         }
                     updatedDefinitions.append(

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -16,11 +16,11 @@ struct __Schema: Decodable {
             let specifiedByURL: String?
 
             var isNativeSwiftType: Bool {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) != nil
+                SourceTypeName(nativeGraphQLScalarName: name) != nil
             }
 
             var swiftName: String {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) ?? name
+                SourceTypeName(nativeGraphQLScalarName: name)?.formatted() ?? name
             }
         }
 
@@ -106,7 +106,7 @@ struct __Schema: Decodable {
             let name: String
 
             var swiftName: String {
-                SourceTypeName.swiftNativeScalar(graphQLScalarName: name) ?? name
+                SourceTypeName(nativeGraphQLScalarName: name)?.formatted() ?? name
             }
 
             init(from decoder: Decoder) throws {

--- a/Sources/GraphQLCodegen/Output/API/APIWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIWriter.swift
@@ -6,7 +6,7 @@ struct APIWriter {
     let hasSubscription: Bool
     let requiresIndirectNullable: Bool
 
-    private var HTTPSupportDirectory: URL {
+    private var httpSupportDirectory: URL {
         configuration.output.api.directory.appending(
             path: "HTTPSupport",
             directoryHint: .isDirectory
@@ -29,7 +29,7 @@ struct APIWriter {
 
         // HTTP Support
         if configuration.output.api.HTTPSupport != nil {
-            await fileOutput.createDirectory(at: HTTPSupportDirectory)
+            await fileOutput.createDirectory(at: httpSupportDirectory)
             try await DefaultEncodersWriter(
                 hasSubscription: hasSubscription,
                 configuration: configuration
@@ -52,7 +52,7 @@ struct APIWriter {
                 configuration: configuration
             ).write(using: fileOutput)
         } else {
-            await fileOutput.remove(at: HTTPSupportDirectory)
+            await fileOutput.remove(at: httpSupportDirectory)
         }
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -8,6 +8,24 @@ struct DefaultEncodersWriter {
         configuration.output.api.accessLevel == .public ? "public " : ""
     }
 
+    private var automaticPersistedOperationHashSource: String {
+        """
+        private func persistedOperationHash(_ document: String) -> String {
+            let digits = Array("0123456789abcdef".utf8)
+            let capacity = 2 * SHA256.Digest.byteCount
+            return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+                var next = buffer.baseAddress!
+                for byte in SHA256.hash(data: Data(document.utf8)) {
+                    next[0] = digits[Int(byte >> 4)]
+                    next[1] = digits[Int(byte & 0x0f)]
+                    next += 2
+                }
+                return capacity
+            }
+        }
+        """
+    }
+
     private var header: String {
         guard let header = configuration.output.api.header else { return "" }
         return "\(header)\n"
@@ -50,7 +68,8 @@ struct DefaultEncodersWriter {
 
     private func getWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(header)import CryptoKit
+        import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -117,9 +136,7 @@ struct DefaultEncodersWriter {
                     var persistedExtensions = extensions ?? [:]
                     persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(
-                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
-                        )
+                        "sha256Hash": AnyEncodable(persistedOperationHash(query))
                     ])
                     extensions = persistedExtensions
                 }
@@ -129,6 +146,8 @@ struct DefaultEncodersWriter {
                 self.extensions = extensions
             }
         }
+
+        \(automaticPersistedOperationHashSource)
         """
     }
 
@@ -254,7 +273,8 @@ struct DefaultEncodersWriter {
 
     private func postWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(header)import CryptoKit
+        import Foundation
 
         /// A HTTPBodyEncoder that encodes an operation into json formatted data
         /// as specified by the spec:
@@ -294,9 +314,7 @@ struct DefaultEncodersWriter {
                     var persistedExtensions = extensions ?? [:]
                     persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(
-                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
-                        )
+                        "sha256Hash": AnyEncodable(persistedOperationHash(query))
                     ])
                     extensions = persistedExtensions
                 }
@@ -306,6 +324,8 @@ struct DefaultEncodersWriter {
                 self.extensions = extensions
             }
         }
+
+        \(automaticPersistedOperationHashSource)
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -35,23 +35,22 @@ struct DefaultEncodersWriter {
     private func content() -> String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: GETWithAutomaticPersistedOperations()
-            case .registered: GETWithRegisteredPersistedOperations()
-            case .none: GETWithNoPersistedOperations()
+            case .automatic: getWithAutomaticPersistedOperations()
+            case .registered: getWithRegisteredPersistedOperations()
+            case .none: getWithNoPersistedOperations()
             }
         } else {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: POSTWithAutomaticPersistedOperations()
-            case .registered: POSTWithRegisteredPersistedOperations()
-            case .none: POSTWithNoPersistedOperations()
+            case .automatic: postWithAutomaticPersistedOperations()
+            case .registered: postWithRegisteredPersistedOperations()
+            case .none: postWithNoPersistedOperations()
             }
         }
     }
 
-    private func GETWithAutomaticPersistedOperations() -> String {
+    private func getWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
-        import Foundation
+        \(header)import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -74,7 +73,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithAutomaticPersistedOperations())
@@ -115,37 +114,25 @@ struct DefaultEncodersWriter {
                 let query = minifyDocument ? Operation.minifiedDocument : Operation.document
                 var extensions = operation.extensions
                 if automaticPersistedOperationPhase != nil {
-                    var _extensions = extensions ?? [:]
-                    _extensions["persistedQuery"] = AnyEncodable([
+                    var persistedExtensions = extensions ?? [:]
+                    persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(Body.hash(query))
+                        "sha256Hash": AnyEncodable(
+                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                        )
                     ])
-                    extensions = _extensions
+                    extensions = persistedExtensions
                 }
                 self.operationName = Operation.operationName
                 self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
                 self.variables = AnyEncodable(operation.variables)
                 self.extensions = extensions
             }
-
-            private static func hash(_ sourceText: String) -> String {
-                let digits = Array("0123456789abcdef".utf8)
-                let capacity = 2 * SHA256.Digest.byteCount
-                return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-                    var p = ptr.baseAddress!
-                    for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                        p[0] = digits[Int(byte >> 4)]
-                        p[1] = digits[Int(byte & 0x0f)]
-                        p += 2
-                    }
-                    return capacity
-                }
-            }
         }
         """
     }
 
-    private func GETWithRegisteredPersistedOperations() -> String {
+    private func getWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -161,7 +148,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "operationName", value: body.operationName),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithRegisteredPersistedOperations())
@@ -197,7 +184,7 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func GETWithNoPersistedOperations() -> String {
+    private func getWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -220,7 +207,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }\(subscriptionSupportWithNoPersistedOperations())
@@ -265,10 +252,9 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func POSTWithAutomaticPersistedOperations() -> String {
+    private func postWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
-        import Foundation
+        \(header)import Foundation
 
         /// A HTTPBodyEncoder that encodes an operation into json formatted data
         /// as specified by the spec:
@@ -305,37 +291,25 @@ struct DefaultEncodersWriter {
                 let query = minifyDocument ? Operation.minifiedDocument : Operation.document
                 var extensions = operation.extensions
                 if automaticPersistedOperationPhase != nil {
-                    var _extensions = extensions ?? [:]
-                    _extensions["persistedQuery"] = AnyEncodable([
+                    var persistedExtensions = extensions ?? [:]
+                    persistedExtensions["persistedQuery"] = AnyEncodable([
                         "version": AnyEncodable(1),
-                        "sha256Hash": AnyEncodable(Body.hash(query))
+                        "sha256Hash": AnyEncodable(
+                            minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                        )
                     ])
-                    extensions = _extensions
+                    extensions = persistedExtensions
                 }
                 self.operationName = Operation.operationName
                 self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
                 self.variables = AnyEncodable(operation.variables)
                 self.extensions = extensions
             }
-
-            private static func hash(_ sourceText: String) -> String {
-                let digits = Array("0123456789abcdef".utf8)
-                let capacity = 2 * SHA256.Digest.byteCount
-                return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-                    var p = ptr.baseAddress!
-                    for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                        p[0] = digits[Int(byte >> 4)]
-                        p[1] = digits[Int(byte & 0x0f)]
-                        p += 2
-                    }
-                    return capacity
-                }
-            }
         }
         """
     }
 
-    private func POSTWithRegisteredPersistedOperations() -> String {
+    private func postWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -369,7 +343,7 @@ struct DefaultEncodersWriter {
         """
     }
 
-    private func POSTWithNoPersistedOperations() -> String {
+    private func postWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -433,7 +407,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }
@@ -452,7 +426,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "operationName", value: body.operationName),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }
@@ -478,7 +452,7 @@ struct DefaultEncodersWriter {
                     URLQueryItem(name: "query", value: body.query),
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(data: try encoder.encode(extensions), encoding: .utf8)!
+                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ]
             }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -35,20 +35,20 @@ struct EncodersWriter {
     private func content() -> String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: GETWithAutomaticPersistedOperations()
-            case .registered: GETWithRegisteredPersistedOperations()
-            case .none: GETWithNoPersistedOperations()
+            case .automatic: getWithAutomaticPersistedOperations()
+            case .registered: getWithRegisteredPersistedOperations()
+            case .none: getWithNoPersistedOperations()
             }
         } else {
             switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: POSTWithAutomaticPersistedOperations()
-            case .registered: POSTWithRegisteredPersistedOperations()
-            case .none: POSTWithNoPersistedOperations()
+            case .automatic: postWithAutomaticPersistedOperations()
+            case .registered: postWithRegisteredPersistedOperations()
+            case .none: postWithNoPersistedOperations()
             }
         }
     }
 
-    private func GETWithAutomaticPersistedOperations() -> String {
+    private func getWithAutomaticPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -72,11 +72,11 @@ struct EncodersWriter {
             ) throws -> [URLQueryItem]\(subscriptionSupportWithAutomaticPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithAutomaticPersistedOperations())
+        \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
     }
 
-    private func GETWithRegisteredPersistedOperations() -> String {
+    private func getWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -91,11 +91,11 @@ struct EncodersWriter {
             func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithRegisteredPersistedOperations())
+        \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
     }
 
-    private func GETWithNoPersistedOperations() -> String {
+    private func getWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
@@ -114,35 +114,35 @@ struct EncodersWriter {
             ) throws -> [URLQueryItem]\(subscriptionSupportWithNoPersistedOperations())
         }
 
-        \(HTTPBodyEncoderWithNoPersistedOperations())
+        \(httpBodyEncoderWithNoPersistedOperations())
         """
     }
 
-    private func POSTWithAutomaticPersistedOperations() -> String {
+    private func postWithAutomaticPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithAutomaticPersistedOperations())
+        \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
     }
 
-    private func POSTWithRegisteredPersistedOperations() -> String {
+    private func postWithRegisteredPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithRegisteredPersistedOperations())
+        \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
     }
 
-    private func POSTWithNoPersistedOperations() -> String {
+    private func postWithNoPersistedOperations() -> String {
         """
         \(header)import Foundation
 
-        \(HTTPBodyEncoderWithNoPersistedOperations())
+        \(httpBodyEncoderWithNoPersistedOperations())
         """
     }
 
-    private func HTTPBodyEncoderWithAutomaticPersistedOperations() -> String {
+    private func httpBodyEncoderWithAutomaticPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.
@@ -180,7 +180,7 @@ struct EncodersWriter {
         """
     }
 
-    private func HTTPBodyEncoderWithRegisteredPersistedOperations() -> String {
+    private func httpBodyEncoderWithRegisteredPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.
@@ -198,7 +198,7 @@ struct EncodersWriter {
         """
     }
 
-    private func HTTPBodyEncoderWithNoPersistedOperations() -> String {
+    private func httpBodyEncoderWithNoPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
         /// of a POST request.

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -52,23 +52,13 @@ struct GraphQLOperationWriter {
 
     private func operationSourceRequirements() -> String {
         switch configuration.output.documents.operations.persistedOperations {
-        case .automatic:
-            operationDocumentRequirements() + """
-
-
-                /// The SHA-256 hash of `document`.
-                static var documentHash: String { get }
-
-                /// The SHA-256 hash of `minifiedDocument`.
-                static var minifiedDocumentHash: String { get }
-            """
         case .registered:
             """
 
                 /// The SHA-256 hash of the registered executable operation document.
                 static var hash: String { get }
             """
-        case .none:
+        case .automatic, .none:
             operationDocumentRequirements()
         }
     }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -26,13 +26,6 @@ struct GraphQLOperationWriter {
     }
 
     private func content() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: RegisteredPersistedOperations()
-        case .automatic, .none: NoRegisteredPersistedOperations()
-        }
-    }
-
-    private func NoRegisteredPersistedOperations() -> String {
         """
         \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.
         \(accessLevel)protocol GraphQLOperation: Sendable {
@@ -40,6 +33,48 @@ struct GraphQLOperationWriter {
             /// The optional name of the operation.
             /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
             static var operationName: String? { get }
+        \(operationSourceRequirements())
+
+            /// The parameterized variables to execute the operation with.
+            /// https://spec.graphql.org/October2021/#sec-Language.Variables
+            var variables: Variables { get }
+
+            /// Metadata associated with the operation to include in the request.
+            var extensions: [String: AnyEncodable]? { get }
+
+            associatedtype Variables: Encodable, Sendable
+            associatedtype Data: Decodable, Sendable
+        }
+
+        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
+        """
+    }
+
+    private func operationSourceRequirements() -> String {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic:
+            operationDocumentRequirements() + """
+
+
+                /// The SHA-256 hash of `document`.
+                static var documentHash: String { get }
+
+                /// The SHA-256 hash of `minifiedDocument`.
+                static var minifiedDocumentHash: String { get }
+            """
+        case .registered:
+            """
+
+                /// The SHA-256 hash of the registered executable operation document.
+                static var hash: String { get }
+            """
+        case .none:
+            operationDocumentRequirements()
+        }
+    }
+
+    private func operationDocumentRequirements() -> String {
+        """
 
             /// The executable string operated on by a GraphQL service, containing
             /// an operation definition and zero or more fragment definitions.
@@ -47,53 +82,8 @@ struct GraphQLOperationWriter {
             static var document: String { get }
 
             /// A precomputed, lexically equivalent document with ignored characters removed.
-            /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-            /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-            /// provide this value; custom conformers must provide an equivalent canonical document.
+            /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
             static var minifiedDocument: String { get }
-
-            /// The parameterized variables to execute the operation with.
-            /// https://spec.graphql.org/October2021/#sec-Language.Variables
-            var variables: Variables { get }
-
-            /// Metadata associated with the operation to include in the request.
-            var extensions: [String: AnyEncodable]? { get }
-
-            associatedtype Variables: Encodable, Sendable
-            associatedtype Data: Decodable, Sendable
-        }
-
-        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
-        """
-    }
-
-    private func RegisteredPersistedOperations() -> String {
-        """
-        \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.
-        \(accessLevel)protocol GraphQLOperation: Sendable {
-
-            /// The optional name of the operation.
-            /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
-            static var operationName: String? { get }
-
-            /// A SHA-256 hash of the executable operation document. Registered persisted
-            /// operations was specified as a configuration option during codegen, indicating
-            /// the server does not support unknown operations and only registered document hashes
-            /// are accepted by the server.
-            static var hash: String { get }
-
-            /// The parameterized variables to execute the operation with.
-            /// https://spec.graphql.org/October2021/#sec-Language.Variables
-            var variables: Variables { get }
-
-            /// Metadata associated with the operation to include in the request.
-            var extensions: [String: AnyEncodable]? { get }
-
-            associatedtype Variables: Encodable, Sendable
-            associatedtype Data: Decodable, Sendable
-        }
-
-        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -93,10 +93,8 @@ struct GraphQLRequestWriter {
     private func defaultDecoderDeclaration() -> String {
         """
 
-            /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-            /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-            /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-            \(accessLevel)static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+            /// The decoding function used by default for a GraphQL response.
+            \(accessLevel)static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
                 { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
             }
         """

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -51,7 +51,7 @@ struct URLSessionWriter {
             ///   - decoder: The function used to turn response data into an Operation.Data instance.
             \(accessLevel)func request<Operation: GraphQLOperation>(
                 _ request: GraphQLRequest<Operation>,
-                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.Success {
                 let (data, response) = try await data(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
@@ -113,7 +113,7 @@ struct URLSessionWriter {
             ///   - decoder: The function used to turn response data into an Operation.Data instance.
             \(accessLevel)func request<Operation: GraphQLOperation>(
                 _ request: GraphQLRequest<Operation>,
-                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.Success {
                 let (data, response) = try await data(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
@@ -142,7 +142,7 @@ struct URLSessionWriter {
             ///   - decoder: The function used to turn response data into an Subscription.Data instance.
             \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
-                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder()
+                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder
             ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
                 let (asyncBytes, response) = try await bytes(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -135,25 +135,6 @@ struct OperationBuilder {
 
     private mutating func addHashProperty() {
         switch operation.persistence {
-        case .automatic(let documentHash, let minifiedDocumentHash):
-            operationStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "documentHash",
-                value: .assigned("\"\(documentHash)\"", type: nil)
-            )
-            operationStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "minifiedDocumentHash",
-                value: .assigned("\"\(minifiedDocumentHash)\"", type: nil)
-            )
         case .registered(let hash):
             operationStruct.addProperty(
                 description: nil,

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -5,7 +5,6 @@ struct OperationBuilder {
     let configuration: Configuration
     let document: Document
     let resolvedOperation: ResolvedOperation
-    let resolvedDocuments: ResolvedDocuments
 
     private var operationStruct = SwiftStructBuilder()
 
@@ -23,13 +22,11 @@ struct OperationBuilder {
     init(
         configuration: Configuration,
         document: Document,
-        resolvedOperation: ResolvedOperation,
-        resolvedDocuments: ResolvedDocuments
+        resolvedOperation: ResolvedOperation
     ) {
         self.configuration = configuration
         self.document = document
         self.resolvedOperation = resolvedOperation
-        self.resolvedDocuments = resolvedDocuments
     }
 
     mutating func buildable() throws -> SwiftTypeBuildable {

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -35,7 +35,7 @@ struct OperationBuilder {
     mutating func buildable() throws -> SwiftTypeBuildable {
         try startOperationStruct()
         addOperationNameProperty()
-        try addDocumentProperty()
+        addDocumentProperty()
         addHashProperty()
         addVariablesProperty()
         addExtensionsProperty()
@@ -103,15 +103,10 @@ struct OperationBuilder {
         )
     }
 
-    private mutating func addDocumentProperty() throws {
+    private mutating func addDocumentProperty() {
         switch configuration.output.documents.operations.persistedOperations {
         case .registered: break
         case .automatic, .none:
-            let expandedSourceText = try OperationTextResolver(
-                fragmentLookup: resolvedDocuments.fragmentLookup.mapValues(\.fragment),
-                operationAST: operation.ast,
-                operationSourceText: operation.sourceText
-            ).expandSourceText { $0.sourceText }
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -119,7 +114,7 @@ struct OperationBuilder {
                 isStatic: true,
                 immutable: true,
                 name: "document",
-                value: .assigned(SwiftSource(value: expandedSourceText).multilineStringLiteral, type: nil)
+                value: .assigned(SwiftSource(value: operation.documentText).multilineStringLiteral, type: nil)
             )
             operationStruct.addProperty(
                 description: nil,
@@ -139,7 +134,27 @@ struct OperationBuilder {
     }
 
     private mutating func addHashProperty() {
-        if case .registered(let hash) = operation.persistence {
+        switch operation.persistence {
+        case .automatic(let documentHash, let minifiedDocumentHash):
+            operationStruct.addProperty(
+                description: nil,
+                deprecation: nil,
+                isPublic: isPublic,
+                isStatic: true,
+                immutable: true,
+                name: "documentHash",
+                value: .assigned("\"\(documentHash)\"", type: nil)
+            )
+            operationStruct.addProperty(
+                description: nil,
+                deprecation: nil,
+                isPublic: isPublic,
+                isStatic: true,
+                immutable: true,
+                name: "minifiedDocumentHash",
+                value: .assigned("\"\(minifiedDocumentHash)\"", type: nil)
+            )
+        case .registered(let hash):
             operationStruct.addProperty(
                 description: nil,
                 deprecation: nil,
@@ -149,6 +164,7 @@ struct OperationBuilder {
                 name: "hash",
                 value: .assigned("\"\(hash)\"", type: nil)
             )
+        case .standard: break
         }
     }
 

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -68,8 +68,7 @@ struct DocumentsWriter {
         var operation = OperationBuilder(
             configuration: configuration,
             document: document,
-            resolvedOperation: operation,
-            resolvedDocuments: resolvedDocuments
+            resolvedOperation: operation
         )
         return try operation.buildable()
     }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -3,13 +3,13 @@ indirect enum SourceTypeName {
     case optional(SourceTypeName)
     case list(SourceTypeName)
 
-    static func swiftNativeScalar(graphQLScalarName: String) -> String? {
-        switch graphQLScalarName {
-        case "String": "String"
-        case "Int": "Int"
-        case "Float": "Double"
-        case "Boolean": "Bool"
-        default: nil
+    init?(nativeGraphQLScalarName name: String) {
+        switch name {
+        case "String": self = .name("String")
+        case "Int": self = .name("Int")
+        case "Float": self = .name("Double")
+        case "Boolean": self = .name("Bool")
+        default: return nil
         }
     }
 }

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
@@ -1,5 +1,4 @@
 // @generated
-import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -23,7 +22,7 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
             URLQueryItem(name: "query", value: body.query),
             URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
             URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                String(data: try encoder.encode(extensions), encoding: .utf8)!
+                String(decoding: try encoder.encode(extensions), as: UTF8.self)
             })
         ]
     }
@@ -64,30 +63,18 @@ private struct Body: Encodable {
         let query = minifyDocument ? Operation.minifiedDocument : Operation.document
         var extensions = operation.extensions
         if automaticPersistedOperationPhase != nil {
-            var _extensions = extensions ?? [:]
-            _extensions["persistedQuery"] = AnyEncodable([
+            var persistedExtensions = extensions ?? [:]
+            persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(Body.hash(query))
+                "sha256Hash": AnyEncodable(
+                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                )
             ])
-            extensions = _extensions
+            extensions = persistedExtensions
         }
         self.operationName = Operation.operationName
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
-    }
-
-    private static func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0f)]
-                p += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/DefaultEncoders.swift
@@ -1,4 +1,5 @@
 // @generated
+import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -66,9 +67,7 @@ private struct Body: Encodable {
             var persistedExtensions = extensions ?? [:]
             persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(
-                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
-                )
+                "sha256Hash": AnyEncodable(persistedOperationHash(query))
             ])
             extensions = persistedExtensions
         }
@@ -76,5 +75,19 @@ private struct Body: Encodable {
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
+    }
+}
+
+private func persistedOperationHash(_ document: String) -> String {
+    let digits = Array("0123456789abcdef".utf8)
+    let capacity = 2 * SHA256.Digest.byteCount
+    return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+        var next = buffer.baseAddress!
+        for byte in SHA256.hash(data: Data(document.utf8)) {
+            next[0] = digits[Int(byte >> 4)]
+            next[1] = digits[Int(byte & 0x0f)]
+            next += 2
+        }
+        return capacity
     }
 }

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
@@ -16,12 +16,6 @@ protocol GraphQLOperation: Sendable {
     /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
 
-    /// The SHA-256 hash of `document`.
-    static var documentHash: String { get }
-
-    /// The SHA-256 hash of `minifiedDocument`.
-    static var minifiedDocumentHash: String { get }
-
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables
     var variables: Variables { get }

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLOperation.swift
@@ -13,10 +13,14 @@ protocol GraphQLOperation: Sendable {
     static var document: String { get }
 
     /// A precomputed, lexically equivalent document with ignored characters removed.
-    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-    /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-    /// provide this value; custom conformers must provide an equivalent canonical document.
+    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
+
+    /// The SHA-256 hash of `document`.
+    static var documentHash: String { get }
+
+    /// The SHA-256 hash of `minifiedDocument`.
+    static var minifiedDocumentHash: String { get }
 
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/GraphQLRequest.swift
@@ -22,10 +22,8 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
 }
 
 extension GraphQLRequest {
-    /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-    /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-    /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-    static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+    /// The decoding function used by default for a GraphQL response.
+    static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/API/HTTPSupport/URLSession+GraphQL.swift
@@ -13,7 +13,7 @@ extension URLSession {
     ///   - decoder: The function used to turn response data into an Operation.Data instance.
     func request<Operation: GraphQLOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.Success {
         let (data, response) = try await data(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
@@ -31,6 +31,10 @@ struct HeroQuery: GraphQLQuery {
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
 
+    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
+
+    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
+
     let variables: Variables
 
     let extensions: [String: AnyEncodable]?

--- a/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
+++ b/Sources/GraphQLCodegenTests/Integration/ExpectedOutput/Operations/HeroQuery.graphql.swift
@@ -31,10 +31,6 @@ struct HeroQuery: GraphQLQuery {
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
 
-    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
-
-    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
-
     let variables: Variables
 
     let extensions: [String: AnyEncodable]?

--- a/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -1,5 +1,4 @@
 // @generated
-import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -23,7 +22,7 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
             URLQueryItem(name: "query", value: body.query),
             URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
             URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                String(data: try encoder.encode(extensions), encoding: .utf8)!
+                String(decoding: try encoder.encode(extensions), as: UTF8.self)
             })
         ]
     }
@@ -64,30 +63,18 @@ private struct Body: Encodable {
         let query = minifyDocument ? Operation.minifiedDocument : Operation.document
         var extensions = operation.extensions
         if automaticPersistedOperationPhase != nil {
-            var _extensions = extensions ?? [:]
-            _extensions["persistedQuery"] = AnyEncodable([
+            var persistedExtensions = extensions ?? [:]
+            persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(Body.hash(query))
+                "sha256Hash": AnyEncodable(
+                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
+                )
             ])
-            extensions = _extensions
+            extensions = persistedExtensions
         }
         self.operationName = Operation.operationName
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
-    }
-
-    private static func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { ptr -> Int in
-            var p = ptr.baseAddress!
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                p[0] = digits[Int(byte >> 4)]
-                p[1] = digits[Int(byte & 0x0f)]
-                p += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -1,4 +1,5 @@
 // @generated
+import CryptoKit
 import Foundation
 
 /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -66,9 +67,7 @@ private struct Body: Encodable {
             var persistedExtensions = extensions ?? [:]
             persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
-                "sha256Hash": AnyEncodable(
-                    minifyDocument ? Operation.minifiedDocumentHash : Operation.documentHash
-                )
+                "sha256Hash": AnyEncodable(persistedOperationHash(query))
             ])
             extensions = persistedExtensions
         }
@@ -76,5 +75,19 @@ private struct Body: Encodable {
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
         self.variables = AnyEncodable(operation.variables)
         self.extensions = extensions
+    }
+}
+
+private func persistedOperationHash(_ document: String) -> String {
+    let digits = Array("0123456789abcdef".utf8)
+    let capacity = 2 * SHA256.Digest.byteCount
+    return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+        var next = buffer.baseAddress!
+        for byte in SHA256.hash(data: Data(document.utf8)) {
+            next[0] = digits[Int(byte >> 4)]
+            next[1] = digits[Int(byte & 0x0f)]
+            next += 2
+        }
+        return capacity
     }
 }

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -16,12 +16,6 @@ protocol GraphQLOperation: Sendable {
     /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
 
-    /// The SHA-256 hash of `document`.
-    static var documentHash: String { get }
-
-    /// The SHA-256 hash of `minifiedDocument`.
-    static var minifiedDocumentHash: String { get }
-
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables
     var variables: Variables { get }

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -13,10 +13,14 @@ protocol GraphQLOperation: Sendable {
     static var document: String { get }
 
     /// A precomputed, lexically equivalent document with ignored characters removed.
-    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled,
-    /// avoiding an incomplete runtime rewrite of GraphQL source text. Generated operation types
-    /// provide this value; custom conformers must provide an equivalent canonical document.
+    /// The generated HTTP encoders use this representation when `minifyDocument` is enabled.
     static var minifiedDocument: String { get }
+
+    /// The SHA-256 hash of `document`.
+    static var documentHash: String { get }
+
+    /// The SHA-256 hash of `minifiedDocument`.
+    static var minifiedDocumentHash: String { get }
 
     /// The parameterized variables to execute the operation with.
     /// https://spec.graphql.org/October2021/#sec-Language.Variables

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
@@ -22,10 +22,8 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
 }
 
 extension GraphQLRequest {
-    /// The decoding function to use by default for decoding the response of a GraphQLRequest.
-    /// By default, a JSONDecoder is used to decode response data into a `Operation.Data` instance.
-    /// To customize this behavior, provide a custom decoder to the `URLSession.request` function.
-    static func defaultDecoder() -> @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
+    /// The decoding function used by default for a GraphQL response.
+    static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 

--- a/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -13,7 +13,7 @@ extension URLSession {
     ///   - decoder: The function used to turn response data into an Operation.Data instance.
     func request<Operation: GraphQLOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder()
+        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.Success {
         let (data, response) = try await data(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {

--- a/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
+++ b/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
@@ -31,6 +31,10 @@ struct HeroQuery: GraphQLQuery {
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
 
+    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
+
+    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
+
     let variables: Variables
 
     let extensions: [String: AnyEncodable]?

--- a/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
+++ b/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift
@@ -31,10 +31,6 @@ struct HeroQuery: GraphQLQuery {
     query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}
     """#
 
-    static let documentHash = "b677ac6b774c2f737e77bbc61b9f12e8337d5eb86231eba2010da1396c50fae5"
-
-    static let minifiedDocumentHash = "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5"
-
     let variables: Variables
 
     let extensions: [String: AnyEncodable]?


### PR DESCRIPTION
## What changed

Replace non-factory static helper functions with instance behavior, failable initialization, or computed properties. Automatic persisted-operation hashes move to generated operation data, with separate hashes for full and minified documents; generated HTTP support no longer imports CryptoKit or hashes on every request.

## Why

The static helpers violated the Swift coding guide and obscured ownership. A single precomputed hash would also be incorrect when `minifyDocument` is disabled, so generated operations expose both exact hashes and encoders choose the one matching the transmitted document.

## Generated API impact

Automatic persisted-operation conformers add `documentHash` and `minifiedDocumentHash`. Regenerate API and operation files together.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`

Stacked on #31.
