### PR TITLE
Omit absent query parameter from GET requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
         .testTarget(
             name: "GraphQLCodegenTests",
             dependencies: [
-                .target(name: "GraphQLCodegen")
+                .target(name: "GraphQLCodegen"),
+                .target(name: "StarwarsExample"),
             ],
             exclude: [
                 "Fixtures/Defaults/Definitions",

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -89,12 +89,12 @@ struct DefaultEncodersWriter {
                 let encoder = JSONEncoder()
                 return [
                     URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "query", value: body.query),
+                    body.query.map { URLQueryItem(name: "query", value: $0) },
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
                         String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
-                ]
+                ].compactMap { $0 }
             }\(subscriptionSupportWithAutomaticPersistedOperations())
         }
 
@@ -148,12 +148,12 @@ struct DefaultEncodersWriter {
                 let encoder = JSONEncoder()
                 return [
                     URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "query", value: body.query),
+                    body.query.map { URLQueryItem(name: "query", value: $0) },
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
                         String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
-                ]
+                ].compactMap { $0 }
             }\(subscriptionSupportWithNoPersistedOperations())
         }
 
@@ -332,12 +332,12 @@ struct DefaultEncodersWriter {
                 let encoder = JSONEncoder()
                 return [
                     URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "query", value: body.query),
+                    body.query.map { URLQueryItem(name: "query", value: $0) },
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
                         String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
-                ]
+                ].compactMap { $0 }
             }
         """
     }
@@ -377,12 +377,12 @@ struct DefaultEncodersWriter {
                 let encoder = JSONEncoder()
                 return [
                     URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "query", value: body.query),
+                    body.query.map { URLQueryItem(name: "query", value: $0) },
                     URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
                     URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
                         String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
-                ]
+                ].compactMap { $0 }
             }
         """
     }

--- a/Sources/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+@testable import StarwarsExample
+import Testing
+
+struct DefaultURLQueryEncoderTests {
+    @Test
+    func omitsDocumentFromPersistedQuery() throws {
+        let queryItems = try DefaultURLQueryEncoder().encode(
+            query: CurrentUserQuery(),
+            automaticPersistedOperations: true,
+            minifyDocument: true
+        )
+
+        #expect(queryItems.map(\.name) == ["operationName", "variables", "extensions"])
+    }
+
+    @Test
+    func includesDocumentInStandardQuery() throws {
+        let queryItems = try DefaultURLQueryEncoder().encode(
+            query: CurrentUserQuery(),
+            automaticPersistedOperations: false,
+            minifyDocument: true
+        )
+
+        #expect(queryItems.map(\.name) == ["operationName", "query", "variables", "extensions"])
+    }
+
+    private struct CurrentUserQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = "CurrentUser"
+        static let document = "query CurrentUser { viewer { id } }"
+        static let minifiedDocument = "query CurrentUser{viewer{id}}"
+
+        let variables: Never? = nil
+        let extensions: [String: StarwarsExample.AnyEncodable]? = nil
+    }
+}

--- a/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -20,12 +20,12 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
         let encoder = JSONEncoder()
         return [
             URLQueryItem(name: "operationName", value: body.operationName),
-            URLQueryItem(name: "query", value: body.query),
+            body.query.map { URLQueryItem(name: "query", value: $0) },
             URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
             URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
                 String(decoding: try encoder.encode(extensions), as: UTF8.self)
             })
-        ]
+        ].compactMap { $0 }
     }
 }
 


### PR DESCRIPTION
## Summary
- omit `query` from generated GET URL query items when the operation document is intentionally absent
- preserve the existing GET encoding of `operationName`, `variables`, and `extensions`
- add generated-API regression coverage for persisted and standard GET requests

## Why
Automatic persisted query requests intentionally omit the operation document on their initial request. Constructing `URLQueryItem(name: "query", value: nil)` serializes as a bare `query` parameter, which can be interpreted as an empty document rather than an absent document.

## Impact
Persisted GET requests no longer contain a bare `query` parameter. Standard GET requests continue to include the document. Variables and the other URL parameters retain their prior behavior, keeping this fix deliberately narrow.

## Root cause
The generated GET encoder always created a `query` item even when the request body's optional document was `nil`.

## Validation
- `swift run StarwarsExample`
- `swift test` (6 tests)
- `swift build -c release`
- `swiftlint lint --strict`
- `git diff --check`
