### PR TITLE
Make SSE subscriptions standards-compliant and bounded

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,25 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 
 The code generator runs on macOS 14 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation. The generated source uses portable Foundation APIs and can be included in iOS, macOS, tvOS, and watchOS applications, subject to the APIs enabled in your configuration.
 
+## Server-Sent Events trust requirement
+
+Only use the generated GraphQL subscription API with a trusted server. Its Foundation-based SSE parser accepts LF, CRLF, and CR line
+endings and bounds both complete event payloads and decoded results waiting for the consumer. The parser buffers bytes until an
+SSE line terminator arrives, however, so the server must not send an arbitrarily long unterminated line. This is an explicit trust
+boundary rather than protection against a malicious or compromised subscription endpoint.
+
 ---
 
 ## Table of Contents
+
 1. [Platform Support](#platform-support)
-2. [Getting Started](#getting-started)
-3. [Example](#example-output)
-4. [Motivation](#motivation)
-5. [Design](#design)
-6. [Contributing](#contributing)
-7. [License](#license)
+2. [Server-Sent Events trust requirement](#server-sent-events-trust-requirement)
+3. [Getting Started](#getting-started)
+4. [Example](#example-output)
+5. [Motivation](#motivation)
+6. [Design](#design)
+7. [Contributing](#contributing)
+8. [License](#license)
 
 ---
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
@@ -16,7 +16,8 @@ extension Configuration.Output.API {
         ///   - subscriptionSupport: Pass `true` to enable support for subscription operations via GraphQL over Server-Sent Events:
         ///   https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#distinct-connections-mode. If your
         ///   graphql documents include one or more subscription operations, this will add a `subscribe` function to the generated URLSession
-        ///   extension.
+        ///   extension. Only enable this for trusted GraphQL servers. The generated implementation buffers each SSE line until its
+        ///   terminator arrives, so an arbitrarily long unterminated line may be buffered indefinitely.
         /// - Returns: A new `HTTPSupport` instance to be passed to the `API.api` factory function.
         public static func httpSupport(
             enableGETQueries: Bool = false,

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -179,6 +179,7 @@ struct URLSessionWriter {
             }
 
             private struct ServerSentEventAccumulator {
+                private let dataFieldSeparator: UInt8 = 0x0A
                 private var data = Data()
                 private var hasDataField = false
                 private var isFirstLine = true
@@ -225,7 +226,7 @@ struct URLSessionWriter {
                             throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                         }
                         if hasDataField {
-                            data.append(0x0A)
+                            data.append(dataFieldSeparator)
                         }
                         data.append(contentsOf: value.utf8)
                         hasDataField = true

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -86,34 +86,83 @@ struct URLSessionWriter {
         return """
 
 
+            \(accessLevel)enum SubscriptionError: Error {
+                case eventTooLarge(maximumByteCount: Int)
+                case invalidContentType(String?)
+                case invalidMaximumBufferedResultCount(Int)
+                case invalidMaximumEventByteCount(Int)
+                case invalidUTF8
+                case missingCompleteEvent
+                case resultBufferOverflow(maximumBufferedResultCount: Int)
+            }
+
             /// Initiates an event stream using a GraphQL subscription.
             /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
             /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode\(automaticPersistedOperationSubscriptionDocumentation())
+            ///
+            /// Only use this API with a trusted GraphQL server. The parser buffers input until it encounters an SSE line
+            /// terminator, so the server must not send an arbitrarily long unterminated line. Complete events and queued
+            /// results remain bounded by `maximumEventByteCount` and `maximumBufferedResultCount`, respectively.
             /// - Parameters:
-            ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
-            ///   in the "accept" header.
-            ///   - decoder: The function used to turn response data into an Subscription.Data instance.
+            ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
+            ///   `text/event-stream` set in the "accept" header.
+            ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+            ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
+            ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
             \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
-                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder
+                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+                maximumEventByteCount: Int = 1_048_576,
+                maximumBufferedResultCount: Int = 16
             ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
+                guard maximumEventByteCount > 0 else {
+                    throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
+                }
+                guard maximumBufferedResultCount > 0 else {
+                    throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
+                }
                 let (asyncBytes, response) = try await bytes(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
                     throw HTTPError(response: httpResponse)
                 }
-                return AsyncThrowingStream { continuation in
+                guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
+                    throw SubscriptionError.invalidContentType(response.mimeType)
+                }
+                return AsyncThrowingStream(
+                    bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
+                ) { continuation in
                     let task = Task {
                         do {
-                            var buffer = ServerSentEventBuffer()
+                            var accumulator = ServerSentEventAccumulator()
+                            var lineBuffer = ServerSentEventLineBuffer()
                             for try await byte in asyncBytes {
-                                if let messageData = buffer.append(byte) {
-                                    switch try decoder(messageData) {
-                                    case .success(let success): continuation.yield(success)
+                                guard let line = try lineBuffer.append(byte) else { continue }
+                                guard let event = try accumulator.consume(
+                                    line,
+                                    maximumByteCount: maximumEventByteCount
+                                ) else { continue }
+                                switch event.name {
+                                case "next":
+                                    switch try decoder(event.data) {
+                                    case .success(let success):
+                                        switch continuation.yield(success) {
+                                        case .enqueued: break
+                                        case .dropped:
+                                            throw SubscriptionError.resultBufferOverflow(
+                                                maximumBufferedResultCount: maximumBufferedResultCount
+                                            )
+                                        case .terminated: return
+                                        @unknown default: return
+                                        }
                                     \(subscriptionRequestErrorHandling())
-                                    }
+                                }
+                                case "complete":
+                                    continuation.finish()
+                                    return
+                                default: continue
                                 }
                             }
-                            continuation.finish()
+                            throw SubscriptionError.missingCompleteEvent
                         } catch {
                             continuation.finish(throwing: error)
                         }
@@ -124,30 +173,107 @@ struct URLSessionWriter {
                 }
             }
 
-            private struct ServerSentEventBuffer {
-                private let newline: UInt8 = 0x0A
-                private let colon: UInt8 = 0x3A
-                private let space: UInt8 = 0x20
-                private let dataKey = Array("data".utf8)
-                private var buffer: [UInt8] = []
-                mutating func append(_ byte: UInt8) -> Data? {
-                    buffer.append(byte)
-                    guard let range = buffer.lastRange(of: [newline, newline]) else { return nil }
-                    let messageData = buffer[..<range.lowerBound]
-                    buffer.removeSubrange(..<range.upperBound)
-                    let lines = messageData.split(separator: newline)
-                    for line in lines where !line.isEmpty {
-                        let parts = line.split(separator: colon, maxSplits: 1)
-                        switch parts.count {
-                        case 1: return Data(parts[0].trimmingPrefix([space]))
-                        case 2:
-                            if Array(parts[0]) == dataKey {
-                                return Data(parts[1].trimmingPrefix([space]))
-                            }
-                        default: break
+            private struct ServerSentEvent {
+                let data: Data
+                let name: String
+            }
+
+            private struct ServerSentEventAccumulator {
+                private var data = Data()
+                private var hasDataField = false
+                private var isFirstLine = true
+                private var name = "message"
+
+                mutating func consume(
+                    _ line: String,
+                    maximumByteCount: Int
+                ) throws -> ServerSentEvent? {
+                    var line = line
+                    if isFirstLine {
+                        isFirstLine = false
+                        if line.first == "\\u{FEFF}" {
+                            line.removeFirst()
                         }
                     }
+                    guard !line.isEmpty else {
+                        defer { reset() }
+                        guard hasDataField else { return nil }
+                        return ServerSentEvent(data: data, name: name)
+                    }
+                    guard !line.hasPrefix(":") else { return nil }
+
+                    let field: Substring
+                    let value: Substring
+                    if let colonIndex = line.firstIndex(of: ":") {
+                        field = line[..<colonIndex]
+                        let valueStartIndex = line.index(after: colonIndex)
+                        let untrimmedValue = line[valueStartIndex...]
+                        value = untrimmedValue.first == " " ? untrimmedValue.dropFirst() : untrimmedValue
+                    } else {
+                        field = line[...]
+                        value = line[line.endIndex...]
+                    }
+
+                    switch field {
+                    case "data":
+                        let separatorByteCount = hasDataField ? 1 : 0
+                        guard data.count <= maximumByteCount - separatorByteCount else {
+                            throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
+                        }
+                        let remainingByteCount = maximumByteCount - separatorByteCount - data.count
+                        guard value.utf8.count <= remainingByteCount else {
+                            throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
+                        }
+                        if hasDataField {
+                            data.append(0x0A)
+                        }
+                        data.append(contentsOf: value.utf8)
+                        hasDataField = true
+                    case "event":
+                        name = String(value)
+                    default: break
+                    }
                     return nil
+                }
+
+                private mutating func reset() {
+                    data.removeAll(keepingCapacity: true)
+                    hasDataField = false
+                    name = "message"
+                }
+            }
+
+            /// Preserves empty lines because Foundation's `AsyncLineSequence` omits them and SSE uses them as event
+            /// delimiters.
+            private struct ServerSentEventLineBuffer {
+                private let carriageReturn: UInt8 = 0x0D
+                private let lineFeed: UInt8 = 0x0A
+                private var buffer: [UInt8] = []
+                private var previousByteWasCarriageReturn = false
+
+                mutating func append(_ byte: UInt8) throws -> String? {
+                    if byte == lineFeed {
+                        if previousByteWasCarriageReturn {
+                            previousByteWasCarriageReturn = false
+                            return nil
+                        }
+                        return try takeLine()
+                    }
+                    previousByteWasCarriageReturn = false
+                    if byte == carriageReturn {
+                        previousByteWasCarriageReturn = true
+                        return try takeLine()
+                    }
+                    buffer.append(byte)
+                    return nil
+                }
+
+                private mutating func takeLine() throws -> String {
+                    defer { buffer.removeAll(keepingCapacity: true) }
+                    guard let line = String(bytes: buffer, encoding: .utf8) else {
+                        throw SubscriptionError.invalidUTF8
+                    }
+                    return line
                 }
             }
         """

--- a/Sources/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -320,16 +320,16 @@ struct ServerSentEventTests {
         let process = Process()
         process.executableURL = executableURL
         process.arguments = arguments
-        let output = Pipe()
-        process.standardError = output
-        process.standardOutput = output
+        let outputPipe = Pipe()
+        process.standardError = outputPipe
+        process.standardOutput = outputPipe
         try process.run()
-        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
+        let output = try #require(String(bytes: data, encoding: .utf8))
         return (
             status: process.terminationStatus,
-            output: String(decoding: data, as: UTF8.self)
+            output: output
         )
     }
-
 }

--- a/Sources/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Sources/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -1,0 +1,335 @@
+import Foundation
+import GraphQLCodegen
+import Testing
+
+struct ServerSentEventTests {
+    @Test
+    func testGeneratedServerSentEventSupportPreservesCriticalInvariants() async throws {
+        let generatedDirectory = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: generatedDirectory, withIntermediateDirectories: true)
+        defer {
+            // Best-effort test cleanup; retaining a temporary directory does not affect test behavior.
+            try? FileManager.default.removeItem(at: generatedDirectory)
+        }
+        let schemaURL = generatedDirectory.appending(path: "schema.sdl", directoryHint: .notDirectory)
+        try """
+        schema {
+          query: Query
+          subscription: Subscription
+        }
+
+        type Query {
+          value: String!
+        }
+
+        type Subscription {
+          updates: String!
+        }
+        """.write(to: schemaURL, atomically: true, encoding: .utf8)
+        let operationsDirectory = generatedDirectory.appending(path: "Operations", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: operationsDirectory, withIntermediateDirectories: true)
+        try """
+        subscription Updates {
+          updates
+        }
+        """.write(
+            to: operationsDirectory.appending(path: "Updates.graphql", directoryHint: .notDirectory),
+            atomically: true,
+            encoding: .utf8
+        )
+        let apiDirectory = generatedDirectory.appending(path: "API", directoryHint: .isDirectory)
+        try await Codegen(
+            .configuration(
+                input: .input(
+                    schemaSource: .SDLSchemaFile(schemaURL),
+                    documentDirectories: [operationsDirectory]
+                ),
+                output: .output(
+                    schema: .schema(
+                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
+                    ),
+                    documents: .documents(directory: .directory(operationsDirectory)),
+                    api: .api(
+                        directory: apiDirectory,
+                        HTTPSupport: .httpSupport(subscriptionSupport: true)
+                    )
+                )
+            )
+        ).run()
+
+        let output = try String(
+            contentsOf: apiDirectory.appending(
+                path: "HTTPSupport/URLSession+GraphQL.swift",
+                directoryHint: .notDirectory
+            ),
+            encoding: .utf8
+        )
+        #expect(output.contains("Only use this API with a trusted GraphQL server"))
+
+        try #"""
+        import Dispatch
+        import Foundation
+
+        final class SubscriptionURLProtocol: URLProtocol {
+            override class func canInit(with request: URLRequest) -> Bool {
+                true
+            }
+
+            override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+                request
+            }
+
+            override func startLoading() {
+                guard let url = request.url else {
+                    client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+                    return
+                }
+                let body: String
+                switch url.path {
+                case "/standards":
+                    body = "\u{FEFF}event: next\r\ndata: {\"data\":\rdata: {\"updates\":\"first\"}}\n\r\nevent: complete\rdata:\r\r"
+                case "/missing-complete":
+                    body = "event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\n"
+                case "/oversized":
+                    body = "event: next\ndata: {\"data\":{\"updates\":\"too large\"}}\n\n"
+                case "/overflow":
+                    body = "event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\nevent: next\ndata: {\"data\":{\"updates\":\"second\"}}\n\nevent: complete\ndata:\n\n"
+                default:
+                    client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+                    return
+                }
+                let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "text/event-stream"]
+                )!
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: Data(body.utf8))
+                client?.urlProtocolDidFinishLoading(self)
+            }
+
+            override func stopLoading() {}
+        }
+
+        final class DroppedResultSignal: @unchecked Sendable {
+            let semaphore: DispatchSemaphore
+
+            init(semaphore: DispatchSemaphore) {
+                self.semaphore = semaphore
+            }
+
+            deinit {
+                semaphore.signal()
+            }
+        }
+
+        final class OverflowProbeData: Decodable, @unchecked Sendable {
+            let droppedResultSignal: DroppedResultSignal?
+
+            init(droppedResultSignal: DroppedResultSignal?) {
+                self.droppedResultSignal = droppedResultSignal
+            }
+
+            init(from decoder: Decoder) throws {
+                droppedResultSignal = nil
+            }
+        }
+
+        struct OverflowProbeSubscription: GraphQLSubscription {
+            static let operationName: String? = "OverflowProbe"
+            static let document = "subscription OverflowProbe { updates }"
+            static let minifiedDocument = document
+
+            let variables: Never? = nil
+            let extensions: [String: AnyEncodable]? = nil
+
+            typealias Data = OverflowProbeData
+            typealias Variables = Never?
+        }
+
+        enum VerificationError: Error {
+            case failed(String)
+        }
+
+        @main
+        struct SubscriptionHarness {
+            static func main() async throws {
+                let harness = SubscriptionHarness()
+                do {
+                    try await harness.verifyStandardsParsingAndCompletion()
+                } catch {
+                    throw VerificationError.failed("Standards verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyMissingCompletionFails()
+                } catch {
+                    throw VerificationError.failed("Completion verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyEventSizeIsBounded()
+                } catch {
+                    throw VerificationError.failed("Event size verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyResultBufferIsBounded()
+                } catch {
+                    throw VerificationError.failed("Result buffer verification failed: \(error)")
+                }
+            }
+
+            private func makeRequest(path: String) throws -> GraphQLRequest<UpdatesSubscription> {
+                try GraphQLRequest(
+                    subscription: UpdatesSubscription(),
+                    endpoint: URL(string: "https://subscriptions.test/\(path)")!
+                )
+            }
+
+            private func makeSession() -> URLSession {
+                let configuration = URLSessionConfiguration.ephemeral
+                configuration.protocolClasses = [SubscriptionURLProtocol.self]
+                return URLSession(configuration: configuration)
+            }
+
+            private func verifyStandardsParsingAndCompletion() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                let stream = try await session.subscribe(try makeRequest(path: "standards"))
+                var values: [String] = []
+                for try await response in stream {
+                    values.append(response.data.updates)
+                }
+                guard values == ["first"] else {
+                    throw VerificationError.failed("Standards-compliant event was not decoded")
+                }
+            }
+
+            private func verifyMissingCompletionFails() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                do {
+                    let stream = try await session.subscribe(try makeRequest(path: "missing-complete"))
+                    for try await _ in stream {}
+                    throw VerificationError.failed("Missing complete event succeeded")
+                } catch URLSession.SubscriptionError.missingCompleteEvent {}
+            }
+
+            private func verifyEventSizeIsBounded() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                do {
+                    let stream = try await session.subscribe(
+                        try makeRequest(path: "oversized"),
+                        maximumEventByteCount: 8
+                    )
+                    for try await _ in stream {}
+                    throw VerificationError.failed("Oversized event succeeded")
+                } catch URLSession.SubscriptionError.eventTooLarge(let maximumByteCount) {
+                    guard maximumByteCount == 8 else {
+                        throw VerificationError.failed("Event limit error contained the wrong limit")
+                    }
+                }
+            }
+
+            private func verifyResultBufferIsBounded() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                let droppedResult = DispatchSemaphore(value: 0)
+                let request = try GraphQLRequest(
+                    subscription: OverflowProbeSubscription(),
+                    endpoint: URL(string: "https://subscriptions.test/overflow")!
+                )
+                let stream = try await session.subscribe(
+                    request,
+                    decoder: { data in
+                        let text = String(decoding: data, as: UTF8.self)
+                        let signal =
+                            text.contains("second") ? DroppedResultSignal(semaphore: droppedResult) : nil
+                        return .success(
+                            GraphQLResponse<OverflowProbeData>.Success(
+                                data: OverflowProbeData(droppedResultSignal: signal),
+                                fieldErrors: nil,
+                                extensions: nil
+                            )
+                        )
+                    },
+                    maximumBufferedResultCount: 1
+                )
+                guard await waitForSignal(droppedResult) else {
+                    throw VerificationError.failed("Timed out waiting for result buffer overflow")
+                }
+                do {
+                    for try await _ in stream {}
+                    throw VerificationError.failed("Result buffer overflow succeeded")
+                } catch URLSession.SubscriptionError.resultBufferOverflow(let maximumBufferedResultCount) {
+                    guard maximumBufferedResultCount == 1 else {
+                        throw VerificationError.failed("Buffer overflow error contained the wrong limit")
+                    }
+                }
+            }
+
+            private func waitForSignal(_ semaphore: DispatchSemaphore) async -> Bool {
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().async {
+                        let result = semaphore.wait(timeout: .now() + 30)
+                        continuation.resume(returning: result == .success)
+                    }
+                }
+            }
+        }
+        """#.write(
+            to: generatedDirectory.appending(path: "SubscriptionHarness.swift", directoryHint: .notDirectory),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        var swiftSourcePaths: [String] = []
+        if let enumerator = FileManager.default.enumerator(
+            at: generatedDirectory,
+            includingPropertiesForKeys: nil
+        ) {
+            while let sourceURL = enumerator.nextObject() as? URL {
+                guard sourceURL.pathExtension == "swift" else { continue }
+                swiftSourcePaths.append(sourceURL.path(percentEncoded: false))
+            }
+        }
+        let executableURL = generatedDirectory.appending(
+            path: "SubscriptionHarness",
+            directoryHint: .notDirectory
+        )
+        let compilation = try run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/xcrun"),
+            arguments: [
+                "swiftc",
+                "-swift-version", "6",
+                "-o", executableURL.path(percentEncoded: false),
+            ] + swiftSourcePaths
+        )
+        try #require(compilation.status == 0, Comment(rawValue: compilation.output))
+        let verification = try run(executableURL: executableURL, arguments: [])
+        #expect(verification.status == 0, Comment(rawValue: verification.output))
+    }
+
+    private func run(
+        executableURL: URL,
+        arguments: [String]
+    ) throws -> (status: Int32, output: String) {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        let output = Pipe()
+        process.standardError = output
+        process.standardOutput = output
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return (
+            status: process.terminationStatus,
+            output: String(decoding: data, as: UTF8.self)
+        )
+    }
+
+}

--- a/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -133,6 +133,7 @@ extension URLSession {
     }
 
     private struct ServerSentEventAccumulator {
+        private let dataFieldSeparator: UInt8 = 0x0A
         private var data = Data()
         private var hasDataField = false
         private var isFirstLine = true
@@ -179,7 +180,7 @@ extension URLSession {
                     throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                 }
                 if hasDataField {
-                    data.append(0x0A)
+                    data.append(dataFieldSeparator)
                 }
                 data.append(contentsOf: value.utf8)
                 hasDataField = true

--- a/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -36,38 +36,87 @@ extension URLSession {
         }
     }
 
+    enum SubscriptionError: Error {
+        case eventTooLarge(maximumByteCount: Int)
+        case invalidContentType(String?)
+        case invalidMaximumBufferedResultCount(Int)
+        case invalidMaximumEventByteCount(Int)
+        case invalidUTF8
+        case missingCompleteEvent
+        case resultBufferOverflow(maximumBufferedResultCount: Int)
+    }
+
     /// Initiates an event stream using a GraphQL subscription.
     /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
     /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode
     /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
     /// requests always include the full operation document.
+    ///
+    /// Only use this API with a trusted GraphQL server. The parser buffers input until it encounters an SSE line
+    /// terminator, so the server must not send an arbitrarily long unterminated line. Complete events and queued
+    /// results remain bounded by `maximumEventByteCount` and `maximumBufferedResultCount`, respectively.
     /// - Parameters:
-    ///   - request: The  request containing the `URLRequest` to be performed. The `URLRequest` must have `text/event-stream` set
-    ///   in the "accept" header.
-    ///   - decoder: The function used to turn response data into an Subscription.Data instance.
+    ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
+    ///   `text/event-stream` set in the "accept" header.
+    ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+    ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
+    ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
     func subscribe<Subscription: GraphQLSubscription>(
         _ request: GraphQLRequest<Subscription>,
-        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder
+        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+        maximumEventByteCount: Int = 1_048_576,
+        maximumBufferedResultCount: Int = 16
     ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
+        guard maximumEventByteCount > 0 else {
+            throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
+        }
+        guard maximumBufferedResultCount > 0 else {
+            throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
+        }
         let (asyncBytes, response) = try await bytes(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
             throw HTTPError(response: httpResponse)
         }
-        return AsyncThrowingStream { continuation in
+        guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
+            throw SubscriptionError.invalidContentType(response.mimeType)
+        }
+        return AsyncThrowingStream(
+            bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
+        ) { continuation in
             let task = Task {
                 do {
-                    var buffer = ServerSentEventBuffer()
+                    var accumulator = ServerSentEventAccumulator()
+                    var lineBuffer = ServerSentEventLineBuffer()
                     for try await byte in asyncBytes {
-                        if let messageData = buffer.append(byte) {
-                            switch try decoder(messageData) {
-                            case .success(let success): continuation.yield(success)
+                        guard let line = try lineBuffer.append(byte) else { continue }
+                        guard let event = try accumulator.consume(
+                            line,
+                            maximumByteCount: maximumEventByteCount
+                        ) else { continue }
+                        switch event.name {
+                        case "next":
+                            switch try decoder(event.data) {
+                            case .success(let success):
+                                switch continuation.yield(success) {
+                                case .enqueued: break
+                                case .dropped:
+                                    throw SubscriptionError.resultBufferOverflow(
+                                        maximumBufferedResultCount: maximumBufferedResultCount
+                                    )
+                                case .terminated: return
+                                @unknown default: return
+                                }
                             case .requestError(let requestError):
                                 // TODO: Support automatic persisted operation fallback for subscriptions.
                                 throw requestError
-                            }
+                        }
+                        case "complete":
+                            continuation.finish()
+                            return
+                        default: continue
                         }
                     }
-                    continuation.finish()
+                    throw SubscriptionError.missingCompleteEvent
                 } catch {
                     continuation.finish(throwing: error)
                 }
@@ -78,30 +127,107 @@ extension URLSession {
         }
     }
 
-    private struct ServerSentEventBuffer {
-        private let newline: UInt8 = 0x0A
-        private let colon: UInt8 = 0x3A
-        private let space: UInt8 = 0x20
-        private let dataKey = Array("data".utf8)
-        private var buffer: [UInt8] = []
-        mutating func append(_ byte: UInt8) -> Data? {
-            buffer.append(byte)
-            guard let range = buffer.lastRange(of: [newline, newline]) else { return nil }
-            let messageData = buffer[..<range.lowerBound]
-            buffer.removeSubrange(..<range.upperBound)
-            let lines = messageData.split(separator: newline)
-            for line in lines where !line.isEmpty {
-                let parts = line.split(separator: colon, maxSplits: 1)
-                switch parts.count {
-                case 1: return Data(parts[0].trimmingPrefix([space]))
-                case 2:
-                    if Array(parts[0]) == dataKey {
-                        return Data(parts[1].trimmingPrefix([space]))
-                    }
-                default: break
+    private struct ServerSentEvent {
+        let data: Data
+        let name: String
+    }
+
+    private struct ServerSentEventAccumulator {
+        private var data = Data()
+        private var hasDataField = false
+        private var isFirstLine = true
+        private var name = "message"
+
+        mutating func consume(
+            _ line: String,
+            maximumByteCount: Int
+        ) throws -> ServerSentEvent? {
+            var line = line
+            if isFirstLine {
+                isFirstLine = false
+                if line.first == "\u{FEFF}" {
+                    line.removeFirst()
                 }
             }
+            guard !line.isEmpty else {
+                defer { reset() }
+                guard hasDataField else { return nil }
+                return ServerSentEvent(data: data, name: name)
+            }
+            guard !line.hasPrefix(":") else { return nil }
+
+            let field: Substring
+            let value: Substring
+            if let colonIndex = line.firstIndex(of: ":") {
+                field = line[..<colonIndex]
+                let valueStartIndex = line.index(after: colonIndex)
+                let untrimmedValue = line[valueStartIndex...]
+                value = untrimmedValue.first == " " ? untrimmedValue.dropFirst() : untrimmedValue
+            } else {
+                field = line[...]
+                value = line[line.endIndex...]
+            }
+
+            switch field {
+            case "data":
+                let separatorByteCount = hasDataField ? 1 : 0
+                guard data.count <= maximumByteCount - separatorByteCount else {
+                    throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
+                }
+                let remainingByteCount = maximumByteCount - separatorByteCount - data.count
+                guard value.utf8.count <= remainingByteCount else {
+                    throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
+                }
+                if hasDataField {
+                    data.append(0x0A)
+                }
+                data.append(contentsOf: value.utf8)
+                hasDataField = true
+            case "event":
+                name = String(value)
+            default: break
+            }
             return nil
+        }
+
+        private mutating func reset() {
+            data.removeAll(keepingCapacity: true)
+            hasDataField = false
+            name = "message"
+        }
+    }
+
+    /// Preserves empty lines because Foundation's `AsyncLineSequence` omits them and SSE uses them as event
+    /// delimiters.
+    private struct ServerSentEventLineBuffer {
+        private let carriageReturn: UInt8 = 0x0D
+        private let lineFeed: UInt8 = 0x0A
+        private var buffer: [UInt8] = []
+        private var previousByteWasCarriageReturn = false
+
+        mutating func append(_ byte: UInt8) throws -> String? {
+            if byte == lineFeed {
+                if previousByteWasCarriageReturn {
+                    previousByteWasCarriageReturn = false
+                    return nil
+                }
+                return try takeLine()
+            }
+            previousByteWasCarriageReturn = false
+            if byte == carriageReturn {
+                previousByteWasCarriageReturn = true
+                return try takeLine()
+            }
+            buffer.append(byte)
+            return nil
+        }
+
+        private mutating func takeLine() throws -> String {
+            defer { buffer.removeAll(keepingCapacity: true) }
+            guard let line = String(bytes: buffer, encoding: .utf8) else {
+                throw SubscriptionError.invalidUTF8
+            }
+            return line
         }
     }
 }


### PR DESCRIPTION
## Summary

- Parse SSE framing across LF, CRLF, and CR line endings, including BOM and multiline `data` fields.
- Bound complete-event payloads and queued decoded results, validate the response content type, and report premature stream completion.
- Document the trusted-server requirement for unterminated SSE lines.
- Add a deterministic generated-client integration harness for critical parser and buffering invariants.

## Why

The previous parser recognized only LF/LF framing, returned only one `data:` line, and allowed event/result buffering to grow without a defined bound. Foundation's line sequence cannot replace the custom parser because it omits the empty lines that delimit SSE events.

## Impact

Generated subscription clients remain dependency-free. Existing `subscribe` calls remain source-compatible through default limits. Invalid content, malformed input, overflows, and streams missing a `complete` event now produce typed `SubscriptionError` values.

## Validation

- `swift test`
- Generated client compiled and exercised by `ServerSentEventTests`
