### PR TITLE
Centralize HTTP generation planning

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/APIWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIWriter.swift
@@ -24,16 +24,20 @@ struct APIWriter {
             JSONValueWriter(configuration: configuration),
         ]
         if configuration.output.api.HTTPSupport != nil {
+            let httpGenerationPlan = HTTPGenerationPlan(
+                configuration: configuration,
+                hasSubscription: hasSubscription
+            )
             let httpOutputs: [any APIOutput] = [
-                DefaultEncodersWriter(hasSubscription: hasSubscription, configuration: configuration),
+                DefaultEncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 GraphQLOperationWriter(
                     configuration: configuration,
                     hasMutation: hasMutation,
                     hasSubscription: hasSubscription
                 ),
-                EncodersWriter(hasSubscription: hasSubscription, configuration: configuration),
+                EncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 URLSessionWriter(hasSubscription: hasSubscription, configuration: configuration),
-                GraphQLRequestWriter(hasSubscription: hasSubscription, configuration: configuration),
+                GraphQLRequestWriter(plan: httpGenerationPlan, configuration: configuration),
             ]
             outputs.append(contentsOf: httpOutputs)
         }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 struct DefaultEncodersWriter: APIOutput {
-    let hasSubscription: Bool
+    let plan: HTTPGenerationPlan
     let configuration: Configuration
     let relativePath = "HTTPSupport/DefaultEncoders.swift"
 
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "JSONBodyEncoder")]
-        if configuration.output.api.HTTPSupport?.enableGETQueries == true {
+        if plan.enablesGETQueries {
             typeNames.append(SwiftTypeIdentifier(swiftName: "DefaultURLQueryEncoder"))
         }
         return typeNames
@@ -41,26 +41,17 @@ struct DefaultEncodersWriter: APIOutput {
     }
 
     private var includeSubscriptionSupport: Bool {
-        hasSubscription && configuration.output.api.HTTPSupport?.subscriptionSupport == true
-    }
-
-    private var enableGETQueries: Bool {
-        configuration.output.api.HTTPSupport?.enableGETQueries == true
+        plan.includesSubscriptions
     }
 
     var source: String {
-        if enableGETQueries {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: getWithAutomaticPersistedOperations()
-            case .registered: getWithRegisteredPersistedOperations()
-            case .none: getWithNoPersistedOperations()
-            }
-        } else {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: postWithAutomaticPersistedOperations()
-            case .registered: postWithRegisteredPersistedOperations()
-            case .none: postWithNoPersistedOperations()
-            }
+        switch plan.mode {
+        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
+        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
+        case .getWithoutPersistence: getWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
+        case .postWithoutPersistence: postWithNoPersistedOperations()
         }
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -1,16 +1,16 @@
 import Foundation
 
 struct EncodersWriter: APIOutput {
-    let hasSubscription: Bool
+    let plan: HTTPGenerationPlan
     let configuration: Configuration
     let relativePath = "HTTPSupport/Encoders.swift"
 
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "HTTPBodyEncoder")]
-        if configuration.output.api.HTTPSupport?.enableGETQueries == true {
+        if plan.enablesGETQueries {
             typeNames.append(SwiftTypeIdentifier(swiftName: "URLQueryEncoder"))
         }
-        if case .automatic = configuration.output.documents.operations.persistedOperations {
+        if case .automatic = plan.persistence {
             typeNames.append(SwiftTypeIdentifier(swiftName: "AutomaticPersistedOperationPhase"))
         }
         return typeNames
@@ -26,26 +26,17 @@ struct EncodersWriter: APIOutput {
     }
 
     private var includeSubscriptionSupport: Bool {
-        hasSubscription && configuration.output.api.HTTPSupport?.subscriptionSupport == true
-    }
-
-    private var enableGETQueries: Bool {
-        configuration.output.api.HTTPSupport?.enableGETQueries == true
+        plan.includesSubscriptions
     }
 
     var source: String {
-        if enableGETQueries {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: getWithAutomaticPersistedOperations()
-            case .registered: getWithRegisteredPersistedOperations()
-            case .none: getWithNoPersistedOperations()
-            }
-        } else {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: postWithAutomaticPersistedOperations()
-            case .registered: postWithRegisteredPersistedOperations()
-            case .none: postWithNoPersistedOperations()
-            }
+        switch plan.mode {
+        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
+        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
+        case .getWithoutPersistence: getWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
+        case .postWithoutPersistence: postWithNoPersistedOperations()
         }
     }
 

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 struct GraphQLRequestWriter: APIOutput {
-    let hasSubscription: Bool
+    let plan: HTTPGenerationPlan
     let configuration: Configuration
     let relativePath = "HTTPSupport/GraphQLRequest.swift"
 
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "GraphQLRequest")]
-        if case .automatic = configuration.output.documents.operations.persistedOperations {
+        if case .automatic = plan.persistence {
             typeNames.append(SwiftTypeIdentifier(swiftName: "PersistedOperationRetry"))
         }
         return typeNames
@@ -23,26 +23,21 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private var includeSubscriptionSupport: Bool {
-        hasSubscription && configuration.output.api.HTTPSupport?.subscriptionSupport == true
+        plan.includesSubscriptions
     }
 
     private var enableGETQueries: Bool {
-        configuration.output.api.HTTPSupport?.enableGETQueries == true
+        plan.enablesGETQueries
     }
 
     var source: String {
-        if enableGETQueries {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: getWithAutomaticPersistedOperations()
-            case .registered: getWithRegisteredPersistedOperations()
-            case .none: getWithNoPersistedOperations()
-            }
-        } else {
-            switch configuration.output.documents.operations.persistedOperations {
-            case .automatic: postWithAutomaticPersistedOperations()
-            case .registered: postWithRegisteredPersistedOperations()
-            case .none: postWithNoPersistedOperations()
-            }
+        switch plan.mode {
+        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
+        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
+        case .getWithoutPersistence: getWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
+        case .postWithoutPersistence: postWithNoPersistedOperations()
         }
     }
 
@@ -65,7 +60,7 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private func requestStateInitializer() -> String {
-        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        guard case .automatic = plan.persistence else { return "" }
         return """
 
 
@@ -86,7 +81,7 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private func persistedOperationRetryDeclaration() -> String {
-        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        guard case .automatic = plan.persistence else { return "" }
         return """
         enum PersistedOperationRetry {
         \(persistedOperationGETRetryCase())
@@ -102,7 +97,7 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private func persistedOperationUpdate() -> String {
-        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        guard case .automatic = plan.persistence else { return "" }
         return """
 
 
@@ -152,7 +147,7 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private func requestStateProperties() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
+        switch plan.persistence {
         case .automatic:
             """
 
@@ -186,7 +181,7 @@ struct GraphQLRequestWriter: APIOutput {
     }
 
     private func operationInitializer() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
+        switch plan.persistence {
         case .automatic: automaticOperationInitializer()
         case .registered: registeredOperationInitializer()
         case .none: operationInitializerWithoutPersistence()

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/HTTPGenerationPlan.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/HTTPGenerationPlan.swift
@@ -1,0 +1,51 @@
+struct HTTPGenerationPlan {
+    enum Mode {
+        case getWithAutomaticPersistence
+        case getWithRegisteredPersistence
+        case getWithoutPersistence
+        case postWithAutomaticPersistence
+        case postWithRegisteredPersistence
+        case postWithoutPersistence
+    }
+
+    enum Persistence {
+        case automatic
+        case registered
+        case none
+    }
+
+    let includesSubscriptions: Bool
+    let mode: Mode
+    let persistence: Persistence
+
+    var enablesGETQueries: Bool {
+        switch mode {
+        case .getWithAutomaticPersistence, .getWithRegisteredPersistence, .getWithoutPersistence:
+            true
+        case .postWithAutomaticPersistence, .postWithRegisteredPersistence, .postWithoutPersistence:
+            false
+        }
+    }
+
+    init(configuration: Configuration, hasSubscription: Bool) {
+        let enablesGETQueries = configuration.output.api.HTTPSupport?.enableGETQueries == true
+        let persistence: Persistence
+        switch configuration.output.documents.operations.persistedOperations {
+        case .automatic: persistence = .automatic
+        case .registered: persistence = .registered
+        case .none: persistence = .none
+        }
+        let mode: Mode = switch (enablesGETQueries, persistence) {
+        case (true, .automatic): .getWithAutomaticPersistence
+        case (true, .registered): .getWithRegisteredPersistence
+        case (true, .none): .getWithoutPersistence
+        case (false, .automatic): .postWithAutomaticPersistence
+        case (false, .registered): .postWithRegisteredPersistence
+        case (false, .none): .postWithoutPersistence
+        }
+        self.includesSubscriptions = hasSubscription &&
+            configuration.output.api.HTTPSupport?.subscriptionSupport == true
+        self.mode = mode
+        self.persistence = persistence
+    }
+}


### PR DESCRIPTION
## What changed

- adds a concrete `HTTPGenerationPlan` for the current transport, persistence, and subscription options
- derives the six supported HTTP generation modes once in `APIWriter`
- passes that plan to request and encoder writers instead of independently interpreting configuration in each writer

## Why

The GET/POST × automatic/registered/none matrix was reconstructed independently across three writers. Centralizing the decision reduces duplicated branches and makes adding or reviewing a supported combination more predictable.

## Impact

Generated source remains unchanged; this only reorganizes generator internals around one semantic owner for the current configuration matrix.

## Validation

- `swift test` (22 tests, including generated-source equality and fixture compilation)
- `swiftlint lint --strict --quiet`
- `git diff --check`
