### PR TITLE
Plan output before rendering Swift type references

### DIFF
--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -41,33 +41,17 @@ public struct Codegen: Sendable {
             schema: loadedSchema.schema,
             documents: documents
         ).resolve()
+        let outputPlan = try CodegenOutputPlan(
+            configuration: configuration,
+            documents: documents,
+            resolvedDocuments: resolvedDocuments,
+            schema: loadedSchema.schema
+        )
 
         // Output
         let fileOutput = FileOutput()
         do {
-            try await DocumentsWriter(
-                configuration: configuration,
-                resolvedDocuments: resolvedDocuments
-            ).write(using: fileOutput)
-            try await SchemaWriter(
-                configuration: configuration,
-                schema: loadedSchema.schema,
-                resolvedDocuments: resolvedDocuments
-            ).write(using: fileOutput)
-            try await APIWriter(
-                configuration: configuration,
-                hasMutation: resolvedDocuments.hasMutation,
-                hasSubscription: resolvedDocuments.hasSubscription,
-                requiresIndirectNullable: resolvedDocuments.requiresIndirectNullable
-            ).write(using: fileOutput)
-            switch configuration.output.documents.operations.persistedOperations {
-            case .registered(let manifestURL):
-                try await PersistedOperationManifestWriter(
-                    manifestURL: manifestURL,
-                    documents: documents
-                ).write(using: fileOutput)
-            case .automatic, .none: break
-            }
+            try await outputPlan.write(using: fileOutput)
         } catch {
             let generationError = error
             do {

--- a/Sources/GraphQLCodegen/Helpers/Configuration+OperationConformances.swift
+++ b/Sources/GraphQLCodegen/Helpers/Configuration+OperationConformances.swift
@@ -1,0 +1,12 @@
+extension Configuration {
+    func operationConformances(for operationType: GraphQLAST.OperationType) -> [String] {
+        var conformances = output.documents.operations.conformances
+        guard output.api.HTTPSupport != nil else { return conformances }
+        switch operationType {
+        case .query: conformances.append("GraphQLQuery")
+        case .mutation: conformances.append("GraphQLMutation")
+        case .subscription: conformances.append("GraphQLSubscription")
+        }
+        return conformances
+    }
+}

--- a/Sources/GraphQLCodegen/Helpers/SwiftConformanceName.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftConformanceName.swift
@@ -1,0 +1,41 @@
+struct SwiftConformanceName {
+    private static let standardLibraryNames: Set<String> = [
+        "CaseIterable",
+        "Codable",
+        "CodingKey",
+        "Comparable",
+        "CustomStringConvertible",
+        "Decodable",
+        "Encodable",
+        "Equatable",
+        "Error",
+        "Hashable",
+        "Identifiable",
+        "OptionSet",
+        "RawRepresentable",
+        "Sendable",
+    ]
+
+    let source: String
+
+    var standardLibraryReference: SwiftTypeReference? {
+        let name = source.hasPrefix("Swift.") ? String(source.dropFirst("Swift.".count)) : source
+        guard Self.standardLibraryNames.contains(name) else { return nil }
+        return SwiftTypeReference(.swift, name)
+    }
+
+    var includesDecodable: Bool {
+        switch source {
+        case "Codable", "Decodable", "Swift.Codable", "Swift.Decodable": true
+        default: false
+        }
+    }
+
+    var usesCodingKeys: Bool {
+        switch source {
+        case "Codable", "Decodable", "Encodable",
+             "Swift.Codable", "Swift.Decodable", "Swift.Encodable": true
+        default: false
+        }
+    }
+}

--- a/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
@@ -1,0 +1,43 @@
+struct SwiftTypeIdentifier: Hashable {
+    static let codingKeys = SwiftTypeIdentifier(swiftName: "CodingKeys")
+    static let data = SwiftTypeIdentifier(swiftName: "Data")
+    static let swiftModule = SwiftTypeIdentifier(swiftName: "Swift")
+    static let variables = SwiftTypeIdentifier(swiftName: "Variables")
+
+    let unescaped: String
+
+    init(capitalizing graphQLName: String) {
+        unescaped = graphQLName.capitalizedFirst
+    }
+
+    init(swiftName: String) {
+        unescaped = swiftName
+    }
+
+    init(operation: Document.Operation, in document: Document) throws {
+        let operationType = operation.ast.operation.rawValue.capitalizedFirst
+        if let name = operation.ast.name {
+            unescaped = name.value + operationType
+        } else {
+            let operationCount = document.definitions.count { definition in
+                switch definition {
+                case .fragment: false
+                case .operation: true
+                }
+            }
+            guard operationCount == 1 else {
+                throw Codegen.Error(description: """
+                Missing operation name. Operations may only be unnamed if they're the only operation in the document.
+                https://spec.graphql.org/October2021/#sel-FAFPTABABoC6of
+                URL: \(document.url)
+                """)
+            }
+            let fileName = document.url.deletingPathExtension().lastPathComponent
+            unescaped = fileName.hasSuffix(operationType) ? fileName : fileName + operationType
+        }
+    }
+
+    var source: String {
+        identifier(unescaped)
+    }
+}

--- a/Sources/GraphQLCodegen/Output/API/APIOutput.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIOutput.swift
@@ -1,0 +1,31 @@
+protocol APIOutput: Sendable {
+    /// Configuration that determines the API output directory.
+    var configuration: Configuration { get }
+
+    /// Generated file path relative to the API output directory.
+    var relativePath: String { get }
+
+    /// Unqualified generated Swift source.
+    var source: String { get }
+
+    /// Top-level Swift types this output writes.
+    var topLevelTypeNames: [SwiftTypeIdentifier] { get }
+
+    /// System types referenced by the generated source.
+    var typeReferences: Set<SwiftTypeReference> { get }
+
+    /// Writes this output, qualifying type references only when a declaration in `typeScope` shadows them.
+    func write(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws
+}
+
+extension APIOutput {
+    func write(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws {
+        try await typeScope.qualify(source, references: typeReferences).write(
+            to: configuration.output.api.directory.appending(
+                path: relativePath,
+                directoryHint: .notDirectory
+            ),
+            using: fileOutput
+        )
+    }
+}

--- a/Sources/GraphQLCodegen/Output/API/APIWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIWriter.swift
@@ -2,9 +2,54 @@ import Foundation
 
 struct APIWriter {
     let configuration: Configuration
-    let hasMutation: Bool
-    let hasSubscription: Bool
-    let requiresIndirectNullable: Bool
+
+    private let outputs: [any APIOutput]
+
+    init(
+        configuration: Configuration,
+        hasMutation: Bool,
+        hasSubscription: Bool,
+        requiresIndirectNullable: Bool
+    ) {
+        var outputs: [any APIOutput] = [
+            AnyEncodableWriter(configuration: configuration),
+            GraphQLEnumWriter(configuration: configuration),
+            GraphQLErrorWriter(configuration: configuration),
+            GraphQLHasDefaultWriter(configuration: configuration),
+            GraphQLNullableWriter(
+                configuration: configuration,
+                requiresIndirectNullable: requiresIndirectNullable
+            ),
+            GraphQLResponseWriter(configuration: configuration),
+            JSONValueWriter(configuration: configuration),
+        ]
+        if configuration.output.api.HTTPSupport != nil {
+            let httpOutputs: [any APIOutput] = [
+                DefaultEncodersWriter(hasSubscription: hasSubscription, configuration: configuration),
+                GraphQLOperationWriter(
+                    configuration: configuration,
+                    hasMutation: hasMutation,
+                    hasSubscription: hasSubscription
+                ),
+                EncodersWriter(hasSubscription: hasSubscription, configuration: configuration),
+                URLSessionWriter(hasSubscription: hasSubscription, configuration: configuration),
+                GraphQLRequestWriter(hasSubscription: hasSubscription, configuration: configuration),
+            ]
+            outputs.append(contentsOf: httpOutputs)
+        }
+        self.configuration = configuration
+        self.outputs = outputs
+    }
+
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        outputs.flatMap(\.topLevelTypeNames).map { typeName in
+            GeneratedTypeDeclaration(
+                name: typeName,
+                origin: .api(typeName.unescaped),
+                conformances: []
+            )
+        }
+    }
 
     private var httpSupportDirectory: URL {
         configuration.output.api.directory.appending(
@@ -13,46 +58,16 @@ struct APIWriter {
         )
     }
 
-    func write(using fileOutput: FileOutput) async throws {
+    func write(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws {
         let destinationPath = configuration.output.api.directory
         await fileOutput.createDirectory(at: destinationPath)
-        try await AnyEncodableWriter(configuration: configuration).write(using: fileOutput)
-        try await GraphQLEnumWriter(configuration: configuration).write(using: fileOutput)
-        try await GraphQLErrorWriter(configuration: configuration).write(using: fileOutput)
-        try await GraphQLHasDefaultWriter(configuration: configuration).write(using: fileOutput)
-        try await GraphQLNullableWriter(
-            configuration: configuration,
-            requiresIndirectNullable: requiresIndirectNullable
-        ).write(using: fileOutput)
-        try await GraphQLResponseWriter(configuration: configuration).write(using: fileOutput)
-        try await JSONValueWriter(configuration: configuration).write(using: fileOutput)
-
-        // HTTP Support
         if configuration.output.api.HTTPSupport != nil {
             await fileOutput.createDirectory(at: httpSupportDirectory)
-            try await DefaultEncodersWriter(
-                hasSubscription: hasSubscription,
-                configuration: configuration
-            ).write(using: fileOutput)
-            try await GraphQLOperationWriter(
-                configuration: configuration,
-                hasMutation: hasMutation,
-                hasSubscription: hasSubscription
-            ).write(using: fileOutput)
-            try await EncodersWriter(
-                hasSubscription: hasSubscription,
-                configuration: configuration
-            ).write(using: fileOutput)
-            try await URLSessionWriter(
-                hasSubscription: hasSubscription,
-                configuration: configuration
-            ).write(using: fileOutput)
-            try await GraphQLRequestWriter(
-                hasSubscription: hasSubscription,
-                configuration: configuration
-            ).write(using: fileOutput)
         } else {
             await fileOutput.remove(at: httpSupportDirectory)
+        }
+        for output in outputs {
+            try await output.write(using: fileOutput, typeScope: typeScope)
         }
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
@@ -1,5 +1,14 @@
-struct AnyEncodableWriter {
+struct AnyEncodableWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "AnyEncodable.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "AnyEncodable")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Encodable"),
+        .init(.swift, "Encoder"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "Void"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +19,8 @@ struct AnyEncodableWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)\(accessLevel)struct AnyEncodable: Encodable, Sendable {
             private let encoder: @Sendable (Encoder) throws -> Void
             \(accessLevel)init<T: Encodable & Sendable>(_ value: T) {
@@ -25,12 +34,6 @@ struct AnyEncodableWriter {
                 try self.encoder(encoder)
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "AnyEncodable.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLEnumWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLEnumWriter.swift
@@ -1,5 +1,16 @@
-struct GraphQLEnumWriter {
+struct GraphQLEnumWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "GraphQLEnum.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLEnum")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Decodable"),
+        .init(.swift, "Decoder"),
+        .init(.swift, "Hashable"),
+        .init(.swift, "RawRepresentable"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +21,8 @@ struct GraphQLEnumWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)\(accessLevel)enum GraphQLEnum<T>: Decodable, Hashable, Sendable where T: Hashable & RawRepresentable & Sendable, T.RawValue == String {
             case known(T)
             case unknown(String)
@@ -25,12 +36,6 @@ struct GraphQLEnumWriter {
                 }
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "GraphQLEnum.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
@@ -1,5 +1,16 @@
-struct GraphQLErrorWriter {
+struct GraphQLErrorWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "GraphQLError.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLError")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Decodable"),
+        .init(.swift, "Decoder"),
+        .init(.swift, "DecodingError"),
+        .init(.swift, "Int"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +21,8 @@ struct GraphQLErrorWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)/// https://spec.graphql.org/October2021/#sec-Errors
         \(accessLevel)struct GraphQLError: Decodable, Sendable {
             \(accessLevel)struct Location: Decodable, Sendable {
@@ -46,12 +57,6 @@ struct GraphQLErrorWriter {
             \(accessLevel)let path: [PathSegment]?
             \(accessLevel)let extensions: [String: JSONValue]?
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "GraphQLError.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLHasDefaultWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLHasDefaultWriter.swift
@@ -1,5 +1,14 @@
-struct GraphQLHasDefaultWriter {
+struct GraphQLHasDefaultWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "GraphQLHasDefault.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLHasDefault")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Encodable"),
+        .init(.swift, "Encoder"),
+        .init(.swift, "Hashable"),
+        .init(.swift, "Sendable"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +19,8 @@ struct GraphQLHasDefaultWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)\(accessLevel)enum GraphQLHasDefault<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
             case useDefault
             case value(T)
@@ -44,12 +53,6 @@ struct GraphQLHasDefaultWriter {
                 }
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "GraphQLHasDefault.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
@@ -1,6 +1,15 @@
-struct GraphQLNullableWriter {
+struct GraphQLNullableWriter: APIOutput {
     let configuration: Configuration
     let requiresIndirectNullable: Bool
+
+    let relativePath = "GraphQLNullable.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLNullable")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Encodable"),
+        .init(.swift, "Encoder"),
+        .init(.swift, "Hashable"),
+        .init(.swift, "Sendable"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -11,9 +20,9 @@ struct GraphQLNullableWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
+    var source: String {
         let indirect = requiresIndirectNullable ? "indirect " : ""
-        try await """
+        return """
         \(header)\(accessLevel)\(indirect)enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
             case null
             case value(T)
@@ -26,12 +35,6 @@ struct GraphQLNullableWriter {
                 }
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "GraphQLNullable.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
@@ -1,5 +1,17 @@
-struct GraphQLResponseWriter {
+struct GraphQLResponseWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "GraphQLResponse.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLResponse")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "CodingKey"),
+        .init(.swift, "Decodable"),
+        .init(.swift, "Decoder"),
+        .init(.swift, "DecodingError"),
+        .init(.swift, "Error"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +22,8 @@ struct GraphQLResponseWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)\(accessLevel)enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
             \(accessLevel)struct Success: Sendable {
                 \(accessLevel)let data: Data
@@ -70,12 +82,6 @@ struct GraphQLResponseWriter {
                 }
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "GraphQLResponse.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -1,8 +1,35 @@
 import Foundation
 
-struct DefaultEncodersWriter {
+struct DefaultEncodersWriter: APIOutput {
     let hasSubscription: Bool
     let configuration: Configuration
+    let relativePath = "HTTPSupport/DefaultEncoders.swift"
+
+    var typeReferences: Set<SwiftTypeReference> {
+        var references: Set<SwiftTypeReference> = [
+            .init(.foundation, "Data"),
+            .init(.foundation, "JSONEncoder"),
+            .init(.foundation, "URLQueryItem"),
+            .init(.swift, "Array"),
+            .init(.swift, "Bool"),
+            .init(.swift, "Encodable"),
+            .init(.swift, "Int"),
+            .init(.swift, "String"),
+            .init(.swift, "UTF8"),
+        ]
+        if case .automatic = configuration.output.documents.operations.persistedOperations {
+            references.insert(.init(.cryptoKit, "SHA256"))
+        }
+        return references
+    }
+
+    var topLevelTypeNames: [SwiftTypeIdentifier] {
+        var typeNames = [SwiftTypeIdentifier(swiftName: "JSONBodyEncoder")]
+        if configuration.output.api.HTTPSupport?.enableGETQueries == true {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "DefaultURLQueryEncoder"))
+        }
+        return typeNames
+    }
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -39,18 +66,7 @@ struct DefaultEncodersWriter {
         configuration.output.api.HTTPSupport?.enableGETQueries == true
     }
 
-    private var url: URL {
-        configuration.output.api.directory.appending(
-            path: "HTTPSupport/DefaultEncoders.swift",
-            directoryHint: .notDirectory
-        )
-    }
-
-    func write(using fileOutput: FileOutput) async throws {
-        try await content().write(to: url, using: fileOutput)
-    }
-
-    private func content() -> String {
+    var source: String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
             case .automatic: getWithAutomaticPersistedOperations()

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -1,8 +1,27 @@
 import Foundation
 
-struct EncodersWriter {
+struct EncodersWriter: APIOutput {
     let hasSubscription: Bool
     let configuration: Configuration
+    let relativePath = "HTTPSupport/Encoders.swift"
+
+    var topLevelTypeNames: [SwiftTypeIdentifier] {
+        var typeNames = [SwiftTypeIdentifier(swiftName: "HTTPBodyEncoder")]
+        if configuration.output.api.HTTPSupport?.enableGETQueries == true {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "URLQueryEncoder"))
+        }
+        if case .automatic = configuration.output.documents.operations.persistedOperations {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "AutomaticPersistedOperationPhase"))
+        }
+        return typeNames
+    }
+
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.foundation, "Data"),
+        .init(.foundation, "URLQueryItem"),
+        .init(.swift, "Bool"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -21,18 +40,7 @@ struct EncodersWriter {
         configuration.output.api.HTTPSupport?.enableGETQueries == true
     }
 
-    private var url: URL {
-        configuration.output.api.directory.appending(
-            path: "HTTPSupport/Encoders.swift",
-            directoryHint: .notDirectory
-        )
-    }
-
-    func write(using fileOutput: FileOutput) async throws {
-        try await content().write(to: url, using: fileOutput)
-    }
-
-    private func content() -> String {
+    var source: String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
             case .automatic: getWithAutomaticPersistedOperations()

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -1,9 +1,31 @@
 import Foundation
 
-struct GraphQLOperationWriter {
+struct GraphQLOperationWriter: APIOutput {
     let configuration: Configuration
     let hasMutation: Bool
     let hasSubscription: Bool
+    let relativePath = "HTTPSupport/GraphQLOperation.swift"
+
+    var topLevelTypeNames: [SwiftTypeIdentifier] {
+        var typeNames = [
+            SwiftTypeIdentifier(swiftName: "GraphQLOperation"),
+            SwiftTypeIdentifier(swiftName: "GraphQLQuery"),
+        ]
+        if hasMutation {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "GraphQLMutation"))
+        }
+        if hasSubscription {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "GraphQLSubscription"))
+        }
+        return typeNames
+    }
+
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Decodable"),
+        .init(.swift, "Encodable"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -14,18 +36,7 @@ struct GraphQLOperationWriter {
         return "\(header)\n\n"
     }
 
-    private var url: URL {
-        configuration.output.api.directory.appending(
-            path: "HTTPSupport/GraphQLOperation.swift",
-            directoryHint: .notDirectory
-        )
-    }
-
-    func write(using fileOutput: FileOutput) async throws {
-        try await content().write(to: url, using: fileOutput)
-    }
-
-    private func content() -> String {
+    var source: String {
         """
         \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.
         \(accessLevel)protocol GraphQLOperation: Sendable {

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -1,8 +1,19 @@
 import Foundation
 
-struct GraphQLRequestWriter {
+struct GraphQLRequestWriter: APIOutput {
     let hasSubscription: Bool
     let configuration: Configuration
+    let relativePath = "HTTPSupport/GraphQLRequest.swift"
+
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLRequest")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.foundation, "Data"),
+        .init(.foundation, "JSONDecoder"),
+        .init(.foundation, "URL"),
+        .init(.foundation, "URLRequest"),
+        .init(.swift, "Bool"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -21,18 +32,7 @@ struct GraphQLRequestWriter {
         configuration.output.api.HTTPSupport?.enableGETQueries == true
     }
 
-    private var url: URL {
-        configuration.output.api.directory.appending(
-            path: "HTTPSupport/GraphQLRequest.swift",
-            directoryHint: .notDirectory
-        )
-    }
-
-    func write(using fileOutput: FileOutput) async throws {
-        try await content().write(to: url, using: fileOutput)
-    }
-
-    private func content() -> String {
+    var source: String {
         if enableGETQueries {
             switch configuration.output.documents.operations.persistedOperations {
             case .automatic: getWithAutomaticPersistedOperations()

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -202,7 +202,7 @@ struct GraphQLRequestWriter: APIOutput {
             /// Initializes a POST request for a single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 automaticPersistedOperations: Bool = true,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
@@ -232,7 +232,7 @@ struct GraphQLRequestWriter: APIOutput {
             /// Initializes a POST request for a registered single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
             ) throws where Operation: GraphQLSingleResponseOperation {
@@ -254,7 +254,7 @@ struct GraphQLRequestWriter: APIOutput {
             /// Initializes a POST request for a single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
@@ -696,7 +696,7 @@ struct GraphQLRequestWriter: APIOutput {
             /// Automatic persisted operations are unavailable because subscription fallback is not supported.
             \(accessLevel)init(
                 subscription: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
@@ -729,7 +729,7 @@ struct GraphQLRequestWriter: APIOutput {
             ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
             \(accessLevel)init(
                 subscription: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
                 self.urlRequest = URLRequest(url: endpoint)
@@ -757,7 +757,7 @@ struct GraphQLRequestWriter: APIOutput {
             ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
             \(accessLevel)init(
                 subscription: Operation,
-                endpoint: Foundation.URL,
+                endpoint: URL,
                 minifyDocument: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -1,8 +1,21 @@
 import Foundation
 
-struct URLSessionWriter {
+struct URLSessionWriter: APIOutput {
     let hasSubscription: Bool
     let configuration: Configuration
+    let relativePath = "HTTPSupport/URLSession+GraphQL.swift"
+
+    let topLevelTypeNames: [SwiftTypeIdentifier] = []
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.foundation, "Data"),
+        .init(.foundation, "HTTPURLResponse"),
+        .init(.foundation, "URLSession"),
+        .init(.swift, "Array"),
+        .init(.swift, "AsyncThrowingStream"),
+        .init(.swift, "Error"),
+        .init(.swift, "Task"),
+        .init(.swift, "UInt8"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -17,18 +30,7 @@ struct URLSessionWriter {
         hasSubscription && configuration.output.api.HTTPSupport?.subscriptionSupport == true
     }
 
-    private var url: URL {
-        configuration.output.api.directory.appending(
-            path: "HTTPSupport/URLSession+GraphQL.swift",
-            directoryHint: .notDirectory
-        )
-    }
-
-    func write(using fileOutput: FileOutput) async throws {
-        try await content().write(to: url, using: fileOutput)
-    }
-
-    private func content() -> String {
+    var source: String {
         """
         \(header)import Foundation
 

--- a/Sources/GraphQLCodegen/Output/API/JSONValueWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/JSONValueWriter.swift
@@ -1,5 +1,17 @@
-struct JSONValueWriter {
+struct JSONValueWriter: APIOutput {
     let configuration: Configuration
+
+    let relativePath = "JSONValue.swift"
+    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "JSONValue")]
+    let typeReferences: Set<SwiftTypeReference> = [
+        .init(.swift, "Bool"),
+        .init(.swift, "Decodable"),
+        .init(.swift, "Decoder"),
+        .init(.swift, "DecodingError"),
+        .init(.swift, "Double"),
+        .init(.swift, "Sendable"),
+        .init(.swift, "String"),
+    ]
 
     private var accessLevel: String {
         configuration.output.api.accessLevel == .public ? "public " : ""
@@ -10,8 +22,8 @@ struct JSONValueWriter {
         return "\(header)\n\n"
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await """
+    var source: String {
+        """
         \(header)\(accessLevel)enum JSONValue: Decodable, Sendable {
             case map([String: JSONValue])
             case list([JSONValue])
@@ -39,12 +51,6 @@ struct JSONValueWriter {
                 }
             }
         }
-        """.write(
-            to: configuration.output.api.directory.appending(
-                path: "JSONValue.swift",
-                directoryHint: .notDirectory
-            ),
-            using: fileOutput
-        )
+        """
     }
 }

--- a/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
+++ b/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
@@ -1,0 +1,55 @@
+struct CodegenOutputPlan {
+    let apiWriter: APIWriter
+    let documentsWriter: DocumentsWriter
+    let manifestWriter: PersistedOperationManifestWriter?
+    let schemaWriter: SchemaWriter
+
+    let configuration: Configuration
+    let topLevelDeclarations: [GeneratedTypeDeclaration]
+
+    init(
+        configuration: Configuration,
+        documents: Documents,
+        resolvedDocuments: ResolvedDocuments,
+        schema: Schema
+    ) throws {
+        let apiWriter = APIWriter(
+            configuration: configuration,
+            hasMutation: resolvedDocuments.hasMutation,
+            hasSubscription: resolvedDocuments.hasSubscription,
+            requiresIndirectNullable: resolvedDocuments.requiresIndirectNullable
+        )
+        let documentsWriter = try DocumentsWriter(
+            configuration: configuration,
+            resolvedDocuments: resolvedDocuments
+        )
+        let schemaWriter = SchemaWriter(
+            configuration: configuration,
+            schema: schema,
+            resolvedDocuments: resolvedDocuments
+        )
+        let manifestWriter: PersistedOperationManifestWriter? =
+            switch configuration.output.documents.operations.persistedOperations {
+        case .registered(let manifestURL):
+            PersistedOperationManifestWriter(manifestURL: manifestURL, documents: documents)
+        case .automatic, .none:
+            nil
+        }
+        let topLevelDeclarations = apiWriter.topLevelDeclarations +
+            documentsWriter.topLevelDeclarations + schemaWriter.topLevelDeclarations
+        self.apiWriter = apiWriter
+        self.configuration = configuration
+        self.documentsWriter = documentsWriter
+        self.manifestWriter = manifestWriter
+        self.schemaWriter = schemaWriter
+        self.topLevelDeclarations = topLevelDeclarations
+    }
+
+    func write(using fileOutput: FileOutput) async throws {
+        let typeScope = SwiftTypeScope(declarations: topLevelDeclarations.map(\.name))
+        try await documentsWriter.write(using: fileOutput, typeScope: typeScope)
+        try await schemaWriter.write(using: fileOutput, typeScope: typeScope)
+        try await apiWriter.write(using: fileOutput, typeScope: typeScope)
+        try await manifestWriter?.write(using: fileOutput)
+    }
+}

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/FragmentBuilder.swift
@@ -4,14 +4,12 @@ struct FragmentBuilder {
     let configuration: Configuration
     let document: Document
     let resolvedFragment: ResolvedFragment
-    let resolvedDocuments: ResolvedDocuments
+    let typeName: SwiftTypeIdentifier
+    let typeScope: SwiftTypeScope
+    let includesSelectionSet: Bool
 
     private var fragment: Document.Fragment {
         resolvedFragment.fragment
-    }
-
-    private var isFulfilled: Bool {
-        resolvedDocuments.fulfilledFragments.contains(fragment.ast.name.value)
     }
 
     private var isPublic: Bool {
@@ -25,10 +23,11 @@ struct FragmentBuilder {
         var fragmentStruct = SwiftStructBuilder(
             description: nil,
             isPublic: isPublic,
-            name: fragment.ast.name.value.capitalizedFirst,
-            conformances: isFulfilled ? configuration.output.documents.fragments.conformances : []
+            name: typeName.source,
+            conformances: includesSelectionSet ? configuration.output.documents.fragments.conformances : [],
+            typeScope: typeScope
         )
-        if isFulfilled {
+        if includesSelectionSet {
             try addSelectionSet(to: &fragmentStruct)
         }
         return fragmentStruct
@@ -41,7 +40,8 @@ struct FragmentBuilder {
                 immutable: configuration.output.documents.fragments.immutable,
                 isPublic: isPublic,
                 conformances: OrderedSet(configuration.output.documents.fragments.conformances),
-                configuration: configuration
+                configuration: configuration,
+                typeScope: typeScope
             )
         } catch {
             switch error as? SelectionSetError {

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -5,6 +5,8 @@ struct OperationBuilder {
     let configuration: Configuration
     let document: Document
     let resolvedOperation: ResolvedOperation
+    let typeName: SwiftTypeIdentifier
+    let typeScope: SwiftTypeScope
 
     private var operation: Document.Operation {
         resolvedOperation.operation
@@ -18,7 +20,7 @@ struct OperationBuilder {
     }
 
     func buildable() throws -> SwiftTypeBuildable {
-        var operationStruct = try makeOperationStruct()
+        var operationStruct = makeOperationStruct()
         addOperationNameProperty(to: &operationStruct)
         addDocumentProperty(to: &operationStruct)
         addHashProperty(to: &operationStruct)
@@ -29,44 +31,13 @@ struct OperationBuilder {
         return operationStruct
     }
 
-    private func makeOperationStruct() throws -> SwiftStructBuilder {
-        let structName: String
-        let operationType = operation.ast.operation.rawValue.capitalizedFirst
-        if let name = operation.ast.name {
-            structName = name.value + operationType
-        } else {
-            let operationCount = document.definitions.count { definition in
-                switch definition {
-                case .fragment: false
-                case .operation: true
-                }
-            }
-            guard operationCount == 1 else {
-                throw Codegen.Error(description: """
-                Missing operation name. Operations may only be unnamed if they're the only operation in the document.
-                https://spec.graphql.org/October2021/#sel-FAFPTABABoC6of
-                URL: \(document.url)
-                """)
-            }
-            let fileName = document.url.deletingPathExtension().lastPathComponent
-            structName = fileName.hasSuffix(operationType) ? fileName : fileName + operationType
-        }
-        var conformances = configuration.output.documents.operations.conformances
-        if configuration.output.api.HTTPSupport != nil {
-            switch operation.ast.operation {
-            case .query:
-                conformances.append("GraphQLQuery")
-            case .mutation:
-                conformances.append("GraphQLMutation")
-            case .subscription:
-                conformances.append("GraphQLSubscription")
-            }
-        }
-        return SwiftStructBuilder(
+    private func makeOperationStruct() -> SwiftStructBuilder {
+        SwiftStructBuilder(
             description: nil,
             isPublic: isPublic,
-            name: structName,
-            conformances: conformances
+            name: typeName.source,
+            conformances: configuration.operationConformances(for: operation.ast.operation),
+            typeScope: typeScope
         )
     }
 
@@ -84,7 +55,10 @@ struct OperationBuilder {
             isStatic: true,
             immutable: true,
             name: "operationName",
-            value: .assigned(value, type: "String?")
+            value: .assigned(
+                value,
+                type: typeScope.reference(.init(.swift, "String")) + "?"
+            )
         )
     }
 
@@ -143,7 +117,7 @@ struct OperationBuilder {
             immutable: configuration.output.documents.operations.immutableExtensions,
             name: "extensions",
             value: .unassigned(
-                type: "[String: AnyEncodable]?",
+                type: "[\(typeScope.reference(.init(.swift, "String"))): AnyEncodable]?",
                 initialized: .direct(defaultValue: "nil")
             )
         )
@@ -159,11 +133,15 @@ struct OperationBuilder {
                 isStatic: false,
                 immutable: true,
                 name: "variables",
-                value: .assigned("nil", type: "Never?")
+                value: .assigned(
+                    "nil",
+                    type: typeScope.reference(.init(.swift, "Never")) + "?"
+                )
             )
             return
         }
-        let typeNames = variableDefinitions.map(\.typeName)
+        let nestedTypeScope = operationNestedTypeScope(hasVariables: true)
+        let typeNames = variableDefinitions.map { $0.typeName(in: nestedTypeScope) }
         operationStruct.addProperty(
             description: nil,
             deprecation: nil,
@@ -172,7 +150,7 @@ struct OperationBuilder {
             immutable: configuration.output.documents.operations.immutableVariables,
             name: "variables",
             value: .unassigned(
-                type: "Variables",
+                type: SwiftTypeIdentifier.variables.source,
                 initialized: .flattened(
                     variableDefinitions.enumerated().map { idx, variableDefinition in
                         .named(
@@ -205,12 +183,14 @@ struct OperationBuilder {
     private func addVariablesStruct(to operationStruct: inout SwiftStructBuilder) {
         let variableDefinitions = operation.ast.variableDefinitions
         guard !variableDefinitions.isEmpty else { return }
-        let typeNames = variableDefinitions.map(\.typeName)
+        let nestedTypeScope = operationNestedTypeScope(hasVariables: true)
+        let typeNames = variableDefinitions.map { $0.typeName(in: nestedTypeScope) }
         var variablesStruct = SwiftStructBuilder(
             description: nil,
             isPublic: isPublic,
-            name: "Variables",
-            conformances: configuration.output.documents.operations.variables.conformances
+            name: SwiftTypeIdentifier.variables.source,
+            conformances: configuration.output.documents.operations.variables.conformances,
+            typeScope: nestedTypeScope
         )
         for (idx, variableDefinition) in variableDefinitions.enumerated() {
             variablesStruct.addProperty(
@@ -227,11 +207,15 @@ struct OperationBuilder {
     }
 
     private func addDataStruct(to operationStruct: inout SwiftStructBuilder) throws {
+        let nestedTypeScope = operationNestedTypeScope(
+            hasVariables: !operation.ast.variableDefinitions.isEmpty
+        )
         var structBuilder = SwiftStructBuilder(
             description: nil,
             isPublic: isPublic,
-            name: "Data",
-            conformances: configuration.output.documents.operations.responseData.conformances
+            name: SwiftTypeIdentifier.data.source,
+            conformances: configuration.output.documents.operations.responseData.conformances,
+            typeScope: nestedTypeScope
         )
         do {
             try structBuilder.addSelectionSet(
@@ -239,7 +223,8 @@ struct OperationBuilder {
                 immutable: configuration.output.documents.operations.responseData.immutable,
                 isPublic: isPublic,
                 conformances: OrderedSet(configuration.output.documents.operations.responseData.conformances),
-                configuration: configuration
+                configuration: configuration,
+                typeScope: nestedTypeScope
             )
         } catch {
             switch error as? SelectionSetError {
@@ -262,10 +247,21 @@ struct OperationBuilder {
         }
         operationStruct.addNestedType(structBuilder)
     }
+
+    private func operationNestedTypeScope(hasVariables: Bool) -> SwiftTypeScope {
+        var declarations = [SwiftTypeIdentifier.data]
+        if hasVariables {
+            declarations.append(.variables)
+        }
+        return typeScope.adding(declarations: declarations)
+    }
 }
 
 extension GraphQLAST.VariableDefinition {
-    fileprivate var typeName: String {
-        type.typeName.inputTypeName(hasDefaultValue: defaultValue != nil)
+    fileprivate func typeName(in typeScope: SwiftTypeScope) -> String {
+        type.typeName.inputTypeName(
+            hasDefaultValue: defaultValue != nil,
+            typeScope: typeScope
+        )
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -11,15 +11,16 @@ extension SwiftStructBuilder {
         immutable: Bool,
         isPublic: Bool,
         conformances: OrderedSet<String>,
-        configuration: Configuration
+        configuration: Configuration,
+        typeScope: SwiftTypeScope
     ) throws {
-        var hasFields = false
-        var hasFragments = false
+        let typePlan = SelectionSetTypePlan(selectionSet: selectionSet, conformances: conformances)
+        let selectionTypeScope = typeScope.adding(declarations: typePlan.declarations.map(\.name))
+
         var hasNonnilTypenameField = false
         for (responseKey, selection) in selectionSet {
             switch selection {
             case .field(let field, let conditional):
-                hasFields = true
                 hasNonnilTypenameField = hasNonnilTypenameField || (responseKey == "__typename" && !conditional)
                 let conditionalField = conditional ? field.asOptional() : field
                 addProperty(
@@ -30,13 +31,15 @@ extension SwiftStructBuilder {
                     immutable: immutable,
                     name: responseKey,
                     value: .unassigned(
-                        type: conditionalField.sourceTypeName(responseKey: responseKey).formatted(),
+                        type: conditionalField.sourceTypeName(
+                            responseKey: responseKey,
+                            typeScope: selectionTypeScope
+                        ).formatted(),
                         initialized: configuration.output.documents.memberwiseInitializer ?
                             .direct(defaultValue: nil) : nil
                     )
                 )
             case .fragmentSpread(let fragmentSpreadName, let checkTypename):
-                hasFragments = true
                 addProperty(
                     description: nil,
                     deprecation: nil,
@@ -45,7 +48,8 @@ extension SwiftStructBuilder {
                     immutable: immutable,
                     name: responseKey,
                     value: .unassigned(
-                        type: fragmentSpreadName.capitalizedFirst + (checkTypename != nil ? "?" : ""),
+                        type: SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source +
+                            (checkTypename != nil ? "?" : ""),
                         initialized: configuration.output.documents.memberwiseInitializer ?
                             .direct(defaultValue: nil) : nil
                     )
@@ -62,16 +66,21 @@ extension SwiftStructBuilder {
                     immutable: immutable,
                     isPublic: isPublic,
                     conformances: conformances,
-                    configuration: configuration
+                    configuration: configuration,
+                    typeScope: selectionTypeScope
                 )
             }
         }
-        if hasFragments, conformances.contains("Decodable") {
+        let includesDecodable = conformances.contains { conformance in
+            SwiftConformanceName(source: conformance).includesDecodable
+        }
+        if typePlan.hasFragments, includesDecodable {
             try addDecodableInitializer(
                 selectionSet,
-                hasFields: hasFields,
+                hasFields: !typePlan.fields.isEmpty,
                 hasNonnilTypenameField: hasNonnilTypenameField,
-                configuration: configuration
+                configuration: configuration,
+                typeScope: selectionTypeScope
             )
         }
     }
@@ -82,7 +91,8 @@ extension SwiftStructBuilder {
         immutable: Bool,
         isPublic: Bool,
         conformances: OrderedSet<String>,
-        configuration: Configuration
+        configuration: Configuration,
+        typeScope: SwiftTypeScope
     ) throws {
         switch fieldType {
         case .scalar: break
@@ -90,8 +100,9 @@ extension SwiftStructBuilder {
             var nestedStruct = SwiftStructBuilder(
                 description: nil,
                 isPublic: isPublic,
-                name: responseKey.capitalizedFirst,
-                conformances: conformances.elements
+                name: SwiftTypeIdentifier(capitalizing: responseKey).source,
+                conformances: conformances.elements,
+                typeScope: typeScope
             )
             do {
                 try nestedStruct.addSelectionSet(
@@ -99,7 +110,8 @@ extension SwiftStructBuilder {
                     immutable: immutable,
                     isPublic: isPublic,
                     conformances: conformances,
-                    configuration: configuration
+                    configuration: configuration,
+                    typeScope: typeScope
                 )
             } catch {
                 switch error as? SelectionSetError {
@@ -119,7 +131,8 @@ extension SwiftStructBuilder {
                 immutable: immutable,
                 isPublic: isPublic,
                 conformances: conformances,
-                configuration: configuration
+                configuration: configuration,
+                typeScope: typeScope
             )
         case .list(let innerType):
             try addNestedStruct(
@@ -128,7 +141,8 @@ extension SwiftStructBuilder {
                 immutable: immutable,
                 isPublic: isPublic,
                 conformances: conformances,
-                configuration: configuration
+                configuration: configuration,
+                typeScope: typeScope
             )
         }
     }
@@ -137,17 +151,21 @@ extension SwiftStructBuilder {
         _ selectionSet: ResolvedSelectionSet,
         hasFields: Bool,
         hasNonnilTypenameField: Bool,
-        configuration: Configuration
+        configuration: Configuration,
+        typeScope: SwiftTypeScope
     ) throws {
         var initializerBody: [String] = []
         if hasFields {
-            initializerBody.append("let container = try decoder.container(keyedBy: CodingKeys.self)")
+            initializerBody.append(
+                "let container = try decoder.container(keyedBy: \(SwiftTypeIdentifier.codingKeys.source).self)"
+            )
         }
         var codingKeysEnum = hasFields ? SwiftEnumBuilder(
             description: nil,
             isPublic: false,
-            name: "CodingKeys",
-            conformances: ["CodingKey"]
+            name: SwiftTypeIdentifier.codingKeys.source,
+            conformances: ["CodingKey"],
+            typeScope: typeScope
         ) : nil
         for (responseKey, selection) in selectionSet {
             switch selection {
@@ -157,10 +175,16 @@ extension SwiftStructBuilder {
                 let typename: String
                 if conditional {
                     assignment.append("decodeIfPresent(")
-                    typename = field.asNonOptional().sourceTypeName(responseKey: responseKey).formatted()
+                    typename = field.asNonOptional().sourceTypeName(
+                        responseKey: responseKey,
+                        typeScope: typeScope
+                    ).formatted()
                 } else {
                     assignment.append("decode(")
-                    typename = field.sourceTypeName(responseKey: responseKey).formatted()
+                    typename = field.sourceTypeName(
+                        responseKey: responseKey,
+                        typeScope: typeScope
+                    ).formatted()
                 }
                 assignment.append("\(typename).self, forKey: .\(responseKey))")
                 codingKeysEnum?.addCase(description: nil, deprecation: nil, name: responseKey)
@@ -172,7 +196,7 @@ extension SwiftStructBuilder {
             switch selection {
             case .field: break
             case .fragmentSpread(let fragmentSpreadName, let checkTypename):
-                let fragmentTypeName = fragmentSpreadName.capitalizedFirst
+                let fragmentTypeName = SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source
                 var assignment = "\(identifier(responseKey)) = "
                 if let checkTypename {
                     if !hasNonnilTypenameField {
@@ -190,7 +214,9 @@ extension SwiftStructBuilder {
             initializerBody = codingKeysEnum.build(configuration: configuration) + initializerBody
         }
         addInitializer(
-            arguments: ["from decoder: Decoder"],
+            arguments: [
+                "from decoder: \(typeScope.reference(.init(.swift, "Decoder")))",
+            ],
             body: initializerBody,
             isThrowing: true
         )

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -2,33 +2,122 @@ import Foundation
 import OrderedCollections
 
 struct DocumentsWriter {
-    let configuration: Configuration
-    let resolvedDocuments: ResolvedDocuments
+    enum DefinitionPlan {
+        case fragment(
+            ResolvedFragment,
+            includesSelectionSet: Bool,
+            declaration: GeneratedTypeDeclaration
+        )
+        case operation(ResolvedOperation, GeneratedTypeDeclaration)
 
-    func write(using fileOutput: FileOutput) async throws {
+        var declaration: GeneratedTypeDeclaration {
+            switch self {
+            case .fragment(_, _, let declaration), .operation(_, let declaration): declaration
+            }
+        }
+    }
+
+    struct DocumentPlan {
+        let document: Document
+        let definitions: [DefinitionPlan]
+    }
+
+    let configuration: Configuration
+    let documentPlans: [DocumentPlan]
+
+    private let previouslyGenerated: [URL]
+
+    init(configuration: Configuration, resolvedDocuments: ResolvedDocuments) throws {
+        var documentPlans: [DocumentPlan] = []
+        for resolvedDocument in resolvedDocuments.documents {
+            var definitions: [DefinitionPlan] = []
+            for definition in resolvedDocument.resolvedDefinitions {
+                switch definition {
+                case .operation(let operation):
+                    let declaration = GeneratedTypeDeclaration(
+                        name: try SwiftTypeIdentifier(
+                            operation: operation.operation,
+                            in: resolvedDocument.document
+                        ),
+                        origin: .operation(
+                            name: operation.operation.ast.name?.value,
+                            file: resolvedDocument.document.url
+                        ),
+                        conformances: configuration.operationConformances(
+                            for: operation.operation.ast.operation
+                        )
+                    )
+                    definitions.append(.operation(operation, declaration))
+                case .fragment(let name):
+                    guard let fragment = resolvedDocuments.fragmentLookup[name] else { continue }
+                    let includesSelectionSet = resolvedDocuments.fulfilledFragments.contains(name)
+                    let declaration = GeneratedTypeDeclaration(
+                        name: SwiftTypeIdentifier(capitalizing: name),
+                        origin: .fragment(name: name, file: fragment.fragment.file),
+                        conformances: includesSelectionSet ?
+                            configuration.output.documents.fragments.conformances : []
+                    )
+                    definitions.append(
+                        .fragment(
+                            fragment,
+                            includesSelectionSet: includesSelectionSet,
+                            declaration: declaration
+                        )
+                    )
+                }
+            }
+            documentPlans.append(
+                DocumentPlan(document: resolvedDocument.document, definitions: definitions)
+            )
+        }
+        self.configuration = configuration
+        self.documentPlans = documentPlans
+        self.previouslyGenerated = resolvedDocuments.previouslyGenerated
+    }
+
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        documentPlans.flatMap(\.definitions).map(\.declaration)
+    }
+
+    func write(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws {
         try validateOutputURLs()
         switch configuration.output.documents.directory {
         case .definition: break
         case .directory(let url):
             await fileOutput.createDirectory(at: url)
         }
-        for resolvedDocument in resolvedDocuments.documents {
-            let document = resolvedDocument.document
+        for plannedDocument in documentPlans {
+            let document = plannedDocument.document
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.documents.header)
             file.setImports(configuration.output.documents.importedModules)
             var emptyFile = true
-            for definition in resolvedDocument.resolvedDefinitions {
+            for definition in plannedDocument.definitions {
                 switch definition {
-                case .operation(let resolvedOperation):
-                    let operation = try buildOperation(resolvedOperation, in: document)
+                case .operation(let resolvedOperation, let declaration):
+                    let operation = try buildOperation(
+                        resolvedOperation,
+                        typeName: declaration.name,
+                        typeScope: typeScope,
+                        in: document
+                    )
                     file.addType(operation)
                     emptyFile = false
-                case .fragment(let name):
-                    if let fragment = try buildFragment(name, in: document) {
-                        file.addType(fragment)
-                        emptyFile = false
-                    }
+                case .fragment(
+                    let resolvedFragment,
+                    let includesSelectionSet,
+                    let declaration
+                ):
+                    file.addType(
+                        try buildFragment(
+                            resolvedFragment,
+                            typeName: declaration.name,
+                            typeScope: typeScope,
+                            includesSelectionSet: includesSelectionSet,
+                            in: document
+                        )
+                    )
+                    emptyFile = false
                 }
             }
             let outputURL = document.outputURL(configuration)
@@ -38,15 +127,15 @@ struct DocumentsWriter {
                 try await file.write(to: outputURL, configuration: configuration, using: fileOutput)
             }
         }
-        let generated = resolvedDocuments.documents.map { $0.document.outputURL(configuration) }
-        let removed = Set(resolvedDocuments.previouslyGenerated).subtracting(generated)
+        let generated = documentPlans.map { $0.document.outputURL(configuration) }
+        let removed = Set(previouslyGenerated).subtracting(generated)
         await fileOutput.remove(at: removed)
     }
 
     private func validateOutputURLs() throws {
         var sourceByOutputURL: [URL: URL] = [:]
-        for resolvedDocument in resolvedDocuments.documents {
-            let document = resolvedDocument.document
+        for plannedDocument in documentPlans {
+            let document = plannedDocument.document
             let outputURL = document.outputURL(configuration).standardizedFileURL
             if let existingSource = sourceByOutputURL[outputURL] {
                 throw Codegen.Error(description: """
@@ -63,28 +152,34 @@ struct DocumentsWriter {
 
     private func buildOperation(
         _ operation: ResolvedOperation,
+        typeName: SwiftTypeIdentifier,
+        typeScope: SwiftTypeScope,
         in document: Document
     ) throws -> SwiftTypeBuildable {
         let operation = OperationBuilder(
             configuration: configuration,
             document: document,
-            resolvedOperation: operation
+            resolvedOperation: operation,
+            typeName: typeName,
+            typeScope: typeScope
         )
         return try operation.buildable()
     }
 
     private func buildFragment(
-        _ fragmentName: String,
+        _ resolvedFragment: ResolvedFragment,
+        typeName: SwiftTypeIdentifier,
+        typeScope: SwiftTypeScope,
+        includesSelectionSet: Bool,
         in document: Document
-    ) throws -> SwiftTypeBuildable? {
-        guard let resolvedFragment = resolvedDocuments.fragmentLookup[fragmentName] else {
-            return nil // fragment not used
-        }
+    ) throws -> SwiftTypeBuildable {
         let fragment = FragmentBuilder(
             configuration: configuration,
             document: document,
             resolvedFragment: resolvedFragment,
-            resolvedDocuments: resolvedDocuments
+            typeName: typeName,
+            typeScope: typeScope,
+            includesSelectionSet: includesSelectionSet
         )
         return try fragment.buildable()
     }

--- a/Sources/GraphQLCodegen/Output/Documents/SelectionSetTypePlan.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/SelectionSetTypePlan.swift
@@ -1,0 +1,48 @@
+struct SelectionSetTypePlan {
+    struct Declaration {
+        enum Origin {
+            case codingKeys
+            case responseKey(String)
+        }
+
+        let name: SwiftTypeIdentifier
+        let origin: Origin
+    }
+
+    let declarations: [Declaration]
+    let fields: [ResolvedField]
+    let hasFragments: Bool
+
+    init<S: Sequence>(
+        selectionSet: ResolvedSelectionSet,
+        conformances: S
+    ) where S.Element == String {
+        var declarations: [Declaration] = []
+        var fields: [ResolvedField] = []
+        var hasFragments = false
+        for (responseKey, selection) in selectionSet {
+            switch selection {
+            case .field(let field, _):
+                fields.append(field)
+                if field.type.unwrappedMap() != nil {
+                    declarations.append(
+                        Declaration(
+                            name: SwiftTypeIdentifier(capitalizing: responseKey),
+                            origin: .responseKey(responseKey)
+                        )
+                    )
+                }
+            case .fragmentSpread:
+                hasFragments = true
+            }
+        }
+        if !fields.isEmpty, conformances.contains(where: { conformance in
+            SwiftConformanceName(source: conformance).usesCodingKeys
+        }) {
+            declarations.append(Declaration(name: .codingKeys, origin: .codingKeys))
+        }
+        self.declarations = declarations
+        self.fields = fields
+        self.hasFragments = hasFragments
+    }
+}

--- a/Sources/GraphQLCodegen/Output/GeneratedTypeDeclaration.swift
+++ b/Sources/GraphQLCodegen/Output/GeneratedTypeDeclaration.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct GeneratedTypeDeclaration {
+    enum Origin: CustomStringConvertible {
+        case api(String)
+        case fragment(name: String, file: URL)
+        case operation(name: String?, file: URL)
+        case schema(String)
+
+        var description: String {
+            switch self {
+            case .api(let name):
+                "Generated API type: \(name)"
+            case .fragment(let name, let file):
+                "Fragment: \(name)\nFile: \(file)"
+            case .operation(let name, let file):
+                "Operation: \(name ?? "<unnamed>")\nFile: \(file)"
+            case .schema(let name):
+                "Schema type: \(name)"
+            }
+        }
+
+        var resolution: String {
+            switch self {
+            case .api:
+                "Rename the conflicting generated GraphQL definition."
+            case .fragment:
+                "Rename the fragment so it produces a distinct Swift type name."
+            case .operation:
+                "Rename the operation so it produces a distinct Swift type name."
+            case .schema:
+                "Rename the schema type so it produces a distinct Swift type name."
+            }
+        }
+    }
+
+    let name: SwiftTypeIdentifier
+    let origin: Origin
+    let conformances: [String]
+}

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -1,30 +1,80 @@
 import Foundation
 
 struct SchemaWriter {
+    enum TypePlan {
+        case `enum`(Schema.Enum)
+        case inputObject(Schema.InputObject)
+        case scalar(Schema.Scalar)
+
+        var name: String {
+            switch self {
+            case .enum(let `enum`): `enum`.ast.name
+            case .inputObject(let inputObject): inputObject.ast.name
+            case .scalar(let scalar): scalar.ast.name
+            }
+        }
+    }
+
     let configuration: Configuration
-    let schema: Schema
-    let resolvedDocuments: ResolvedDocuments
+
+    let typePlans: [TypePlan]
+
+    init(configuration: Configuration, schema: Schema, resolvedDocuments: ResolvedDocuments) {
+        self.configuration = configuration
+        self.typePlans = resolvedDocuments.usedTypes.sorted().compactMap { name -> TypePlan? in
+            if let scalar = schema.typeCache.scalars[name] {
+                return scalar.ast.isNativeSwiftType ? nil : .scalar(scalar)
+            }
+            if let `enum` = schema.typeCache.enums[name] {
+                return `enum`.ast.isSystemType ? nil : .enum(`enum`)
+            }
+            return schema.typeCache.inputObjects[name].map(TypePlan.inputObject)
+        }
+    }
+
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        typePlans.map { type in
+            GeneratedTypeDeclaration(
+                name: SwiftTypeIdentifier(swiftName: type.name),
+                origin: .schema(type.name),
+                conformances: conformances(for: type)
+            )
+        }
+    }
+
+    func conformances(for type: TypePlan) -> [String] {
+        switch type {
+        case .enum:
+            ["String"] + configuration.output.schema.enums.conformances
+        case .inputObject:
+            configuration.output.schema.inputObjects.conformances
+        case .scalar:
+            []
+        }
+    }
 
     private var schemaDirectory: URL {
         configuration.output.schema.directory
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await writeCustomScalars(using: fileOutput)
-        try await writeEnums(using: fileOutput)
-        try await writeInputObjects(using: fileOutput)
+    func write(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws {
+        try await writeCustomScalars(using: fileOutput, typeScope: typeScope)
+        try await writeEnums(using: fileOutput, typeScope: typeScope)
+        try await writeInputObjects(using: fileOutput, typeScope: typeScope)
     }
 
-    private func writeCustomScalars(using fileOutput: FileOutput) async throws {
+    private func writeCustomScalars(
+        using fileOutput: FileOutput,
+        typeScope: SwiftTypeScope
+    ) async throws {
         var scalarsDir = schemaDirectory
         if let scalarDirectoryName = configuration.output.schema.scalars.directoryName {
             scalarsDir.append(path: scalarDirectoryName, directoryHint: .isDirectory)
         }
         await fileOutput.remove(at: scalarsDir)
         await fileOutput.createDirectory(at: scalarsDir)
-        for scalar in schema.typeCache.scalars.values {
-            guard !scalar.ast.isNativeSwiftType else { continue }
-            guard resolvedDocuments.usedTypes.contains(scalar.ast.name) else { continue }
+        for type in typePlans {
+            guard case .scalar(let scalar) = type else { continue }
             let filename = "\(scalar.ast.name).graphqls.swift"
             let url = scalarsDir.appending(path: filename, directoryHint: .notDirectory)
             guard !FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
@@ -35,25 +85,26 @@ struct SchemaWriter {
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.scalars.header)
             file.setImports(configuration.output.schema.scalars.importedModules)
-            file.addType(SchemaScalarBuilder(scalar: scalar))
+            file.addType(SchemaScalarBuilder(scalar: scalar, typeScope: typeScope))
             try await file.write(to: url, configuration: configuration, using: fileOutput)
         }
     }
 
-    private func writeEnums(using fileOutput: FileOutput) async throws {
+    private func writeEnums(using fileOutput: FileOutput, typeScope: SwiftTypeScope) async throws {
         var enumsDir = schemaDirectory
         if let enumDirectoryName = configuration.output.schema.enums.directoryName {
             enumsDir.append(path: enumDirectoryName, directoryHint: .isDirectory)
         }
         await fileOutput.remove(at: enumsDir)
         await fileOutput.createDirectory(at: enumsDir)
-        for `enum` in schema.typeCache.enums.values {
-            guard !`enum`.ast.isSystemType else { continue }
-            guard resolvedDocuments.usedTypes.contains(`enum`.ast.name) else { continue }
+        for type in typePlans {
+            guard case .enum(let `enum`) = type else { continue }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.enums.header)
             file.setImports(configuration.output.schema.enums.importedModules)
-            file.addType(SchemaEnumBuilder(enum: `enum`, configuration: configuration))
+            file.addType(
+                SchemaEnumBuilder(enum: `enum`, configuration: configuration, typeScope: typeScope)
+            )
             try await file.write(
                 to: enumsDir.appending(path: "\(`enum`.ast.name).graphqls.swift", directoryHint: .notDirectory),
                 configuration: configuration,
@@ -62,19 +113,22 @@ struct SchemaWriter {
         }
     }
 
-    private func writeInputObjects(using fileOutput: FileOutput) async throws {
+    private func writeInputObjects(
+        using fileOutput: FileOutput,
+        typeScope: SwiftTypeScope
+    ) async throws {
         var inputObjectsDir = schemaDirectory
         if let inputObjectDirectoryName = configuration.output.schema.inputObjects.directoryName {
             inputObjectsDir.append(path: inputObjectDirectoryName, directoryHint: .isDirectory)
         }
         await fileOutput.remove(at: inputObjectsDir)
         await fileOutput.createDirectory(at: inputObjectsDir)
-        for inputObject in schema.typeCache.inputObjects.values {
-            guard resolvedDocuments.usedTypes.contains(inputObject.ast.name) else { continue }
+        for type in typePlans {
+            guard case .inputObject(let inputObject) = type else { continue }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.inputObjects.header)
             file.setImports(configuration.output.schema.inputObjects.importedModules)
-            file.addType(SchemaInputObjectBuilder(inputObject: inputObject))
+            file.addType(SchemaInputObjectBuilder(inputObject: inputObject, typeScope: typeScope))
             try await file.write(
                 to: inputObjectsDir.appending(
                     path: "\(inputObject.ast.name).graphqls.swift",

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
@@ -1,13 +1,16 @@
 struct SchemaEnumBuilder: SwiftTypeBuildable {
     let `enum`: Schema.Enum
     let configuration: Configuration
+    let typeScope: SwiftTypeScope
 
     func build(configuration: Configuration) -> [String] {
         var builder = SwiftEnumBuilder(
             description: `enum`.ast.description,
             isPublic: configuration.output.schema.accessLevel == .public,
-            name: `enum`.ast.name,
-            conformances: ["String"] + configuration.output.schema.enums.conformances
+            name: SwiftTypeIdentifier(swiftName: `enum`.ast.name).source,
+            conformances: [typeScope.reference(.init(.swift, "String"))] +
+                configuration.output.schema.enums.conformances,
+            typeScope: typeScope
         )
         for enumValue in `enum`.ast.enumValues {
             let caseName: String

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
@@ -1,13 +1,15 @@
 struct SchemaInputObjectBuilder: SwiftTypeBuildable {
     let inputObject: Schema.InputObject
+    let typeScope: SwiftTypeScope
 
     func build(configuration: Configuration) -> [String] {
         let isPublic = configuration.output.schema.accessLevel == .public
         var builder = SwiftStructBuilder(
             description: inputObject.ast.description,
             isPublic: isPublic,
-            name: inputObject.ast.name,
-            conformances: configuration.output.schema.inputObjects.conformances
+            name: SwiftTypeIdentifier(swiftName: inputObject.ast.name).source,
+            conformances: configuration.output.schema.inputObjects.conformances,
+            typeScope: typeScope
         )
         for inputField in inputObject.ast.inputFields {
             builder.addProperty(
@@ -18,7 +20,7 @@ struct SchemaInputObjectBuilder: SwiftTypeBuildable {
                 immutable: configuration.output.schema.inputObjects.immutable,
                 name: inputField.name,
                 value: .unassigned(
-                    type: inputField.typeName,
+                    type: inputField.typeName(in: typeScope),
                     initialized: .direct(
                         defaultValue: {
                             switch inputField.type.swiftName {
@@ -45,7 +47,10 @@ struct SchemaInputObjectBuilder: SwiftTypeBuildable {
 }
 
 extension __Schema.__InputValue {
-    var typeName: String {
-        type.swiftName.inputTypeName(hasDefaultValue: defaultValue != nil)
+    func typeName(in typeScope: SwiftTypeScope) -> String {
+        type.swiftName.inputTypeName(
+            hasDefaultValue: defaultValue != nil,
+            typeScope: typeScope
+        )
     }
 }

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
@@ -1,5 +1,6 @@
 struct SchemaScalarBuilder: SwiftTypeBuildable {
     let scalar: Schema.Scalar
+    let typeScope: SwiftTypeScope
 
     func build(configuration: Configuration) -> [String] {
         var lines: [String] = []
@@ -12,7 +13,9 @@ struct SchemaScalarBuilder: SwiftTypeBuildable {
             lines.append("/// @specifiedBy \(specifiedByURL)")
         }
         let isPublic = configuration.output.schema.accessLevel == .public
-        lines.append("\(isPublic ? "public " : "")typealias \(scalar.ast.name) = String")
+        let typeName = SwiftTypeIdentifier(swiftName: scalar.ast.name).source
+        let string = typeScope.reference(.init(.swift, "String"))
+        lines.append("\(isPublic ? "public " : "")typealias \(typeName) = \(string)")
         return lines
     }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -45,8 +45,16 @@ extension SourceTypeName {
         }
     }
 
-    func inputTypeName(hasDefaultValue: Bool) -> String {
-        let typeName = formatted(formatOptional: { "GraphQLNullable<\($0)>?" })
+    func inputTypeName(hasDefaultValue: Bool, typeScope: SwiftTypeScope) -> String {
+        let typeName = formatted(
+            formatName: { name in
+                if let reference = SwiftTypeReference(nativeScalarName: name) {
+                    return typeScope.reference(reference)
+                }
+                return SwiftTypeIdentifier(swiftName: name).source
+            },
+            formatOptional: { "GraphQLNullable<\($0)>?" }
+        )
         guard hasDefaultValue else { return typeName }
         switch self {
         case .optional: return typeName

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
@@ -5,14 +5,16 @@ struct SwiftEnumBuilder: SwiftTypeBuildable {
         description: String?,
         isPublic: Bool,
         name: String,
-        conformances: [String]
+        conformances: [String],
+        typeScope: SwiftTypeScope
     ) {
         builder = SwiftTypeBuilder(
             description: description,
             isPublic: isPublic,
             type: "enum",
             name: identifier(name),
-            conformances: conformances
+            conformances: conformances,
+            typeScope: typeScope
         )
     }
 

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
@@ -26,14 +26,16 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
         description: String?,
         isPublic: Bool,
         name: String,
-        conformances: [String]
+        conformances: [String],
+        typeScope: SwiftTypeScope
     ) {
         builder = SwiftTypeBuilder(
             description: description,
             isPublic: isPublic,
             type: "struct",
             name: identifier(name),
-            conformances: conformances
+            conformances: conformances,
+            typeScope: typeScope
         )
     }
 

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
@@ -20,7 +20,8 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
         isPublic: Bool,
         type: String,
         name: String,
-        conformances: [String]
+        conformances: [String],
+        typeScope: SwiftTypeScope
     ) {
         var lines: [String] = []
         if let description {
@@ -28,7 +29,7 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
         }
         var line = "\(isPublic ? "public " : "")\(type) \(name)"
         if !conformances.isEmpty {
-            line.append(": " + conformances.joined(separator: ", "))
+            line.append(": " + conformances.map(typeScope.conformance).joined(separator: ", "))
         }
         line.append(" {")
         lines.append(line)

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeScope.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeScope.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 struct SwiftTypeReference: Hashable {
     enum Module: String {
         case cryptoKit = "CryptoKit"
@@ -33,14 +35,139 @@ struct SwiftTypeScope {
     }
 
     func conformance(_ source: String) -> String {
-        source
+        guard let reference = SwiftConformanceName(source: source).standardLibraryReference else {
+            return source
+        }
+        return self.reference(reference)
     }
 
     func reference(_ reference: SwiftTypeReference) -> String {
-        reference.name.source
+        guard declarations.contains(reference.name) else { return reference.name.source }
+        return reference.module.rawValue + "." + reference.name.source
     }
 
-    func qualify(_ source: String, references _: Set<SwiftTypeReference>) -> String {
-        source
+    func qualify(_ source: String, references: Set<SwiftTypeReference>) -> String {
+        let replacements = references.reduce(into: [String: String]()) { result, reference in
+            let qualified = self.reference(reference)
+            guard qualified != reference.name.source else { return }
+            result[reference.name.unescaped] = qualified
+        }
+        guard !replacements.isEmpty else { return source }
+        return source.replacingTypeReferences(replacements)
+    }
+}
+
+extension String {
+    fileprivate func replacingTypeReferences(_ replacements: [String: String]) -> String {
+        enum State {
+            case blockComment
+            case lineComment
+            case multilineString
+            case source
+            case string
+        }
+
+        let bytes = Array(utf8)
+        var output: [UInt8] = []
+        var state = State.source
+        var index = 0
+        while index < bytes.count {
+            let byte = bytes[index]
+            switch state {
+            case .source:
+                if bytes.hasPrefix([0x2F, 0x2F], at: index) {
+                    output.append(contentsOf: bytes[index ..< index + 2])
+                    index += 2
+                    state = .lineComment
+                } else if bytes.hasPrefix([0x2F, 0x2A], at: index) {
+                    output.append(contentsOf: bytes[index ..< index + 2])
+                    index += 2
+                    state = .blockComment
+                } else if bytes.hasPrefix([0x22, 0x22, 0x22], at: index) {
+                    output.append(contentsOf: bytes[index ..< index + 3])
+                    index += 3
+                    state = .multilineString
+                } else if byte == 0x22 {
+                    output.append(byte)
+                    index += 1
+                    state = .string
+                } else if byte.isIdentifierHead {
+                    let start = index
+                    index += 1
+                    while index < bytes.count, bytes[index].isIdentifierBody {
+                        index += 1
+                    }
+                    guard let identifier = String(bytes: bytes[start ..< index], encoding: .utf8) else {
+                        preconditionFailure("A substring of valid Swift source must be valid UTF-8")
+                    }
+                    let previous = output.last { !$0.isWhitespace }
+                    if previous != 0x2E, previous != 0x40, let replacement = replacements[identifier] {
+                        output.append(contentsOf: replacement.utf8)
+                    } else {
+                        output.append(contentsOf: bytes[start ..< index])
+                    }
+                } else {
+                    output.append(byte)
+                    index += 1
+                }
+            case .lineComment:
+                output.append(byte)
+                index += 1
+                if byte == 0x0A {
+                    state = .source
+                }
+            case .blockComment:
+                output.append(byte)
+                index += 1
+                if byte == 0x2A, index < bytes.count, bytes[index] == 0x2F {
+                    output.append(bytes[index])
+                    index += 1
+                    state = .source
+                }
+            case .string:
+                output.append(byte)
+                index += 1
+                if byte == 0x5C, index < bytes.count {
+                    output.append(bytes[index])
+                    index += 1
+                } else if byte == 0x22 {
+                    state = .source
+                }
+            case .multilineString:
+                if bytes.hasPrefix([0x22, 0x22, 0x22], at: index) {
+                    output.append(contentsOf: bytes[index ..< index + 3])
+                    index += 3
+                    state = .source
+                } else {
+                    output.append(byte)
+                    index += 1
+                }
+            }
+        }
+        guard let result = String(bytes: output, encoding: .utf8) else {
+            preconditionFailure("Replacing ASCII identifiers cannot invalidate UTF-8 source")
+        }
+        return result
+    }
+}
+
+extension Array where Element == UInt8 {
+    fileprivate func hasPrefix(_ prefix: [UInt8], at index: Int) -> Bool {
+        guard index + prefix.count <= count else { return false }
+        return self[index ..< index + prefix.count].elementsEqual(prefix)
+    }
+}
+
+extension UInt8 {
+    fileprivate var isIdentifierBody: Bool {
+        isIdentifierHead || (0x30 ... 0x39).contains(self)
+    }
+
+    fileprivate var isIdentifierHead: Bool {
+        self == 0x5F || (0x41 ... 0x5A).contains(self) || (0x61 ... 0x7A).contains(self)
+    }
+
+    fileprivate var isWhitespace: Bool {
+        self == 0x09 || self == 0x0A || self == 0x0D || self == 0x20
     }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeScope.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeScope.swift
@@ -1,0 +1,46 @@
+struct SwiftTypeReference: Hashable {
+    enum Module: String {
+        case cryptoKit = "CryptoKit"
+        case foundation = "Foundation"
+        case swift = "Swift"
+    }
+
+    let module: Module
+    let name: SwiftTypeIdentifier
+
+    init(_ module: Module, _ name: String) {
+        self.module = module
+        self.name = SwiftTypeIdentifier(swiftName: name)
+    }
+
+    init?(nativeScalarName: String) {
+        guard ["Bool", "Double", "Int", "String"].contains(nativeScalarName) else {
+            return nil
+        }
+        self.init(.swift, nativeScalarName)
+    }
+}
+
+struct SwiftTypeScope {
+    private let declarations: Set<SwiftTypeIdentifier>
+
+    init<S: Sequence>(declarations: S) where S.Element == SwiftTypeIdentifier {
+        self.declarations = Set(declarations)
+    }
+
+    func adding<S: Sequence>(declarations: S) -> SwiftTypeScope where S.Element == SwiftTypeIdentifier {
+        SwiftTypeScope(declarations: self.declarations.union(declarations))
+    }
+
+    func conformance(_ source: String) -> String {
+        source
+    }
+
+    func reference(_ reference: SwiftTypeReference) -> String {
+        reference.name.source
+    }
+
+    func qualify(_ source: String, references _: Set<SwiftTypeReference>) -> String {
+        source
+    }
+}

--- a/Sources/GraphQLCodegen/Resolution/Field/ResolvedField.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/ResolvedField.swift
@@ -52,12 +52,21 @@ struct ResolvedField {
 
     func sourceTypeName(
         responseKey: String,
-        scalarConversion: (_ name: String, _ isEnum: Bool) -> String = { $1 ? "GraphQLEnum<\($0)>" : $0 }
+        typeScope: SwiftTypeScope,
+        scalarConversion: (_ name: String, _ isEnum: Bool) -> String = { name, isEnum in
+            let typeName = SwiftTypeIdentifier(swiftName: name).source
+            return isEnum ? "GraphQLEnum<\(typeName)>" : typeName
+        }
     ) -> SourceTypeName {
         _sourceTypeName(
             type: type,
             responseKey: responseKey,
-            scalarConversion: scalarConversion
+            scalarConversion: { name, isEnum in
+                if !isEnum, let reference = SwiftTypeReference(nativeScalarName: name) {
+                    return typeScope.reference(reference)
+                }
+                return scalarConversion(name, isEnum)
+            }
         )
     }
 
@@ -68,7 +77,7 @@ struct ResolvedField {
     ) -> SourceTypeName {
         switch type {
         case .scalar(let name, let isEnum): .name(scalarConversion(name, isEnum))
-        case .map: .name(responseKey.capitalizedFirst)
+        case .map: .name(SwiftTypeIdentifier(capitalizing: responseKey).source)
         case .list(let innerType):
             .list(
                 _sourceTypeName(

--- a/Sources/GraphQLCodegenTests/Unit/SwiftTypeScopeTests.swift
+++ b/Sources/GraphQLCodegenTests/Unit/SwiftTypeScopeTests.swift
@@ -1,0 +1,70 @@
+@testable import GraphQLCodegen
+import Testing
+
+struct SwiftTypeScopeTests {
+    @Test
+    func leavesReferencesUnqualifiedWithoutCollision() {
+        let scope = SwiftTypeScope(declarations: [SwiftTypeIdentifier]())
+
+        #expect(scope.reference(.init(.swift, "String")) == "String")
+        #expect(scope.reference(.init(.foundation, "URL")) == "URL")
+        #expect(scope.conformance("Decodable") == "Decodable")
+        #expect(scope.conformance("Swift.Decodable") == "Decodable")
+    }
+
+    @Test
+    func qualifiesOnlyTheCollidingReference() {
+        let scope = SwiftTypeScope(
+            declarations: [
+                SwiftTypeIdentifier(swiftName: "Decoder"),
+                SwiftTypeIdentifier(swiftName: "URL"),
+            ]
+        )
+
+        #expect(scope.reference(.init(.swift, "Decoder")) == "Swift.Decoder")
+        #expect(scope.reference(.init(.foundation, "URL")) == "Foundation.URL")
+        #expect(scope.reference(.init(.swift, "String")) == "String")
+    }
+
+    @Test
+    func qualifiesStandardLibraryConformanceOnCollision() {
+        let scope = SwiftTypeScope(
+            declarations: [SwiftTypeIdentifier(swiftName: "Decodable")]
+        )
+
+        #expect(scope.conformance("Decodable") == "Swift.Decodable")
+        #expect(scope.conformance("Swift.Decodable") == "Swift.Decodable")
+        #expect(scope.conformance("CustomProtocol") == "CustomProtocol")
+    }
+
+    @Test
+    func qualifiesOnlyReferenceTokensInSource() {
+        let scope = SwiftTypeScope(
+            declarations: [
+                SwiftTypeIdentifier(swiftName: "Decoder"),
+                SwiftTypeIdentifier(swiftName: "Sendable"),
+            ]
+        )
+        let source = """
+        /// Decoder remains unchanged in documentation.
+        let decoder: Decoder
+        let nested: Operation.Decoder
+        let closure: @Sendable () -> Void
+        let text = "Decoder"
+        """
+
+        let qualified = scope.qualify(
+            source,
+            references: [
+                .init(.swift, "Decoder"),
+                .init(.swift, "Sendable"),
+            ]
+        )
+
+        #expect(qualified.contains("/// Decoder remains unchanged"))
+        #expect(qualified.contains("let decoder: Swift.Decoder"))
+        #expect(qualified.contains("let nested: Operation.Decoder"))
+        #expect(qualified.contains("@Sendable"))
+        #expect(qualified.contains("let text = \"Decoder\""))
+    }
+}

--- a/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
+++ b/Sources/StarwarsExample/API/HTTPSupport/GraphQLRequest.swift
@@ -199,7 +199,7 @@ extension GraphQLRequest {
     /// Initializes a POST request for a single-response GraphQL operation.
     init(
         operation: Operation,
-        endpoint: Foundation.URL,
+        endpoint: URL,
         automaticPersistedOperations: Bool = true,
         minifyDocument: Bool = true,
         bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),


### PR DESCRIPTION
## Summary

- build a single typed output plan before writing generated files
- model generated declaration names and system type references explicitly
- qualify Swift, Foundation, and CryptoKit references only when a generated declaration shadows them
- share selection-set declaration planning between nested type rendering and scope construction

## Why

Generated GraphQL names can shadow types referenced by generated Swift. The writers previously decided names and emitted files independently, so there was no authoritative view of the declarations visible to each reference. This establishes that model and makes references collision-aware without adding module qualifiers to normal output.

## Impact

Normal generated source remains unqualified. A reference gains its module prefix only when required for valid Swift; the checked-in GraphQLRequest example now uses the ordinary unqualified URL spelling.

## Checks

- swift test
- swiftlint lint --strict
- swift build -c release
- git diff --check