### PR TITLE
Trim GraphQL AST projection

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -16,12 +16,10 @@ enum GraphQLAST {
     }
 
     struct Name: Decodable {
-        let loc: Location
         let value: String
     }
 
     struct Document: Decodable {
-        let loc: Location
         let definitions: [Definition]
     }
 
@@ -48,7 +46,6 @@ enum GraphQLAST {
         let operation: OperationType
         let name: Name?
         let variableDefinitions: [VariableDefinition]
-        let directives: [Directive]
         let selectionSet: SelectionSet
     }
 
@@ -59,20 +56,16 @@ enum GraphQLAST {
     }
 
     struct VariableDefinition: Decodable, Sendable {
-        let loc: Location
         let variable: Variable
         let type: TypeNode
         let defaultValue: ConstValue?
-        let directives: [ConstDirective]?
     }
 
     struct Variable: Decodable {
-        let loc: Location
         let name: Name
     }
 
     struct SelectionSet: Decodable, Sendable {
-        let loc: Location
         let selections: [Selection]
     }
 
@@ -112,10 +105,8 @@ enum GraphQLAST {
     }
 
     struct Field: Decodable {
-        let loc: Location
         let alias: Name?
         let name: Name
-        let arguments: [Argument]
         let directives: [Directive]
         let selectionSet: SelectionSet?
 
@@ -124,26 +115,12 @@ enum GraphQLAST {
         }
     }
 
-    struct Argument: Decodable, Sendable {
-        let loc: Location
-        let name: Name
-        let value: Value
-    }
-
-    struct ConstArgument: Decodable {
-        let loc: Location
-        let name: Name
-        let value: ConstValue
-    }
-
     struct FragmentSpread: Decodable {
-        let loc: Location
         let name: Name
         let directives: [Directive]
     }
 
     struct InlineFragment: Decodable {
-        let loc: Location
         let typeCondition: NamedType?
         let directives: [Directive]
         let selectionSet: SelectionSet
@@ -153,47 +130,7 @@ enum GraphQLAST {
         let loc: Location
         let name: Name
         let typeCondition: NamedType
-        let directives: [Directive]
         let selectionSet: SelectionSet
-    }
-
-    enum Value: Decodable, Sendable {
-        case variable(Variable)
-        case int(IntValue)
-        case float(FloatValue)
-        case string(StringValue)
-        case boolean(BooleanValue)
-        case null(NullValue)
-        case `enum`(EnumValue)
-        case list(ListValue)
-        case object(ObjectValue)
-
-        private enum Kind: String, Decodable {
-            case Variable
-            case IntValue
-            case FloatValue
-            case StringValue
-            case BooleanValue
-            case NullValue
-            case EnumValue
-            case ListValue
-            case ObjectValue
-        }
-
-        init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            switch try decoder.container(keyedBy: KindCodingKey.self).decode(Kind.self, forKey: .kind) {
-            case .Variable: self = try .variable(container.decode(Variable.self))
-            case .IntValue: self = try .int(container.decode(IntValue.self))
-            case .FloatValue: self = try .float(container.decode(FloatValue.self))
-            case .StringValue: self = try .string(container.decode(StringValue.self))
-            case .BooleanValue: self = try .boolean(container.decode(BooleanValue.self))
-            case .NullValue: self = try .null(container.decode(NullValue.self))
-            case .EnumValue: self = try .enum(container.decode(EnumValue.self))
-            case .ListValue: self = try .list(container.decode(ListValue.self))
-            case .ObjectValue: self = try .object(container.decode(ObjectValue.self))
-            }
-        }
     }
 
     enum ConstValue: Decodable, Sendable {
@@ -201,7 +138,7 @@ enum GraphQLAST {
         case float(FloatValue)
         case string(StringValue)
         case boolean(BooleanValue)
-        case null(NullValue)
+        case null
         case `enum`(EnumValue)
         case list(ConstListValue)
         case object(ConstObjectValue)
@@ -245,7 +182,7 @@ enum GraphQLAST {
             case .FloatValue: self = try .float(container.decode(FloatValue.self))
             case .StringValue: self = try .string(container.decode(StringValue.self))
             case .BooleanValue: self = try .boolean(container.decode(BooleanValue.self))
-            case .NullValue: self = try .null(container.decode(NullValue.self))
+            case .NullValue: self = .null
             case .EnumValue: self = try .enum(container.decode(EnumValue.self))
             case .ListValue: self = try .list(container.decode(ConstListValue.self))
             case .ObjectValue: self = try .object(container.decode(ConstObjectValue.self))
@@ -254,76 +191,40 @@ enum GraphQLAST {
     }
 
     struct IntValue: Decodable {
-        let loc: Location
         let value: String
     }
 
     struct FloatValue: Decodable {
-        let loc: Location
         let value: String
     }
 
     struct StringValue: Decodable {
         let value: String
-        let loc: Location
     }
 
     struct BooleanValue: Decodable {
-        let loc: Location
         let value: Bool
     }
 
-    struct NullValue: Decodable {
-        let loc: Location
-    }
-
     struct EnumValue: Decodable {
-        let loc: Location
         let value: String
     }
 
-    struct ListValue: Decodable {
-        let loc: Location
-        let values: [Value]
-    }
-
     struct ConstListValue: Decodable {
-        let loc: Location
         let values: [ConstValue]
     }
 
-    struct ObjectValue: Decodable {
-        let loc: Location
-        let fields: [ObjectField]
-    }
-
     struct ConstObjectValue: Decodable {
-        let loc: Location
         let fields: [ConstObjectField]
     }
 
-    struct ObjectField: Decodable {
-        let loc: Location
-        let name: Name
-        let value: Value
-    }
-
     struct ConstObjectField: Decodable {
-        let loc: Location
         let name: Name
         let value: ConstValue
     }
 
     struct Directive: Decodable, Sendable {
-        let loc: Location
         let name: Name
-        let arguments: [Argument]?
-    }
-
-    struct ConstDirective: Decodable {
-        let loc: Location
-        let name: Name
-        let arguments: [ConstArgument]?
     }
 
     indirect enum TypeNode: Decodable, Sendable {
@@ -365,17 +266,14 @@ enum GraphQLAST {
     }
 
     struct NamedType: Decodable {
-        let loc: Location
         let name: Name
     }
 
     struct ListType: Decodable {
-        let loc: Location
         let type: TypeNode
     }
 
     struct NonNullType: Decodable {
-        let loc: Location
         let type: TypeNode
     }
 


### PR DESCRIPTION
## Summary

- remove executable-document AST fields that code generation never reads
- remove the unused runtime argument/value subtree
- represent null constant values without a location-only payload

## Why

The bundled graphql-js parser owns the wire shape, while Swift only consumes a narrow subset of that AST. Mirroring unused fields and node families added maintenance and decoding coupling without supporting current behavior.

## Impact

Generated output and public API behavior are unchanged. The Swift boundary model now contains only state consumed by document loading, resolution, and default-value rendering.

## Checks

- `swift test`
- `git diff --check`