### PR TITLE
Make persisted operation retry policy explicit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,9 @@ let package = Package(
                 .target(name: "GraphQLCodegen"),
             ],
             exclude: [
+                "Operations/FavoriteEpisodeChangedSubscription.graphql",
                 "Operations/HeroQuery.graphql",
+                "Operations/SetFavoriteEpisodeMutation.graphql",
                 "schema.sdl",
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 - [x] Swift concurrency support via Sendable conformance
 - [x] Persisted operations support
 - [x] Optional URLSession support, including support for query operations using GET and subscriptions using server-sent events
+- [ ] TODO: Automatic persisted-operation fallback for subscriptions; currently unsupported
 - [x] Schema can come from SDL, JSON or an introspection endpoint
 - [x] Control over public/internal access level
 - [x] Control over mutable or immutable types

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -76,14 +76,14 @@ struct DefaultEncodersWriter {
         /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
             \(accessLevel)init() {}
-            \(accessLevel)func encode<Query: GraphQLQuery>(
-                query: Query,
-                automaticPersistedOperations: Bool,
+            \(accessLevel)func encode<Operation: GraphQLOperation>(
+                operation: Operation,
+                automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
                 minifyDocument: Bool
             ) throws -> [URLQueryItem] {
                 let body = Body(
-                    operation: query,
-                    automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
+                    operation: operation,
+                    automaticPersistedOperationPhase: automaticPersistedOperationPhase,
                     minifyDocument: minifyDocument
                 )
                 let encoder = JSONEncoder()
@@ -95,7 +95,7 @@ struct DefaultEncodersWriter {
                         String(decoding: try encoder.encode(extensions), as: UTF8.self)
                     })
                 ].compactMap { $0 }
-            }\(subscriptionSupportWithAutomaticPersistedOperations())
+            }
         }
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
@@ -311,34 +311,6 @@ struct DefaultEncodersWriter {
             }
 
         }
-        """
-    }
-
-    private func subscriptionSupportWithAutomaticPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
-        return """
-
-
-            \(accessLevel)func encode<Subscription: GraphQLSubscription>(
-                subscription: Subscription,
-                automaticPersistedOperations: Bool,
-                minifyDocument: Bool
-            ) throws -> [URLQueryItem] {
-                let body = Body(
-                    operation: subscription,
-                    automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
-                    minifyDocument: minifyDocument
-                )
-                let encoder = JSONEncoder()
-                return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
-                    body.query.map { URLQueryItem(name: "query", value: $0) },
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
-                ].compactMap { $0 }
-            }
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -52,24 +52,22 @@ struct EncodersWriter {
         """
         \(header)import Foundation
 
-        /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
-        /// is being used.
+        /// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
         \(accessLevel)protocol URLQueryEncoder {
 
-            /// Encodes a query operation for a GET request.
+            /// Encodes an operation for a GET request.
             /// - Parameters:
-            ///   query: The query operation to encode.
-            ///   automaticPersistedOperations: Pass `true` if automatic persisted operations is enabled.
-            ///   When automatic persisted operations is enabled, implementations should encode the document's
-            ///   hash, rather than the full document text. Note: Only the initial request uses GET. When the
-            ///   persisted operation is not found by the server, the subsequent request is sent as a POST.
+            ///   operation: The operation to encode.
+            ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
+            ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
+            ///   should always be sent.
             ///   minifyDocument: Pass `true` if the document should remove unnecessary whitespace.
             /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Query: GraphQLQuery>(
-                query: Query,
-                automaticPersistedOperations: Bool,
+            func encode<Operation: GraphQLOperation>(
+                operation: Operation,
+                automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
                 minifyDocument: Bool
-            ) throws -> [URLQueryItem]\(subscriptionSupportWithAutomaticPersistedOperations())
+            ) throws -> [URLQueryItem]
         }
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
@@ -217,28 +215,6 @@ struct EncodersWriter {
                 minifyDocument: Bool
             ) throws -> Data
         }
-        """
-    }
-
-    private func subscriptionSupportWithAutomaticPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
-        return """
-
-
-            /// Encodes a subscription operation for a GET request.
-            /// - Parameters:
-            ///   subscription: The subscription operation to encode.
-            ///   automaticPersistedOperations: Pass `true` if automatic persisted operations is enabled.
-            ///   When automatic persisted operations is enabled, implementations should encode the document's
-            ///   hash, rather than the full document text. Note: Only the initial request uses GET. When the
-            ///   persisted operation is not found by the server, the subsequent request is sent as a POST.
-            ///   minifyDocument: Pass `true` if the document should remove unnecessary whitespace.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Subscription: GraphQLSubscription>(
-                subscription: Subscription,
-                automaticPersistedOperations: Bool,
-                minifyDocument: Bool
-            ) throws -> [URLQueryItem]
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -46,7 +46,11 @@ struct GraphQLOperationWriter {
             associatedtype Data: Decodable, Sendable
         }
 
-        \(accessLevel)protocol GraphQLQuery: GraphQLOperation {}\(mutationProtocol())\(subscriptionProtocol())
+        /// A `GraphQLSingleResponseOperation` produces one response and can be executed with `URLSession.request`.
+        /// Queries and mutations have this capability; subscriptions produce a stream instead.
+        \(accessLevel)protocol GraphQLSingleResponseOperation: GraphQLOperation {}
+
+        \(accessLevel)protocol GraphQLQuery: GraphQLSingleResponseOperation {}\(mutationProtocol())\(subscriptionProtocol())
         """
     }
 
@@ -82,7 +86,7 @@ struct GraphQLOperationWriter {
         return """
 
 
-        \(accessLevel)protocol GraphQLMutation: GraphQLOperation {}
+        \(accessLevel)protocol GraphQLMutation: GraphQLSingleResponseOperation {}
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -61,8 +61,95 @@ struct GraphQLRequestWriter {
             \(accessLevel)let endpoint: URL
 
             /// The GraphQL operation executed in the request.
-            \(accessLevel)let operation: Operation\(requestStateProperties())
+            \(accessLevel)let operation: Operation\(requestStateProperties())\(requestStateInitializer())
         }
+        """
+    }
+
+    private func requestStateInitializer() -> String {
+        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        return """
+
+
+            private init(
+                urlRequest: URLRequest,
+                endpoint: URL,
+                operation: Operation,
+                minifyDocument: Bool,
+                persistedOperationRetry: PersistedOperationRetry?
+            ) {
+                self.urlRequest = urlRequest
+                self.endpoint = endpoint
+                self.operation = operation
+                self.minifyDocument = minifyDocument
+                self.persistedOperationRetry = persistedOperationRetry
+            }
+        """
+    }
+
+    private func persistedOperationRetryDeclaration() -> String {
+        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        return """
+        enum PersistedOperationRetry {
+        \(persistedOperationGETRetryCase())
+            case POST(bodyEncoder: HTTPBodyEncoder)
+        }
+
+        """
+    }
+
+    private func persistedOperationGETRetryCase() -> String {
+        guard enableGETQueries else { return "" }
+        return "    case GET(queryEncoder: URLQueryEncoder)"
+    }
+
+    private func persistedOperationUpdate() -> String {
+        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        return """
+
+
+            /// Returns a request updated to retry an unknown persisted operation with its full document.
+            func updated(
+                for retry: PersistedOperationRetry
+            ) throws -> Self where Operation: GraphQLSingleResponseOperation {
+                var urlRequest = urlRequest
+                switch retry {\(persistedOperationGETUpdate())
+                case .POST(let bodyEncoder):
+                    urlRequest.url = endpoint
+                    urlRequest.httpMethod = "POST"
+                    urlRequest.httpBody = try bodyEncoder.encode(
+                        operation: operation,
+                        automaticPersistedOperationPhase: .persistRequestWithDocument,
+                        minifyDocument: minifyDocument
+                    )
+                    urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                }
+                return Self(
+                    urlRequest: urlRequest,
+                    endpoint: endpoint,
+                    operation: operation,
+                    minifyDocument: minifyDocument,
+                    persistedOperationRetry: nil
+                )
+            }
+        """
+    }
+
+    private func persistedOperationGETUpdate() -> String {
+        guard enableGETQueries else { return "" }
+        return """
+
+                case .GET(let queryEncoder):
+                    urlRequest.url = endpoint.appending(
+                        queryItems: try queryEncoder.encode(
+                            operation: operation,
+                            automaticPersistedOperationPhase: .persistRequestWithDocument,
+                            minifyDocument: minifyDocument
+                        )
+                    )
+                    urlRequest.httpMethod = "GET"
+                    urlRequest.httpBody = nil
+                    urlRequest.setValue(nil, forHTTPHeaderField: "content-type")
         """
     }
 
@@ -75,8 +162,8 @@ struct GraphQLRequestWriter {
                 /// Whether the request uses the operation's precomputed canonical document.
                 \(accessLevel)let minifyDocument: Bool
 
-                /// The encoder used to retry an unknown persisted operation with its full document.
-                \(accessLevel)let persistedOperationBodyEncoder: HTTPBodyEncoder?
+                /// The retry configuration for an unknown persisted operation.
+                let persistedOperationRetry: PersistedOperationRetry?
             """
         case .registered:
             ""
@@ -112,7 +199,7 @@ struct GraphQLRequestWriter {
         """
 
 
-            /// Initializes a POST request for a GraphQL operation.
+            /// Initializes a POST request for a single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
                 endpoint: Foundation.URL,
@@ -120,7 +207,7 @@ struct GraphQLRequestWriter {
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
-            ) throws {
+            ) throws where Operation: GraphQLSingleResponseOperation {
                 self.urlRequest = URLRequest(url: endpoint)
                 self.urlRequest.httpMethod = "POST"
                 self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -133,7 +220,7 @@ struct GraphQLRequestWriter {
                 self.endpoint = endpoint
                 self.operation = operation
                 self.minifyDocument = minifyDocument
-                self.persistedOperationBodyEncoder = automaticPersistedOperations ? bodyEncoder : nil
+                self.persistedOperationRetry = automaticPersistedOperations ? .POST(bodyEncoder: bodyEncoder) : nil
             }
         """
     }
@@ -142,13 +229,13 @@ struct GraphQLRequestWriter {
         """
 
 
-            /// Initializes a POST request for a registered GraphQL operation.
+            /// Initializes a POST request for a registered single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
                 endpoint: Foundation.URL,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
-            ) throws {
+            ) throws where Operation: GraphQLSingleResponseOperation {
                 self.urlRequest = URLRequest(url: endpoint)
                 self.urlRequest.httpMethod = "POST"
                 self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation)
@@ -164,14 +251,14 @@ struct GraphQLRequestWriter {
         """
 
 
-            /// Initializes a POST request for a GraphQL operation.
+            /// Initializes a POST request for a single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
                 endpoint: Foundation.URL,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
-            ) throws {
+            ) throws where Operation: GraphQLSingleResponseOperation {
                 self.urlRequest = URLRequest(url: endpoint)
                 self.urlRequest.httpMethod = "POST"
                 self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -201,6 +288,25 @@ struct GraphQLRequestWriter {
             /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`
             \(accessLevel)enum QueryStrategy {
 
+                /// Describes how to retry an automatic persisted operation when its hash is not recognized.
+                \(accessLevel)enum AutomaticPersistedOperationRetryPolicy {
+
+                    /// Retries with the full document encoded in the URL query component.
+                    case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
+
+                    /// Retries with the full document encoded in the HTTP body.
+                    case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+
+                    var retry: PersistedOperationRetry {
+                        switch self {
+                        case .GET(let queryEncoder):
+                            return .GET(queryEncoder: queryEncoder)
+                        case .POST(let bodyEncoder):
+                            return .POST(bodyEncoder: bodyEncoder)
+                        }
+                    }
+                }
+
                 /// Instructs the request to be a GET request without support for automatic persisted queries
                 case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
 
@@ -210,11 +316,15 @@ struct GraphQLRequestWriter {
                 /// Instructs the request to be a GET request, enabling automatic persisted queries
                 case GETWithAutomaticPersistedOperations(
                     queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder(),
-                    persistRequestBodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
+                    retryPolicy: AutomaticPersistedOperationRetryPolicy = .POST()
                 )
 
-                /// Instructs the request to be a GET request, enabling automatic persisted queries
-                case POSTWithAutomaticPersistedOperations(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+                /// Instructs the request to be a POST request, enabling automatic persisted queries.
+                /// The retry policy must be selected explicitly.
+                case POSTWithAutomaticPersistedOperations(
+                    bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+                    retryPolicy: AutomaticPersistedOperationRetryPolicy
+                )
             }
 
             /// Initializes a new `GraphQLRequest` with a query operation
@@ -223,8 +333,8 @@ struct GraphQLRequestWriter {
             ///   - endpoint: The GraphQL server endpoint.
             ///   - strategy: The option describing whether the request should be a GET or POST and whether
             ///   automatic persisted operations is enabled. By default `GET` is used
-            ///   and automatic persisted operations is enabled, meaning a `POST` will be executed with the full
-            ///   query document if the initial GET results in a "PersistedQueryNotFound" error.
+            ///   and automatic persisted operations is enabled. If the initial request results in a
+            ///   "PersistedQueryNotFound" error, the configured retry policy sends the full query document.
             ///   - minifyDocument: Whether the query document text should be minified
             ///   (unnecessary whitespace removed) when sent. `true` by default.
             ///   - accept: The value to use in the "accept" header field. By default this is
@@ -237,21 +347,21 @@ struct GraphQLRequestWriter {
                 minifyDocument: Bool = true,
                 accept: String = "application/graphql-response+json"
             ) throws where Operation: GraphQLQuery {
-                let persistedOperationBodyEncoder: HTTPBodyEncoder?
+                let persistedOperationRetry: PersistedOperationRetry?
                 switch strategy {
                 case .GET(let queryEncoder):
-                    persistedOperationBodyEncoder = nil
+                    persistedOperationRetry = nil
                     let url = endpoint.appending(
                         queryItems: try queryEncoder.encode(
-                            query: query,
-                            automaticPersistedOperations: false,
+                            operation: query,
+                            automaticPersistedOperationPhase: nil,
                             minifyDocument: minifyDocument
                         )
                     )
                     self.urlRequest = URLRequest(url: url)
                     self.urlRequest.httpMethod = "GET"
                 case .POST(let bodyEncoder):
-                    persistedOperationBodyEncoder = nil
+                    persistedOperationRetry = nil
                     self.urlRequest = URLRequest(url: endpoint)
                     self.urlRequest.httpMethod = "POST"
                     self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -260,19 +370,19 @@ struct GraphQLRequestWriter {
                         minifyDocument: minifyDocument
                     )
                     self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                case .GETWithAutomaticPersistedOperations(let queryEncoder, let persistRequestBodyEncoder):
-                    persistedOperationBodyEncoder = persistRequestBodyEncoder
+                case .GETWithAutomaticPersistedOperations(let queryEncoder, let retryPolicy):
+                    persistedOperationRetry = retryPolicy.retry
                     let url = endpoint.appending(
                         queryItems: try queryEncoder.encode(
-                            query: query,
-                            automaticPersistedOperations: true,
+                            operation: query,
+                            automaticPersistedOperationPhase: .initialRequestWithHash,
                             minifyDocument: minifyDocument
                         )
                     )
                     self.urlRequest = URLRequest(url: url)
                     self.urlRequest.httpMethod = "GET"
-                case .POSTWithAutomaticPersistedOperations(let bodyEncoder):
-                    persistedOperationBodyEncoder = bodyEncoder
+                case .POSTWithAutomaticPersistedOperations(let bodyEncoder, let retryPolicy):
+                    persistedOperationRetry = retryPolicy.retry
                     self.urlRequest = URLRequest(url: endpoint)
                     self.urlRequest.httpMethod = "POST"
                     self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -286,7 +396,7 @@ struct GraphQLRequestWriter {
                 self.endpoint = endpoint
                 self.operation = query
                 self.minifyDocument = minifyDocument
-                self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
+                self.persistedOperationRetry = persistedOperationRetry
             }
         """
     }
@@ -420,10 +530,26 @@ struct GraphQLRequestWriter {
         """
         \(header)import Foundation
 
+        \(persistedOperationRetryDeclaration())
         \(requestDeclaration())
 
-        extension GraphQLRequest {\(defaultDecoderDeclaration())\(querySupport)\(operationInitializer())\(subscriptionSupport)
+        extension GraphQLRequest {\(defaultDecoderDeclaration())\(persistedOperationUpdate())\(querySupport)\(operationInitializer())\(subscriptionSupport)
         }
+        """
+    }
+
+    private func subscriptionStrategyDeclaration() -> String {
+        """
+            /// Describes how the `GraphQLRequest` should encode a `GraphQLSubscription` operation into its
+            /// `URLRequest`.
+            \(accessLevel)enum SubscriptionStrategy {
+
+                /// Instructs the request to be a GET request.
+                case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
+
+                /// Instructs the request to be a POST request.
+                case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+            }
         """
     }
 
@@ -432,37 +558,34 @@ struct GraphQLRequestWriter {
         return """
 
 
+        \(subscriptionStrategyDeclaration())
+
             /// Initializes a new `GraphQLRequest` with a subscription operation
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
             ///   - endpoint: The GraphQL server endpoint supporting GraphQL over Server-Sent Events.
-            ///   - strategy: The option describing whether the request should be a GET or POST and whether
-            ///   automatic persisted operations is enabled. By default `GET` is used
-            ///   and automatic persisted operations is enabled, meaning a `POST` will be executed with the full
-            ///   query document if the initial GET results in a "PersistedQueryNotFound" error.
+            ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
+            ///   Automatic persisted operations are unavailable because subscription fallback is not supported.
             ///   - minifyDocument: Whether the query document text should be minified
             ///   (unnecessary whitespace removed) when sent. `true` by default.
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: URL,
-                strategy: QueryStrategy = .GETWithAutomaticPersistedOperations(),
+                strategy: SubscriptionStrategy = .GET(),
                 minifyDocument: Bool = true
             ) throws where Operation: GraphQLSubscription {
-                let persistedOperationBodyEncoder: HTTPBodyEncoder?
                 switch strategy {
                 case .GET(let queryEncoder):
-                    persistedOperationBodyEncoder = nil
                     let url = endpoint.appending(
                         queryItems: try queryEncoder.encode(
-                            subscription: subscription,
-                            automaticPersistedOperations: false,
+                            operation: subscription,
+                            automaticPersistedOperationPhase: nil,
                             minifyDocument: minifyDocument
                         )
                     )
                     self.urlRequest = URLRequest(url: url)
                     self.urlRequest.httpMethod = "GET"
                 case .POST(let bodyEncoder):
-                    persistedOperationBodyEncoder = nil
                     self.urlRequest = URLRequest(url: endpoint)
                     self.urlRequest.httpMethod = "POST"
                     self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -471,33 +594,12 @@ struct GraphQLRequestWriter {
                         minifyDocument: minifyDocument
                     )
                     self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-                case .GETWithAutomaticPersistedOperations(let queryEncoder, let persistRequestBodyEncoder):
-                    persistedOperationBodyEncoder = persistRequestBodyEncoder
-                    let url = endpoint.appending(
-                        queryItems: try queryEncoder.encode(
-                            subscription: subscription,
-                            automaticPersistedOperations: true,
-                            minifyDocument: minifyDocument
-                        )
-                    )
-                    self.urlRequest = URLRequest(url: url)
-                    self.urlRequest.httpMethod = "GET"
-                case .POSTWithAutomaticPersistedOperations(let bodyEncoder):
-                    persistedOperationBodyEncoder = bodyEncoder
-                    self.urlRequest = URLRequest(url: endpoint)
-                    self.urlRequest.httpMethod = "POST"
-                    self.urlRequest.httpBody = try bodyEncoder.encode(
-                        operation: subscription,
-                        automaticPersistedOperationPhase: .initialRequestWithHash,
-                        minifyDocument: minifyDocument
-                    )
-                    self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
                 }
                 self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
                 self.endpoint = endpoint
                 self.operation = subscription
                 self.minifyDocument = minifyDocument
-                self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
+                self.persistedOperationRetry = nil
             }
         """
     }
@@ -507,6 +609,8 @@ struct GraphQLRequestWriter {
         return """
 
 
+        \(subscriptionStrategyDeclaration())
+
             /// Initializes a new `GraphQLRequest` with a subscription operation
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
@@ -515,7 +619,7 @@ struct GraphQLRequestWriter {
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: URL,
-                strategy: QueryStrategy = .GET()
+                strategy: SubscriptionStrategy = .GET()
             ) throws where Operation: GraphQLSubscription {
                 switch strategy {
                 case .GET(let queryEncoder):
@@ -540,6 +644,8 @@ struct GraphQLRequestWriter {
         return """
 
 
+        \(subscriptionStrategyDeclaration())
+
             /// Initializes a new `GraphQLRequest` with a subscription operation
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
@@ -550,7 +656,7 @@ struct GraphQLRequestWriter {
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: URL,
-                strategy: QueryStrategy = .GET(),
+                strategy: SubscriptionStrategy = .GET(),
                 minifyDocument: Bool = true
             ) throws where Operation: GraphQLSubscription {
                 switch strategy {
@@ -583,27 +689,30 @@ struct GraphQLRequestWriter {
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
             ///   - endpoint: The GraphQL server endpoint.
-            ///   - automaticPersistedOperations: Whether automatic persisted operations is enabled.
-            ///   By default this is `true` meaning a subsequent request will be executed with the full
-            ///   query document if this initial request results in a "PersistedQueryNotFound" error.
             ///   - minifyDocument: Whether the query document text should be minified
             ///   (unnecessary whitespace removed) when sent. `true` by default.
             ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
+            ///
+            /// Automatic persisted operations are unavailable because subscription fallback is not supported.
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: Foundation.URL,
-                automaticPersistedOperations: Bool = true,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
-                try self.init(
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(
                     operation: subscription,
-                    endpoint: endpoint,
-                    automaticPersistedOperations: automaticPersistedOperations,
-                    minifyDocument: minifyDocument,
-                    bodyEncoder: bodyEncoder,
-                    accept: "text/event-stream"
+                    automaticPersistedOperationPhase: nil,
+                    minifyDocument: minifyDocument
                 )
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = subscription
+                self.minifyDocument = minifyDocument
+                self.persistedOperationRetry = nil
             }
         """
     }
@@ -623,12 +732,13 @@ struct GraphQLRequestWriter {
                 endpoint: Foundation.URL,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
-                try self.init(
-                    operation: subscription,
-                    endpoint: endpoint,
-                    bodyEncoder: bodyEncoder,
-                    accept: "text/event-stream"
-                )
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(operation: subscription)
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = subscription
             }
         """
     }
@@ -651,13 +761,17 @@ struct GraphQLRequestWriter {
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
-                try self.init(
+                self.urlRequest = URLRequest(url: endpoint)
+                self.urlRequest.httpMethod = "POST"
+                self.urlRequest.httpBody = try bodyEncoder.encode(
                     operation: subscription,
-                    endpoint: endpoint,
-                    minifyDocument: minifyDocument,
-                    bodyEncoder: bodyEncoder,
-                    accept: "text/event-stream"
+                    minifyDocument: minifyDocument
                 )
+                self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+                self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
+                self.endpoint = endpoint
+                self.operation = subscription
+                self.minifyDocument = minifyDocument
             }
         """
     }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -38,11 +38,11 @@ struct URLSessionWriter {
                 \(accessLevel)let response: HTTPURLResponse
             }
 
-            /// Executes a GraphQL operation
+            /// Executes a single-response GraphQL operation.
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed.
             ///   - decoder: The function used to turn response data into an Operation.Data instance.
-            \(accessLevel)func request<Operation: GraphQLOperation>(
+            \(accessLevel)func request<Operation: GraphQLSingleResponseOperation>(
                 _ request: GraphQLRequest<Operation>,
                 decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.Success {
@@ -54,7 +54,7 @@ struct URLSessionWriter {
                 case .success(let success): return success
                 \(requestErrorHandling())
                 }
-            }\(persistingRequest())\(subscriptions())
+            }\(subscriptions())
         }
         """
     }
@@ -68,9 +68,9 @@ struct URLSessionWriter {
                             error.message == "PersistedQueryNotFound"
                         }
                         if containsPersistedQueryNotFound,
-                           let persistedOperationBodyEncoder = request.persistedOperationBodyEncoder {
+                           let retry = request.persistedOperationRetry {
                             return try await self.request(
-                                try persistingRequest(request, bodyEncoder: persistedOperationBodyEncoder),
+                                try request.updated(for: retry),
                                 decoder: decoder
                             )
                         }
@@ -81,33 +81,6 @@ struct URLSessionWriter {
         }
     }
 
-    private func persistingRequest() -> String {
-        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
-        return """
-
-
-            private func persistingRequest<Operation: GraphQLOperation>(
-                _ original: GraphQLRequest<Operation>,
-                bodyEncoder: HTTPBodyEncoder
-            ) throws -> GraphQLRequest<Operation> {
-                var urlRequest = original.urlRequest
-                urlRequest.url = original.endpoint
-                urlRequest.httpBody = try bodyEncoder.encode(
-                    operation: original.operation,
-                    automaticPersistedOperationPhase: .persistRequestWithDocument,
-                    minifyDocument: original.minifyDocument
-                )
-                return GraphQLRequest(
-                    urlRequest: urlRequest,
-                    endpoint: original.endpoint,
-                    operation: original.operation,
-                    minifyDocument: original.minifyDocument,
-                    persistedOperationBodyEncoder: nil
-                )
-            }
-        """
-    }
-
     private func subscriptions() -> String {
         guard includeSubscriptionSupport else { return "" }
         return """
@@ -115,7 +88,7 @@ struct URLSessionWriter {
 
             /// Initiates an event stream using a GraphQL subscription.
             /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
-            /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode
+            /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode\(automaticPersistedOperationSubscriptionDocumentation())
             /// - Parameters:
             ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
             ///   in the "accept" header.
@@ -136,7 +109,7 @@ struct URLSessionWriter {
                                 if let messageData = buffer.append(byte) {
                                     switch try decoder(messageData) {
                                     case .success(let success): continuation.yield(success)
-                                    case .requestError(let requestError): throw requestError
+                                    \(subscriptionRequestErrorHandling())
                                     }
                                 }
                             }
@@ -178,5 +151,27 @@ struct URLSessionWriter {
                 }
             }
         """
+    }
+
+    private func automaticPersistedOperationSubscriptionDocumentation() -> String {
+        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        return """
+
+            /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
+            /// requests always include the full operation document.
+        """
+    }
+
+    private func subscriptionRequestErrorHandling() -> String {
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic:
+            """
+            case .requestError(let requestError):
+                                            // TODO: Support automatic persisted operation fallback for subscriptions.
+                                            throw requestError
+            """
+        case .registered, .none:
+            "case .requestError(let requestError): throw requestError"
+        }
     }
 }

--- a/Sources/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -6,8 +6,8 @@ struct DefaultURLQueryEncoderTests {
     @Test
     func omitsDocumentFromPersistedQuery() throws {
         let queryItems = try DefaultURLQueryEncoder().encode(
-            query: CurrentUserQuery(),
-            automaticPersistedOperations: true,
+            operation: CurrentUserQuery(),
+            automaticPersistedOperationPhase: .initialRequestWithHash,
             minifyDocument: true
         )
 
@@ -17,8 +17,8 @@ struct DefaultURLQueryEncoderTests {
     @Test
     func includesDocumentInStandardQuery() throws {
         let queryItems = try DefaultURLQueryEncoder().encode(
-            query: CurrentUserQuery(),
-            automaticPersistedOperations: false,
+            operation: CurrentUserQuery(),
+            automaticPersistedOperationPhase: nil,
             minifyDocument: true
         )
 

--- a/Sources/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -25,13 +25,19 @@ struct GraphQLCodeGeneratorTests {
         }
         let operationsDirectory = generatedDirectory.appending(path: "Operations", directoryHint: .isDirectory)
         try FileManager.default.createDirectory(at: operationsDirectory, withIntermediateDirectories: true)
-        try FileManager.default.copyItem(
-            at: starwarsExampleDirectory.appending(
-                path: "Operations/HeroQuery.graphql",
-                directoryHint: .notDirectory
-            ),
-            to: operationsDirectory.appending(path: "HeroQuery.graphql", directoryHint: .notDirectory)
-        )
+        for operationFile in [
+            "FavoriteEpisodeChangedSubscription.graphql",
+            "HeroQuery.graphql",
+            "SetFavoriteEpisodeMutation.graphql",
+        ] {
+            try FileManager.default.copyItem(
+                at: starwarsExampleDirectory.appending(
+                    path: "Operations/\(operationFile)",
+                    directoryHint: .notDirectory
+                ),
+                to: operationsDirectory.appending(path: operationFile, directoryHint: .notDirectory)
+            )
+        }
         let scalarsDirectory = generatedDirectory.appending(
             path: "SchemaTypes/Scalars",
             directoryHint: .isDirectory
@@ -63,7 +69,10 @@ struct GraphQLCodeGeneratorTests {
                     ),
                     api: .api(
                         directory: generatedDirectory.appending(path: "API", directoryHint: .isDirectory),
-                        HTTPSupport: .httpSupport(enableGETQueries: true)
+                        HTTPSupport: .httpSupport(
+                            enableGETQueries: true,
+                            subscriptionSupport: true
+                        )
                     )
                 )
             )
@@ -71,6 +80,190 @@ struct GraphQLCodeGeneratorTests {
         try OutputFile.allCases.forEach { outputFile in
             try verifyOutputFile(outputFile, generatedDirectory: generatedDirectory)
         }
+    }
+
+    @Test
+    func generatedSubscriptionRequestsCannotEnableAutomaticPersistedOperations() async throws {
+        let generatedDirectory = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: generatedDirectory, withIntermediateDirectories: true)
+        defer {
+            // Best-effort test cleanup; retaining a temporary directory does not affect test behavior.
+            try? FileManager.default.removeItem(at: generatedDirectory)
+        }
+
+        let schemaURL = generatedDirectory.appending(path: "schema.graphqls", directoryHint: .notDirectory)
+        try """
+        type Query {
+          version: String!
+        }
+
+        type Mutation {
+          setVersion(version: String!): String!
+        }
+
+        type Subscription {
+          ticks: Int!
+        }
+        """.write(to: schemaURL, atomically: true, encoding: .utf8)
+
+        let operationsDirectory = generatedDirectory.appending(path: "Operations", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: operationsDirectory, withIntermediateDirectories: true)
+        try """
+        mutation SetVersion { setVersion(version: "2") }
+        subscription Ticks { ticks }
+        """.write(
+            to: operationsDirectory.appending(path: "Ticks.graphql", directoryHint: .notDirectory),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let getAPI = generatedDirectory.appending(path: "GET/API", directoryHint: .isDirectory)
+        try await generateSubscriptionAPI(
+            schemaURL: schemaURL,
+            operationsDirectory: operationsDirectory,
+            apiDirectory: getAPI,
+            enableGETQueries: true
+        )
+        let getRequest = try String(
+            contentsOf: getAPI.appending(path: "HTTPSupport/GraphQLRequest.swift"),
+            encoding: .utf8
+        )
+        let operationProtocols = try String(
+            contentsOf: getAPI.appending(path: "HTTPSupport/GraphQLOperation.swift"),
+            encoding: .utf8
+        )
+        #expect(operationProtocols.contains("protocol GraphQLSingleResponseOperation: GraphQLOperation"))
+        #expect(operationProtocols.contains("protocol GraphQLQuery: GraphQLSingleResponseOperation"))
+        #expect(operationProtocols.contains("protocol GraphQLMutation: GraphQLSingleResponseOperation"))
+        #expect(operationProtocols.contains("protocol GraphQLSubscription: GraphQLOperation"))
+
+        let urlSession = try String(
+            contentsOf: getAPI.appending(path: "HTTPSupport/URLSession+GraphQL.swift"),
+            encoding: .utf8
+        )
+        #expect(urlSession.contains("func request<Operation: GraphQLSingleResponseOperation>"))
+        #expect(urlSession.contains("func subscribe<Subscription: GraphQLSubscription>"))
+
+        #expect(getRequest.contains("enum SubscriptionStrategy"))
+        #expect(getRequest.contains("strategy: SubscriptionStrategy = .GET()"))
+        #expect(getRequest.contains(") throws where Operation: GraphQLSingleResponseOperation"))
+        #expect(getRequest.contains("private init(\n        urlRequest: URLRequest"))
+        let subscriptionStrategyStart = try #require(getRequest.range(of: "enum SubscriptionStrategy"))
+        let subscriptionInitializerStart = try #require(
+            getRequest.range(
+                of: "/// Initializes a new `GraphQLRequest` with a subscription operation",
+                range: subscriptionStrategyStart.upperBound..<getRequest.endIndex
+            )
+        )
+        let subscriptionStrategy = getRequest[
+            subscriptionStrategyStart.lowerBound..<subscriptionInitializerStart.lowerBound
+        ]
+        #expect(!subscriptionStrategy.contains("AutomaticPersistedOperation"))
+
+        let postAPI = generatedDirectory.appending(path: "POST/API", directoryHint: .isDirectory)
+        try await generateSubscriptionAPI(
+            schemaURL: schemaURL,
+            operationsDirectory: operationsDirectory,
+            apiDirectory: postAPI,
+            enableGETQueries: false
+        )
+        let postRequest = try String(
+            contentsOf: postAPI.appending(path: "HTTPSupport/GraphQLRequest.swift"),
+            encoding: .utf8
+        )
+        let subscriptionInitializer = try #require(
+            postRequest.range(of: "/// Initializes a new `GraphQLRequest` with a subscription operation")
+        )
+        let subscriptionRequest = postRequest[subscriptionInitializer.lowerBound...]
+        #expect(!subscriptionRequest.contains("automaticPersistedOperations"))
+        #expect(subscriptionRequest.contains("automaticPersistedOperationPhase: nil"))
+        #expect(subscriptionRequest.contains("self.persistedOperationRetry = nil"))
+
+        for persistedOperations in [
+            Configuration.Output.Documents.Operations.PersistedOperations.registered(
+                manifestJSONFileOutput: generatedDirectory.appending(path: "manifest.json")
+            ),
+            nil,
+        ] {
+            let variantDirectory = generatedDirectory.appending(
+                path: UUID().uuidString,
+                directoryHint: .isDirectory
+            )
+
+            let getVariantAPI = variantDirectory.appending(path: "GET/API", directoryHint: .isDirectory)
+            try await generateSubscriptionAPI(
+                schemaURL: schemaURL,
+                operationsDirectory: operationsDirectory,
+                apiDirectory: getVariantAPI,
+                enableGETQueries: true,
+                persistedOperations: persistedOperations
+            )
+            let getRequest = try String(
+                contentsOf: getVariantAPI.appending(path: "HTTPSupport/GraphQLRequest.swift"),
+                encoding: .utf8
+            )
+            let getInitializer = try #require(
+                getRequest.range(of: "/// Initializes a new `GraphQLRequest` with a subscription operation")
+            )
+            let getSubscriptionRequest = getRequest[getInitializer.lowerBound...]
+            #expect(getRequest.contains("enum SubscriptionStrategy"))
+            #expect(getSubscriptionRequest.contains("strategy: SubscriptionStrategy = .GET()"))
+            #expect(!getSubscriptionRequest.contains("strategy: QueryStrategy"))
+
+            let postVariantAPI = variantDirectory.appending(path: "POST/API", directoryHint: .isDirectory)
+            try await generateSubscriptionAPI(
+                schemaURL: schemaURL,
+                operationsDirectory: operationsDirectory,
+                apiDirectory: postVariantAPI,
+                enableGETQueries: false,
+                persistedOperations: persistedOperations
+            )
+            let postRequest = try String(
+                contentsOf: postVariantAPI.appending(path: "HTTPSupport/GraphQLRequest.swift"),
+                encoding: .utf8
+            )
+            let postInitializer = try #require(
+                postRequest.range(of: "/// Initializes a new `GraphQLRequest` with a subscription operation")
+            )
+            #expect(!postRequest[postInitializer.lowerBound...].contains("try self.init("))
+        }
+    }
+
+    private func generateSubscriptionAPI(
+        schemaURL: URL,
+        operationsDirectory: URL,
+        apiDirectory: URL,
+        enableGETQueries: Bool,
+        persistedOperations: Configuration.Output.Documents.Operations.PersistedOperations? = .automatic
+    ) async throws {
+        try await Codegen(
+            .configuration(
+                input: .input(
+                    schemaSource: .SDLSchemaFile(schemaURL),
+                    documentDirectories: [operationsDirectory]
+                ),
+                output: .output(
+                    schema: .schema(
+                        directory: apiDirectory
+                            .deletingLastPathComponent()
+                            .appending(path: "SchemaTypes", directoryHint: .isDirectory)
+                    ),
+                    documents: .documents(
+                        operations: .operations(persistedOperations: persistedOperations)
+                    ),
+                    api: .api(
+                        directory: apiDirectory,
+                        HTTPSupport: .httpSupport(
+                            enableGETQueries: enableGETQueries,
+                            subscriptionSupport: true
+                        )
+                    )
+                )
+            )
+        ).run()
     }
 
     private func verifyOutputFile(_ outputFile: OutputFile, generatedDirectory: URL) throws {
@@ -93,6 +286,7 @@ struct GraphQLCodeGeneratorTests {
 enum OutputFile: String, CaseIterable {
     case DefaultEncoders
     case Encoders
+    case FavoriteEpisodeChangedSubscription
     case GraphQLOperation
     case GraphQLRequest
     case URLSessionGraphQL
@@ -104,6 +298,7 @@ enum OutputFile: String, CaseIterable {
     case GraphQLResponse
     case JSONValue
     case HeroQuery
+    case SetFavoriteEpisodeMutation
     case Episode
     case ID
 
@@ -111,6 +306,8 @@ enum OutputFile: String, CaseIterable {
         switch self {
         case .DefaultEncoders: "API/HTTPSupport/DefaultEncoders.swift"
         case .Encoders: "API/HTTPSupport/Encoders.swift"
+        case .FavoriteEpisodeChangedSubscription:
+            "Operations/FavoriteEpisodeChangedSubscription.graphql.swift"
         case .GraphQLOperation: "API/HTTPSupport/GraphQLOperation.swift"
         case .GraphQLRequest: "API/HTTPSupport/GraphQLRequest.swift"
         case .URLSessionGraphQL: "API/HTTPSupport/URLSession+GraphQL.swift"
@@ -122,6 +319,7 @@ enum OutputFile: String, CaseIterable {
         case .GraphQLResponse: "API/GraphQLResponse.swift"
         case .JSONValue: "API/JSONValue.swift"
         case .HeroQuery: "Operations/HeroQuery.graphql.swift"
+        case .SetFavoriteEpisodeMutation: "Operations/SetFavoriteEpisodeMutation.graphql.swift"
         case .Episode: "SchemaTypes/Enums/Episode.graphqls.swift"
         case .ID: "SchemaTypes/Scalars/ID.graphqls.swift"
         }

--- a/Sources/GraphQLCodegenTests/Tests/Integration/GraphQLRequestTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/GraphQLRequestTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+@testable import StarwarsExample
+import Testing
+
+struct GraphQLRequestTests {
+    private final class TrackingHTTPBodyEncoder: HTTPBodyEncoder {
+        let contentType = "application/json"
+        private(set) var initialRequestCount = 0
+        private(set) var persistRequestCount = 0
+
+        func encode<Operation: GraphQLOperation>(
+            operation: Operation,
+            automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
+            minifyDocument: Bool
+        ) throws -> Data {
+            switch automaticPersistedOperationPhase {
+            case .some(.initialRequestWithHash): initialRequestCount += 1
+            case .some(.persistRequestWithDocument): persistRequestCount += 1
+            case nil: break
+            }
+            return try JSONBodyEncoder().encode(
+                operation: operation,
+                automaticPersistedOperationPhase: automaticPersistedOperationPhase,
+                minifyDocument: minifyDocument
+            )
+        }
+    }
+
+    private final class TrackingURLQueryEncoder: URLQueryEncoder {
+        private(set) var encodeCount = 0
+
+        func encode<Operation: GraphQLOperation>(
+            operation: Operation,
+            automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
+            minifyDocument: Bool
+        ) throws -> [URLQueryItem] {
+            encodeCount += 1
+            return try DefaultURLQueryEncoder().encode(
+                operation: operation,
+                automaticPersistedOperationPhase: automaticPersistedOperationPhase,
+                minifyDocument: minifyDocument
+            )
+        }
+    }
+
+    private struct EncodedExtensions: Decodable {
+        struct PersistedQuery: Decodable {
+            let sha256Hash: String
+            let version: Int
+        }
+
+        let persistedQuery: PersistedQuery
+    }
+
+    private struct EncodedDocument: Decodable {
+        let query: String?
+    }
+
+    private struct EncodedRequest: Decodable {
+        struct Variables: Decodable {
+            let episode: String
+        }
+
+        let extensions: EncodedExtensions
+        let operationName: String?
+        let query: String?
+        let variables: Variables
+    }
+
+    private let endpoint = URL(string: "https://example.com/graphql")!
+    private let operation = HeroQuery(episode: .JEDI)
+
+    @Test
+    func compiledFixtureSupportsMutationAndSubscriptionRequests() throws {
+        let mutationRequest = try GraphQLRequest(
+            operation: SetFavoriteEpisodeMutation(episode: .JEDI),
+            endpoint: endpoint
+        )
+        #expect(mutationRequest.urlRequest.httpMethod == "POST")
+        #expect(mutationRequest.persistedOperationRetry != nil)
+
+        let subscriptionRequest = try GraphQLRequest(
+            subscription: FavoriteEpisodeChangedSubscription(),
+            endpoint: endpoint
+        )
+        #expect(subscriptionRequest.urlRequest.httpMethod == "GET")
+        #expect(subscriptionRequest.urlRequest.value(forHTTPHeaderField: "accept") == "text/event-stream")
+        #expect(subscriptionRequest.persistedOperationRetry == nil)
+
+        let url = try #require(subscriptionRequest.urlRequest.url)
+        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(
+            queryItems.first { $0.name == "query" }?.value
+                == FavoriteEpisodeChangedSubscription.minifiedDocument
+        )
+
+        let postSubscriptionRequest = try GraphQLRequest(
+            subscription: FavoriteEpisodeChangedSubscription(),
+            endpoint: endpoint,
+            strategy: .POST()
+        )
+        #expect(postSubscriptionRequest.urlRequest.httpMethod == "POST")
+        #expect(postSubscriptionRequest.persistedOperationRetry == nil)
+        let body = try JSONDecoder().decode(
+            EncodedDocument.self,
+            from: try #require(postSubscriptionRequest.urlRequest.httpBody)
+        )
+        #expect(body.query == FavoriteEpisodeChangedSubscription.minifiedDocument)
+    }
+
+    @Test
+    func automaticPersistedOperationDefersGETRetryEncoding() throws {
+        let retryEncoder = TrackingURLQueryEncoder()
+        let request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .GETWithAutomaticPersistedOperations(
+                retryPolicy: .GET(queryEncoder: retryEncoder)
+            )
+        )
+
+        #expect(retryEncoder.encodeCount == 0)
+        let retry = try #require(request.persistedOperationRetry)
+        _ = try request.updated(for: retry)
+        #expect(retryEncoder.encodeCount == 1)
+    }
+
+    @Test
+    func automaticPersistedOperationRetriesWithGET() throws {
+        var request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .GETWithAutomaticPersistedOperations(retryPolicy: .GET())
+        )
+        request.urlRequest.setValue("Bearer token", forHTTPHeaderField: "authorization")
+
+        let retry = try #require(request.persistedOperationRetry)
+        let updatedRequest = try request.updated(for: retry)
+        let urlRequest = updatedRequest.urlRequest
+
+        #expect(updatedRequest.persistedOperationRetry == nil)
+        #expect(urlRequest.httpMethod == "GET")
+        #expect(urlRequest.httpBody == nil)
+        #expect(urlRequest.value(forHTTPHeaderField: "content-type") == nil)
+        #expect(urlRequest.value(forHTTPHeaderField: "authorization") == "Bearer token")
+
+        let url = try #require(urlRequest.url)
+        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(queryItems.first { $0.name == "operationName" }?.value == "Hero")
+        #expect(queryItems.first { $0.name == "query" }?.value == HeroQuery.minifiedDocument)
+
+        let variablesData = try #require(queryItems.first { $0.name == "variables" }?.value?.data(using: .utf8))
+        let variables = try JSONDecoder().decode(EncodedRequest.Variables.self, from: variablesData)
+        #expect(variables.episode == "JEDI")
+
+        let extensionsData = try #require(queryItems.first { $0.name == "extensions" }?.value?.data(using: .utf8))
+        let extensions = try JSONDecoder().decode(EncodedExtensions.self, from: extensionsData)
+        #expect(extensions.persistedQuery.version == 1)
+        #expect(extensions.persistedQuery.sha256Hash.count == 64)
+    }
+
+    @Test
+    func automaticPersistedOperationDefaultsToPOSTRetry() throws {
+        var request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .GETWithAutomaticPersistedOperations()
+        )
+        request.urlRequest.setValue("Bearer token", forHTTPHeaderField: "authorization")
+
+        let retry = try #require(request.persistedOperationRetry)
+        let updatedRequest = try request.updated(for: retry)
+        let urlRequest = updatedRequest.urlRequest
+
+        #expect(updatedRequest.persistedOperationRetry == nil)
+        #expect(urlRequest.url == endpoint)
+        #expect(urlRequest.httpMethod == "POST")
+        #expect(urlRequest.value(forHTTPHeaderField: "content-type") == "application/json")
+        #expect(urlRequest.value(forHTTPHeaderField: "authorization") == "Bearer token")
+
+        let body = try JSONDecoder().decode(EncodedRequest.self, from: try #require(urlRequest.httpBody))
+        #expect(body.operationName == "Hero")
+        #expect(body.query == HeroQuery.minifiedDocument)
+        #expect(body.variables.episode == "JEDI")
+        #expect(body.extensions.persistedQuery.version == 1)
+        #expect(body.extensions.persistedQuery.sha256Hash.count == 64)
+    }
+
+    @Test
+    func automaticPersistedOperationCanStartWithPOSTAndRetryWithGET() throws {
+        let request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .POSTWithAutomaticPersistedOperations(retryPolicy: .GET())
+        )
+
+        #expect(request.urlRequest.httpMethod == "POST")
+        let retry = try #require(request.persistedOperationRetry)
+        let updatedRequest = try request.updated(for: retry)
+        let urlRequest = updatedRequest.urlRequest
+
+        #expect(updatedRequest.persistedOperationRetry == nil)
+        #expect(urlRequest.httpMethod == "GET")
+        #expect(urlRequest.httpBody == nil)
+        let url = try #require(urlRequest.url)
+        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(queryItems.first { $0.name == "query" }?.value == HeroQuery.minifiedDocument)
+    }
+
+    @Test
+    func automaticPersistedOperationUsesExplicitPOSTRetryEncoder() throws {
+        let initialEncoder = TrackingHTTPBodyEncoder()
+        let retryEncoder = TrackingHTTPBodyEncoder()
+        let request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .POSTWithAutomaticPersistedOperations(
+                bodyEncoder: initialEncoder,
+                retryPolicy: .POST(bodyEncoder: retryEncoder)
+            )
+        )
+
+        #expect(initialEncoder.initialRequestCount == 1)
+        #expect(initialEncoder.persistRequestCount == 0)
+        #expect(retryEncoder.initialRequestCount == 0)
+        #expect(retryEncoder.persistRequestCount == 0)
+
+        let retry = try #require(request.persistedOperationRetry)
+        _ = try request.updated(for: retry)
+
+        #expect(initialEncoder.persistRequestCount == 0)
+        #expect(retryEncoder.persistRequestCount == 1)
+    }
+}

--- a/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -7,14 +7,14 @@ import Foundation
 /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
 struct DefaultURLQueryEncoder: URLQueryEncoder {
     init() {}
-    func encode<Query: GraphQLQuery>(
-        query: Query,
-        automaticPersistedOperations: Bool,
+    func encode<Operation: GraphQLOperation>(
+        operation: Operation,
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
         minifyDocument: Bool
     ) throws -> [URLQueryItem] {
         let body = Body(
-            operation: query,
-            automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil,
+            operation: operation,
+            automaticPersistedOperationPhase: automaticPersistedOperationPhase,
             minifyDocument: minifyDocument
         )
         let encoder = JSONEncoder()

--- a/Sources/StarwarsExample/API/HTTPSupport/Encoders.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/Encoders.swift
@@ -1,22 +1,20 @@
 // @generated
 import Foundation
 
-/// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
-/// is being used.
+/// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
 protocol URLQueryEncoder {
 
-    /// Encodes a query operation for a GET request.
+    /// Encodes an operation for a GET request.
     /// - Parameters:
-    ///   query: The query operation to encode.
-    ///   automaticPersistedOperations: Pass `true` if automatic persisted operations is enabled.
-    ///   When automatic persisted operations is enabled, implementations should encode the document's
-    ///   hash, rather than the full document text. Note: Only the initial request uses GET. When the
-    ///   persisted operation is not found by the server, the subsequent request is sent as a POST.
+    ///   operation: The operation to encode.
+    ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
+    ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
+    ///   should always be sent.
     ///   minifyDocument: Pass `true` if the document should remove unnecessary whitespace.
     /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-    func encode<Query: GraphQLQuery>(
-        query: Query,
-        automaticPersistedOperations: Bool,
+    func encode<Operation: GraphQLOperation>(
+        operation: Operation,
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?,
         minifyDocument: Bool
     ) throws -> [URLQueryItem]
 }

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -27,4 +27,12 @@ protocol GraphQLOperation: Sendable {
     associatedtype Data: Decodable, Sendable
 }
 
-protocol GraphQLQuery: GraphQLOperation {}
+/// A `GraphQLSingleResponseOperation` produces one response and can be executed with `URLSession.request`.
+/// Queries and mutations have this capability; subscriptions produce a stream instead.
+protocol GraphQLSingleResponseOperation: GraphQLOperation {}
+
+protocol GraphQLQuery: GraphQLSingleResponseOperation {}
+
+protocol GraphQLMutation: GraphQLSingleResponseOperation {}
+
+protocol GraphQLSubscription: GraphQLOperation {}

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
@@ -1,6 +1,11 @@
 // @generated
 import Foundation
 
+enum PersistedOperationRetry {
+    case GET(queryEncoder: URLQueryEncoder)
+    case POST(bodyEncoder: HTTPBodyEncoder)
+}
+
 /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
 struct GraphQLRequest<Operation: GraphQLOperation> {
 
@@ -17,8 +22,22 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
     /// Whether the request uses the operation's precomputed canonical document.
     let minifyDocument: Bool
 
-    /// The encoder used to retry an unknown persisted operation with its full document.
-    let persistedOperationBodyEncoder: HTTPBodyEncoder?
+    /// The retry configuration for an unknown persisted operation.
+    let persistedOperationRetry: PersistedOperationRetry?
+
+    private init(
+        urlRequest: URLRequest,
+        endpoint: URL,
+        operation: Operation,
+        minifyDocument: Bool,
+        persistedOperationRetry: PersistedOperationRetry?
+    ) {
+        self.urlRequest = urlRequest
+        self.endpoint = endpoint
+        self.operation = operation
+        self.minifyDocument = minifyDocument
+        self.persistedOperationRetry = persistedOperationRetry
+    }
 }
 
 extension GraphQLRequest {
@@ -27,8 +46,63 @@ extension GraphQLRequest {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
+    /// Returns a request updated to retry an unknown persisted operation with its full document.
+    func updated(
+        for retry: PersistedOperationRetry
+    ) throws -> Self where Operation: GraphQLSingleResponseOperation {
+        var urlRequest = urlRequest
+        switch retry {
+        case .GET(let queryEncoder):
+            urlRequest.url = endpoint.appending(
+                queryItems: try queryEncoder.encode(
+                    operation: operation,
+                    automaticPersistedOperationPhase: .persistRequestWithDocument,
+                    minifyDocument: minifyDocument
+                )
+            )
+            urlRequest.httpMethod = "GET"
+            urlRequest.httpBody = nil
+            urlRequest.setValue(nil, forHTTPHeaderField: "content-type")
+        case .POST(let bodyEncoder):
+            urlRequest.url = endpoint
+            urlRequest.httpMethod = "POST"
+            urlRequest.httpBody = try bodyEncoder.encode(
+                operation: operation,
+                automaticPersistedOperationPhase: .persistRequestWithDocument,
+                minifyDocument: minifyDocument
+            )
+            urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+        }
+        return Self(
+            urlRequest: urlRequest,
+            endpoint: endpoint,
+            operation: operation,
+            minifyDocument: minifyDocument,
+            persistedOperationRetry: nil
+        )
+    }
+
     /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`
     enum QueryStrategy {
+
+        /// Describes how to retry an automatic persisted operation when its hash is not recognized.
+        enum AutomaticPersistedOperationRetryPolicy {
+
+            /// Retries with the full document encoded in the URL query component.
+            case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
+
+            /// Retries with the full document encoded in the HTTP body.
+            case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+
+            var retry: PersistedOperationRetry {
+                switch self {
+                case .GET(let queryEncoder):
+                    return .GET(queryEncoder: queryEncoder)
+                case .POST(let bodyEncoder):
+                    return .POST(bodyEncoder: bodyEncoder)
+                }
+            }
+        }
 
         /// Instructs the request to be a GET request without support for automatic persisted queries
         case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
@@ -39,11 +113,15 @@ extension GraphQLRequest {
         /// Instructs the request to be a GET request, enabling automatic persisted queries
         case GETWithAutomaticPersistedOperations(
             queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder(),
-            persistRequestBodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
+            retryPolicy: AutomaticPersistedOperationRetryPolicy = .POST()
         )
 
-        /// Instructs the request to be a GET request, enabling automatic persisted queries
-        case POSTWithAutomaticPersistedOperations(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+        /// Instructs the request to be a POST request, enabling automatic persisted queries.
+        /// The retry policy must be selected explicitly.
+        case POSTWithAutomaticPersistedOperations(
+            bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+            retryPolicy: AutomaticPersistedOperationRetryPolicy
+        )
     }
 
     /// Initializes a new `GraphQLRequest` with a query operation
@@ -52,8 +130,8 @@ extension GraphQLRequest {
     ///   - endpoint: The GraphQL server endpoint.
     ///   - strategy: The option describing whether the request should be a GET or POST and whether
     ///   automatic persisted operations is enabled. By default `GET` is used
-    ///   and automatic persisted operations is enabled, meaning a `POST` will be executed with the full
-    ///   query document if the initial GET results in a "PersistedQueryNotFound" error.
+    ///   and automatic persisted operations is enabled. If the initial request results in a
+    ///   "PersistedQueryNotFound" error, the configured retry policy sends the full query document.
     ///   - minifyDocument: Whether the query document text should be minified
     ///   (unnecessary whitespace removed) when sent. `true` by default.
     ///   - accept: The value to use in the "accept" header field. By default this is
@@ -66,21 +144,21 @@ extension GraphQLRequest {
         minifyDocument: Bool = true,
         accept: String = "application/graphql-response+json"
     ) throws where Operation: GraphQLQuery {
-        let persistedOperationBodyEncoder: HTTPBodyEncoder?
+        let persistedOperationRetry: PersistedOperationRetry?
         switch strategy {
         case .GET(let queryEncoder):
-            persistedOperationBodyEncoder = nil
+            persistedOperationRetry = nil
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    query: query,
-                    automaticPersistedOperations: false,
+                    operation: query,
+                    automaticPersistedOperationPhase: nil,
                     minifyDocument: minifyDocument
                 )
             )
             self.urlRequest = URLRequest(url: url)
             self.urlRequest.httpMethod = "GET"
         case .POST(let bodyEncoder):
-            persistedOperationBodyEncoder = nil
+            persistedOperationRetry = nil
             self.urlRequest = URLRequest(url: endpoint)
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -89,19 +167,19 @@ extension GraphQLRequest {
                 minifyDocument: minifyDocument
             )
             self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-        case .GETWithAutomaticPersistedOperations(let queryEncoder, let persistRequestBodyEncoder):
-            persistedOperationBodyEncoder = persistRequestBodyEncoder
+        case .GETWithAutomaticPersistedOperations(let queryEncoder, let retryPolicy):
+            persistedOperationRetry = retryPolicy.retry
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    query: query,
-                    automaticPersistedOperations: true,
+                    operation: query,
+                    automaticPersistedOperationPhase: .initialRequestWithHash,
                     minifyDocument: minifyDocument
                 )
             )
             self.urlRequest = URLRequest(url: url)
             self.urlRequest.httpMethod = "GET"
-        case .POSTWithAutomaticPersistedOperations(let bodyEncoder):
-            persistedOperationBodyEncoder = bodyEncoder
+        case .POSTWithAutomaticPersistedOperations(let bodyEncoder, let retryPolicy):
+            persistedOperationRetry = retryPolicy.retry
             self.urlRequest = URLRequest(url: endpoint)
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -115,10 +193,10 @@ extension GraphQLRequest {
         self.endpoint = endpoint
         self.operation = query
         self.minifyDocument = minifyDocument
-        self.persistedOperationBodyEncoder = persistedOperationBodyEncoder
+        self.persistedOperationRetry = persistedOperationRetry
     }
 
-    /// Initializes a POST request for a GraphQL operation.
+    /// Initializes a POST request for a single-response GraphQL operation.
     init(
         operation: Operation,
         endpoint: Foundation.URL,
@@ -126,7 +204,7 @@ extension GraphQLRequest {
         minifyDocument: Bool = true,
         bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
         accept: String = "application/graphql-response+json"
-    ) throws {
+    ) throws where Operation: GraphQLSingleResponseOperation {
         self.urlRequest = URLRequest(url: endpoint)
         self.urlRequest.httpMethod = "POST"
         self.urlRequest.httpBody = try bodyEncoder.encode(
@@ -139,6 +217,59 @@ extension GraphQLRequest {
         self.endpoint = endpoint
         self.operation = operation
         self.minifyDocument = minifyDocument
-        self.persistedOperationBodyEncoder = automaticPersistedOperations ? bodyEncoder : nil
+        self.persistedOperationRetry = automaticPersistedOperations ? .POST(bodyEncoder: bodyEncoder) : nil
+    }
+
+    /// Describes how the `GraphQLRequest` should encode a `GraphQLSubscription` operation into its
+    /// `URLRequest`.
+    enum SubscriptionStrategy {
+
+        /// Instructs the request to be a GET request.
+        case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
+
+        /// Instructs the request to be a POST request.
+        case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+    }
+
+    /// Initializes a new `GraphQLRequest` with a subscription operation
+    /// - Parameters:
+    ///   - subscription: The GraphQLSubscription operation the request is for.
+    ///   - endpoint: The GraphQL server endpoint supporting GraphQL over Server-Sent Events.
+    ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
+    ///   Automatic persisted operations are unavailable because subscription fallback is not supported.
+    ///   - minifyDocument: Whether the query document text should be minified
+    ///   (unnecessary whitespace removed) when sent. `true` by default.
+    init(
+        subscription: Operation,
+        endpoint: URL,
+        strategy: SubscriptionStrategy = .GET(),
+        minifyDocument: Bool = true
+    ) throws where Operation: GraphQLSubscription {
+        switch strategy {
+        case .GET(let queryEncoder):
+            let url = endpoint.appending(
+                queryItems: try queryEncoder.encode(
+                    operation: subscription,
+                    automaticPersistedOperationPhase: nil,
+                    minifyDocument: minifyDocument
+                )
+            )
+            self.urlRequest = URLRequest(url: url)
+            self.urlRequest.httpMethod = "GET"
+        case .POST(let bodyEncoder):
+            self.urlRequest = URLRequest(url: endpoint)
+            self.urlRequest.httpMethod = "POST"
+            self.urlRequest.httpBody = try bodyEncoder.encode(
+                operation: subscription,
+                automaticPersistedOperationPhase: nil,
+                minifyDocument: minifyDocument
+            )
+            self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+        }
+        self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
+        self.endpoint = endpoint
+        self.operation = subscription
+        self.minifyDocument = minifyDocument
+        self.persistedOperationRetry = nil
     }
 }

--- a/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -7,11 +7,11 @@ extension URLSession {
         let response: HTTPURLResponse
     }
 
-    /// Executes a GraphQL operation
+    /// Executes a single-response GraphQL operation.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed.
     ///   - decoder: The function used to turn response data into an Operation.Data instance.
-    func request<Operation: GraphQLOperation>(
+    func request<Operation: GraphQLSingleResponseOperation>(
         _ request: GraphQLRequest<Operation>,
         decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.Success {
@@ -26,9 +26,9 @@ extension URLSession {
                 error.message == "PersistedQueryNotFound"
             }
             if containsPersistedQueryNotFound,
-               let persistedOperationBodyEncoder = request.persistedOperationBodyEncoder {
+               let retry = request.persistedOperationRetry {
                 return try await self.request(
-                    try persistingRequest(request, bodyEncoder: persistedOperationBodyEncoder),
+                    try request.updated(for: retry),
                     decoder: decoder
                 )
             }
@@ -36,23 +36,72 @@ extension URLSession {
         }
     }
 
-    private func persistingRequest<Operation: GraphQLOperation>(
-        _ original: GraphQLRequest<Operation>,
-        bodyEncoder: HTTPBodyEncoder
-    ) throws -> GraphQLRequest<Operation> {
-        var urlRequest = original.urlRequest
-        urlRequest.url = original.endpoint
-        urlRequest.httpBody = try bodyEncoder.encode(
-            operation: original.operation,
-            automaticPersistedOperationPhase: .persistRequestWithDocument,
-            minifyDocument: original.minifyDocument
-        )
-        return GraphQLRequest(
-            urlRequest: urlRequest,
-            endpoint: original.endpoint,
-            operation: original.operation,
-            minifyDocument: original.minifyDocument,
-            persistedOperationBodyEncoder: nil
-        )
+    /// Initiates an event stream using a GraphQL subscription.
+    /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
+    /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode
+    /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
+    /// requests always include the full operation document.
+    /// - Parameters:
+    ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
+    ///   in the "accept" header.
+    ///   - decoder: The function used to turn response data into an Subscription.Data instance.
+    func subscribe<Subscription: GraphQLSubscription>(
+        _ request: GraphQLRequest<Subscription>,
+        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder
+    ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
+        let (asyncBytes, response) = try await bytes(for: request.urlRequest)
+        if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
+            throw HTTPError(response: httpResponse)
+        }
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    var buffer = ServerSentEventBuffer()
+                    for try await byte in asyncBytes {
+                        if let messageData = buffer.append(byte) {
+                            switch try decoder(messageData) {
+                            case .success(let success): continuation.yield(success)
+                            case .requestError(let requestError):
+                                // TODO: Support automatic persisted operation fallback for subscriptions.
+                                throw requestError
+                            }
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    private struct ServerSentEventBuffer {
+        private let newline: UInt8 = 0x0A
+        private let colon: UInt8 = 0x3A
+        private let space: UInt8 = 0x20
+        private let dataKey = Array("data".utf8)
+        private var buffer: [UInt8] = []
+        mutating func append(_ byte: UInt8) -> Data? {
+            buffer.append(byte)
+            guard let range = buffer.lastRange(of: [newline, newline]) else { return nil }
+            let messageData = buffer[..<range.lowerBound]
+            buffer.removeSubrange(..<range.upperBound)
+            let lines = messageData.split(separator: newline)
+            for line in lines where !line.isEmpty {
+                let parts = line.split(separator: colon, maxSplits: 1)
+                switch parts.count {
+                case 1: return Data(parts[0].trimmingPrefix([space]))
+                case 2:
+                    if Array(parts[0]) == dataKey {
+                        return Data(parts[1].trimmingPrefix([space]))
+                    }
+                default: break
+                }
+            }
+            return nil
+        }
     }
 }

--- a/Sources/StarwarsExample/Codegen.swift
+++ b/Sources/StarwarsExample/Codegen.swift
@@ -20,7 +20,10 @@ struct StarwarsCodegen {
                     ),
                     api: .api(
                         directory: currentFileDirectory.appending(path: "API", directoryHint: .isDirectory),
-                        HTTPSupport: .httpSupport(enableGETQueries: true)
+                        HTTPSupport: .httpSupport(
+                            enableGETQueries: true,
+                            subscriptionSupport: true
+                        )
                     )
                 )
             )

--- a/Sources/StarwarsExample/Operations/FavoriteEpisodeChangedSubscription.graphql
+++ b/Sources/StarwarsExample/Operations/FavoriteEpisodeChangedSubscription.graphql
@@ -1,0 +1,3 @@
+subscription FavoriteEpisodeChanged {
+  favoriteEpisodeChanged
+}

--- a/Sources/StarwarsExample/Operations/FavoriteEpisodeChangedSubscription.graphql.swift
+++ b/Sources/StarwarsExample/Operations/FavoriteEpisodeChangedSubscription.graphql.swift
@@ -1,0 +1,30 @@
+// @generated
+
+struct FavoriteEpisodeChangedSubscription: GraphQLSubscription {
+
+    static let operationName: String? = "FavoriteEpisodeChanged"
+
+    static let document = #"""
+    subscription FavoriteEpisodeChanged {
+      favoriteEpisodeChanged
+    }
+    """#
+
+    static let minifiedDocument = #"""
+    subscription FavoriteEpisodeChanged{favoriteEpisodeChanged}
+    """#
+
+    let variables: Never? = nil
+
+    let extensions: [String: AnyEncodable]?
+
+    init(extensions: [String: AnyEncodable]? = nil) {
+        self.extensions = extensions
+    }
+
+    struct Data: Decodable, Sendable, Hashable {
+
+        let favoriteEpisodeChanged: GraphQLEnum<Episode>
+    }
+}
+

--- a/Sources/StarwarsExample/Operations/SetFavoriteEpisodeMutation.graphql
+++ b/Sources/StarwarsExample/Operations/SetFavoriteEpisodeMutation.graphql
@@ -1,0 +1,3 @@
+mutation SetFavoriteEpisode($episode: Episode!) {
+  setFavoriteEpisode(episode: $episode)
+}

--- a/Sources/StarwarsExample/Operations/SetFavoriteEpisodeMutation.graphql.swift
+++ b/Sources/StarwarsExample/Operations/SetFavoriteEpisodeMutation.graphql.swift
@@ -1,0 +1,41 @@
+// @generated
+
+struct SetFavoriteEpisodeMutation: GraphQLMutation {
+
+    static let operationName: String? = "SetFavoriteEpisode"
+
+    static let document = #"""
+    mutation SetFavoriteEpisode($episode: Episode!) {
+      setFavoriteEpisode(episode: $episode)
+    }
+    """#
+
+    static let minifiedDocument = #"""
+    mutation SetFavoriteEpisode($episode:Episode!){setFavoriteEpisode(episode:$episode)}
+    """#
+
+    let variables: Variables
+
+    let extensions: [String: AnyEncodable]?
+
+    init(
+        episode: Episode,
+        extensions: [String: AnyEncodable]? = nil
+    ) {
+        self.variables = Variables(
+            episode: episode
+        )
+        self.extensions = extensions
+    }
+
+    struct Variables: Encodable, Sendable {
+
+        let episode: Episode
+    }
+
+    struct Data: Decodable, Sendable, Hashable {
+
+        let setFavoriteEpisode: GraphQLEnum<Episode>
+    }
+}
+

--- a/Sources/StarwarsExample/schema.sdl
+++ b/Sources/StarwarsExample/schema.sdl
@@ -2,6 +2,14 @@ type Query {
   hero(episode: Episode): Character!
 }
 
+type Mutation {
+  setFavoriteEpisode(episode: Episode!): Episode!
+}
+
+type Subscription {
+  favoriteEpisodeChanged: Episode!
+}
+
 interface Character {
   id: ID!
   name: String!


### PR DESCRIPTION
## Summary

- model automatic persisted-operation fallback as an explicit GET or POST retry policy
- defer GET retry encoding until the server reports `PersistedQueryNotFound`
- preserve custom POST encoders and prevent repeated fallback attempts
- explicitly exclude subscriptions from automatic persisted-operation fallback
- distinguish single-response operations from subscriptions in generated APIs
- add compiled mutation and subscription fixtures plus retry behavior tests

## Why

The previous fallback path always rebuilt the request as a POST and could silently replace encoder behavior. It also allowed generated subscription APIs to imply fallback support even though subscription retries were not applied.

## Impact

Clients can now choose GET or POST fallback explicitly. GET remains opt-in for the full document, while the default GET APQ flow retries with POST. Subscription requests always send their full operation document and document automatic fallback as unsupported.

## Validation

- rebased onto latest `origin/main`
- `swift test` — 13 tests passed across 5 suites
- generated Starwars fixture reproduced after conflict resolution
