### PR TITLE
Model valid GraphQL type wrappers

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -346,12 +346,7 @@ enum GraphQLAST {
                 )
             )
             case .list(let innerType): return .optional(.list(innerType.type.typeName))
-            case .nonNull(let innerType):
-                let resolved = innerType.type.typeName
-                switch resolved {
-                case .optional(let unwrapped): return unwrapped
-                case .list, .name: return resolved // Already non-null
-                }
+            case .nonNull(let innerType): return innerType.type.typeName
             }
         }
 
@@ -377,7 +372,33 @@ enum GraphQLAST {
 
     struct NonNullType: Decodable {
         let loc: Location
-        let type: TypeNode
+        let type: NullableTypeNode
+    }
+
+    indirect enum NullableTypeNode: Decodable {
+        case named(NamedType)
+        case list(ListType)
+
+        private enum Kind: String, Decodable {
+            case NamedType
+            case ListType
+        }
+
+        var typeName: SourceTypeName {
+            switch self {
+            case .named(let namedType):
+                .name(SourceTypeName(nativeGraphQLScalarName: namedType.name.value)?.formatted() ?? namedType.name.value)
+            case .list(let innerType): .list(innerType.type.typeName)
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            switch try decoder.container(keyedBy: KindCodingKey.self).decode(Kind.self, forKey: .kind) {
+            case .NamedType: self = try .named(container.decode(NamedType.self))
+            case .ListType: self = try .list(container.decode(ListType.self))
+            }
+        }
     }
 
     private enum KindCodingKey: String, CodingKey {

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -4,7 +4,7 @@
 /// Keep this boundary model aligned with:
 /// https://spec.graphql.org/October2021/#sec-Schema-Introspection.Schema-Introspection-Schema
 struct __Schema: Decodable {
-    enum __Type: Decodable {
+    enum __NamedType: Decodable {
         case SCALAR(Scalar)
         case OBJECT(Object)
         case INTERFACE(Interface)
@@ -345,7 +345,7 @@ struct __Schema: Decodable {
     }
 
     let description: String?
-    let types: [__Type]
+    let types: [__NamedType]
     let queryType: __TypeRef.Object
     let mutationType: __TypeRef.Object?
     let subscriptionType: __TypeRef.Object?

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -11,8 +11,6 @@ struct __Schema: Decodable {
         case UNION(Union)
         case ENUM(Enum)
         case INPUT_OBJECT(InputObject)
-        case LIST(ofType: __TypeRef)
-        case NON_NULL(ofType: __TypeRef)
 
         struct Scalar: Decodable {
             let description: String?
@@ -68,7 +66,6 @@ struct __Schema: Decodable {
 
         private enum CodingKeys: CodingKey {
             case kind
-            case ofType
         }
 
         init(from decoder: Decoder) throws {
@@ -76,15 +73,13 @@ struct __Schema: Decodable {
                 try decoder.singleValueContainer()
             }
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            switch try container.decode(__TypeKind.self, forKey: .kind) {
+            switch try container.decode(__NamedTypeKind.self, forKey: .kind) {
             case .SCALAR: self = try .SCALAR(_container().decode(Scalar.self))
             case .OBJECT: self = try .OBJECT(_container().decode(Object.self))
             case .INTERFACE: self = try .INTERFACE(_container().decode(Interface.self))
             case .UNION: self = try .UNION(_container().decode(Union.self))
             case .ENUM: self = try .ENUM(_container().decode(Enum.self))
             case .INPUT_OBJECT: self = try .INPUT_OBJECT(_container().decode(InputObject.self))
-            case .LIST: self = try .LIST(ofType: container.decode(__TypeRef.self, forKey: .ofType))
-            case .NON_NULL: self = try .NON_NULL(ofType: container.decode(__TypeRef.self, forKey: .ofType))
             }
         }
     }
@@ -97,7 +92,7 @@ struct __Schema: Decodable {
         case ENUM(Enum)
         case INPUT_OBJECT(InputObject)
         case LIST(ofType: __TypeRef)
-        case NON_NULL(ofType: __TypeRef)
+        case NON_NULL(ofType: __NullableTypeRef)
 
         struct Scalar: Decodable {
             let name: String
@@ -212,12 +207,7 @@ struct __Schema: Decodable {
             case .ENUM(let `enum`): return .optional(.name(`enum`.name))
             case .INPUT_OBJECT(let inputObject): return .optional(.name(inputObject.name))
             case .LIST(let innerType): return .optional(.list(innerType.swiftName))
-            case .NON_NULL(let innerType):
-                let resolved = innerType.swiftName
-                switch resolved {
-                case .optional(let unwrapped): return unwrapped
-                case .list, .name: return resolved // Already non-null
-                }
+            case .NON_NULL(let innerType): return innerType.swiftName
             }
         }
 
@@ -234,7 +224,49 @@ struct __Schema: Decodable {
             case .ENUM: self = try .ENUM(_container().decode(Enum.self))
             case .INPUT_OBJECT: self = try .INPUT_OBJECT(_container().decode(InputObject.self))
             case .LIST: self = try .LIST(ofType: container.decode(__TypeRef.self, forKey: .ofType))
-            case .NON_NULL: self = try .NON_NULL(ofType: container.decode(__TypeRef.self, forKey: .ofType))
+            case .NON_NULL:
+                self = try .NON_NULL(ofType: container.decode(__NullableTypeRef.self, forKey: .ofType))
+            }
+        }
+    }
+
+    indirect enum __NullableTypeRef: Decodable {
+        case SCALAR(__TypeRef.Scalar)
+        case OBJECT(__TypeRef.Object)
+        case INTERFACE(__TypeRef.Interface)
+        case UNION(__TypeRef.Union)
+        case ENUM(__TypeRef.Enum)
+        case INPUT_OBJECT(__TypeRef.InputObject)
+        case LIST(ofType: __TypeRef)
+
+        var swiftName: SourceTypeName {
+            switch self {
+            case .SCALAR(let scalar): .name(scalar.swiftName)
+            case .OBJECT(let object): .name(object.name)
+            case .INTERFACE(let interface): .name(interface.name)
+            case .UNION(let union): .name(union.name)
+            case .ENUM(let `enum`): .name(`enum`.name)
+            case .INPUT_OBJECT(let inputObject): .name(inputObject.name)
+            case .LIST(let innerType): .list(innerType.swiftName)
+            }
+        }
+
+        init(from decoder: Decoder) throws {
+            switch try __TypeRef(from: decoder) {
+            case .SCALAR(let scalar): self = .SCALAR(scalar)
+            case .OBJECT(let object): self = .OBJECT(object)
+            case .INTERFACE(let interface): self = .INTERFACE(interface)
+            case .UNION(let union): self = .UNION(union)
+            case .ENUM(let `enum`): self = .ENUM(`enum`)
+            case .INPUT_OBJECT(let inputObject): self = .INPUT_OBJECT(inputObject)
+            case .LIST(let innerType): self = .LIST(ofType: innerType)
+            case .NON_NULL:
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "A non-null type cannot wrap another non-null type"
+                    )
+                )
             }
         }
     }
@@ -301,6 +333,15 @@ struct __Schema: Decodable {
         case INPUT_OBJECT
         case LIST
         case NON_NULL
+    }
+
+    private enum __NamedTypeKind: String, Decodable {
+        case SCALAR
+        case OBJECT
+        case INTERFACE
+        case UNION
+        case ENUM
+        case INPUT_OBJECT
     }
 
     let description: String?

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -77,21 +77,35 @@ struct Schema {
     }
 
     indirect enum Field {
-        case SCALAR(Scalar)
-        case OBJECT(Object)
-        case INTERFACE(Interface)
-        case UNION(Union)
-        case ENUM(Enum)
-        case LIST(Field)
-        case NON_NULL(Field)
+        indirect enum Value {
+            case SCALAR(Scalar)
+            case OBJECT(Object)
+            case INTERFACE(Interface)
+            case UNION(Union)
+            case ENUM(Enum)
+            case LIST(Field)
+        }
+
+        case nullable(Value)
+        case nonNull(Value)
     }
 
     indirect enum Input {
-        case SCALAR(Scalar)
-        case ENUM(Enum)
-        case INPUT_OBJECT(InputObject)
-        case LIST(Input)
-        case NON_NULL(Input)
+        indirect enum Value {
+            case SCALAR(Scalar)
+            case ENUM(Enum)
+            case INPUT_OBJECT(InputObject)
+            case LIST(Input)
+        }
+
+        case nullable(Value)
+        case nonNull(Value)
+
+        var value: Value {
+            switch self {
+            case .nullable(let value), .nonNull(let value): value
+            }
+        }
     }
 
     func queryType() throws -> Object {
@@ -129,13 +143,13 @@ struct Schema {
 
     private func fieldType(_ typeRef: __Schema.__TypeRef) throws -> Field {
         switch typeRef {
-        case .SCALAR(let scalar): .SCALAR(try type(scalar))
-        case .ENUM(let `enum`): .ENUM(try type(`enum`))
-        case .OBJECT(let objectType): .OBJECT(try type(objectType))
-        case .INTERFACE(let interfaceType): .INTERFACE(try type(interfaceType))
-        case .UNION(let unionType): .UNION(try type(unionType))
-        case .LIST(let ofType): .LIST(try fieldType(ofType))
-        case .NON_NULL(let ofType): .NON_NULL(try fieldType(ofType))
+        case .SCALAR(let scalar): .nullable(.SCALAR(try type(scalar)))
+        case .ENUM(let `enum`): .nullable(.ENUM(try type(`enum`)))
+        case .OBJECT(let objectType): .nullable(.OBJECT(try type(objectType)))
+        case .INTERFACE(let interfaceType): .nullable(.INTERFACE(try type(interfaceType)))
+        case .UNION(let unionType): .nullable(.UNION(try type(unionType)))
+        case .LIST(let ofType): .nullable(.LIST(try fieldType(ofType)))
+        case .NON_NULL(let ofType): .nonNull(try fieldValue(ofType))
         case .INPUT_OBJECT:
             throw Codegen.Error(description: """
             Selected a field \(typeRef) whose type is an input object.
@@ -144,6 +158,19 @@ struct Schema {
 
             Note: Turning on validation can help find other similar errors
             """)
+        }
+    }
+
+    private func fieldValue(_ typeRef: __Schema.__NullableTypeRef) throws -> Field.Value {
+        switch typeRef {
+        case .SCALAR(let scalar): .SCALAR(try type(scalar))
+        case .ENUM(let `enum`): .ENUM(try type(`enum`))
+        case .OBJECT(let objectType): .OBJECT(try type(objectType))
+        case .INTERFACE(let interfaceType): .INTERFACE(try type(interfaceType))
+        case .UNION(let unionType): .UNION(try type(unionType))
+        case .LIST(let ofType): .LIST(try fieldType(ofType))
+        case .INPUT_OBJECT:
+            throw Codegen.Error(description: "Invalid output type \(typeRef)")
         }
     }
 
@@ -209,13 +236,20 @@ struct Schema {
 
     private func inputType(_ typeNode: GraphQLAST.TypeNode) throws -> Input {
         switch typeNode {
-        case .named(let namedType): try inputType(namedType)
-        case .list(let listType): .LIST(try inputType(listType.type))
-        case .nonNull(let nonNullType): .NON_NULL(try inputType(nonNullType.type))
+        case .named(let namedType): .nullable(try inputValue(namedType))
+        case .list(let listType): .nullable(.LIST(try inputType(listType.type)))
+        case .nonNull(let nonNullType): .nonNull(try inputValue(nonNullType.type))
         }
     }
 
-    private func inputType(_ namedType: GraphQLAST.NamedType) throws -> Input {
+    private func inputValue(_ typeNode: GraphQLAST.NullableTypeNode) throws -> Input.Value {
+        switch typeNode {
+        case .named(let namedType): try inputValue(namedType)
+        case .list(let listType): .LIST(try inputType(listType.type))
+        }
+    }
+
+    private func inputValue(_ namedType: GraphQLAST.NamedType) throws -> Input.Value {
         let name = namedType.name.value
         if let scalarType = typeCache.scalars[name] {
             return .SCALAR(scalarType)
@@ -230,12 +264,23 @@ struct Schema {
 
     private func inputType(_ typeRef: __Schema.__TypeRef) throws -> Input {
         switch typeRef {
+        case .SCALAR(let scalar): .nullable(.SCALAR(try type(scalar)))
+        case .ENUM(let `enum`): .nullable(.ENUM(try type(`enum`)))
+        case .INPUT_OBJECT(let inputObject): .nullable(.INPUT_OBJECT(try type(inputObject)))
+        case .LIST(let ofType): .nullable(.LIST(try inputType(ofType)))
+        case .NON_NULL(let ofType): .nonNull(try inputValue(ofType))
+        case .INTERFACE, .OBJECT, .UNION: throw Codegen.Error(description: "Invalid Input Type \(typeRef)")
+        }
+    }
+
+    private func inputValue(_ typeRef: __Schema.__NullableTypeRef) throws -> Input.Value {
+        switch typeRef {
         case .SCALAR(let scalar): .SCALAR(try type(scalar))
         case .ENUM(let `enum`): .ENUM(try type(`enum`))
         case .INPUT_OBJECT(let inputObject): .INPUT_OBJECT(try type(inputObject))
         case .LIST(let ofType): .LIST(try inputType(ofType))
-        case .NON_NULL(let ofType): .NON_NULL(try inputType(ofType))
-        case .INTERFACE, .OBJECT, .UNION: throw Codegen.Error(description: "Invalid Input Type \(typeRef)")
+        case .INTERFACE, .OBJECT, .UNION:
+            throw Codegen.Error(description: "Invalid input type \(typeRef)")
         }
     }
 

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -8,32 +8,32 @@ struct Schema {
     let typeCache: TypeCache
 
     struct Object {
-        let ast: __Schema.__Type.Object
+        let ast: __Schema.__NamedType.Object
         let fields: [String: __Schema.__Field]
         let implements: Set<String>
     }
 
     struct Scalar {
-        let ast: __Schema.__Type.Scalar
+        let ast: __Schema.__NamedType.Scalar
     }
 
     struct Interface {
-        let ast: __Schema.__Type.Interface
+        let ast: __Schema.__NamedType.Interface
         let fields: [String: __Schema.__Field]
         let implements: Set<String>
     }
 
     struct Union {
-        let ast: __Schema.__Type.Union
+        let ast: __Schema.__NamedType.Union
         let possibleTypes: Set<String>
     }
 
     struct Enum {
-        let ast: __Schema.__Type.Enum
+        let ast: __Schema.__NamedType.Enum
     }
 
     struct InputObject {
-        let ast: __Schema.__Type.InputObject
+        let ast: __Schema.__NamedType.InputObject
     }
 
     enum SelectionSet {

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -28,8 +28,6 @@ struct TypeASTCache {
             case .UNION(let union): unions[union.name] = union
             case .ENUM(let `enum`): enums[`enum`.name] = `enum`
             case .INPUT_OBJECT(let inputObject): inputObjects[inputObject.name] = inputObject
-            case .LIST: break
-            case .NON_NULL: break
             }
         }
     }

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -13,12 +13,12 @@ struct LoadedSchema {
 // Type names are guaranteed to be unique
 // https://spec.graphql.org/October2021/#sel-FAHTLABDBEmrR
 struct TypeASTCache {
-    var scalars: [String: __Schema.__Type.Scalar] = [:]
-    var objects: [String: __Schema.__Type.Object] = [:]
-    var interfaces: [String: __Schema.__Type.Interface] = [:]
-    var unions: [String: __Schema.__Type.Union] = [:]
-    var enums: [String: __Schema.__Type.Enum] = [:]
-    var inputObjects: [String: __Schema.__Type.InputObject] = [:]
+    var scalars: [String: __Schema.__NamedType.Scalar] = [:]
+    var objects: [String: __Schema.__NamedType.Object] = [:]
+    var interfaces: [String: __Schema.__NamedType.Interface] = [:]
+    var unions: [String: __Schema.__NamedType.Union] = [:]
+    var enums: [String: __Schema.__NamedType.Enum] = [:]
+    var inputObjects: [String: __Schema.__NamedType.InputObject] = [:]
     init(_ schema: __Schema) {
         for type in schema.types {
             switch type {

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -171,13 +171,13 @@ struct DocumentsResolver {
     ) throws {
         var inputTypes = [try schema.inputType(variableDefinition)]
         while let inputType = inputTypes.popLast() {
-            switch inputType {
+            switch inputType.value {
             case .SCALAR(let scalar): usedTypes.insert(scalar.ast.name)
             case .ENUM(let `enum`): usedTypes.insert(`enum`.ast.name)
             case .INPUT_OBJECT(let inputObject):
                 guard usedTypes.insert(inputObject.ast.name).inserted else { continue }
                 inputTypes.append(contentsOf: try inputObject.ast.inputFields.map { try schema.inputType($0) })
-            case .LIST(let innerType), .NON_NULL(let innerType): inputTypes.append(innerType)
+            case .LIST(let innerType): inputTypes.append(innerType)
             }
         }
     }
@@ -197,11 +197,8 @@ struct DocumentsResolver {
             defer { visiting.remove(name) }
 
             for field in inputObject.ast.inputFields {
-                var type = try schema.inputType(field)
-                while case .NON_NULL(let innerType) = type {
-                    type = innerType
-                }
-                guard case .INPUT_OBJECT(let nestedInputObject) = type else { continue }
+                let type = try schema.inputType(field)
+                guard case .INPUT_OBJECT(let nestedInputObject) = type.value else { continue }
                 if try visit(nestedInputObject) {
                     return true
                 }

--- a/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
@@ -18,61 +18,57 @@ struct FieldResolver {
         _ fieldType: Schema.Field
     ) throws -> ResolvedFieldType {
         switch fieldType {
+        case .nullable(let value): .optional(innerType: try resolveFieldValue(value))
+        case .nonNull(let value): try resolveFieldValue(value)
+        }
+    }
+
+    private func resolveFieldValue(
+        _ value: Schema.Field.Value
+    ) throws -> ResolvedFieldType {
+        switch value {
         case .SCALAR(let scalarType):
-            return .optional(innerType: .scalar(typeName: scalarType.ast.swiftName, isEnum: false))
+            return .scalar(typeName: scalarType.ast.swiftName, isEnum: false)
         case .OBJECT(let objectType):
             guard let selectionSet = fieldSelection.selectionSet else {
                 throw missingSelectionSetError()
             }
-            return .optional(
-                innerType: .map(
-                    try SelectionSetResolver(
-                        onType: .OBJECT(objectType),
-                        selectionSet: selectionSet,
-                        schema: schema,
-                        documents: documents
-                    ).resolve()
-                )
+            return .map(
+                try SelectionSetResolver(
+                    onType: .OBJECT(objectType),
+                    selectionSet: selectionSet,
+                    schema: schema,
+                    documents: documents
+                ).resolve()
             )
         case .INTERFACE(let interfaceType):
             guard let selectionSet = fieldSelection.selectionSet else {
                 throw missingSelectionSetError()
             }
-            return .optional(
-                innerType: .map(
-                    try SelectionSetResolver(
-                        onType: .INTERFACE(interfaceType),
-                        selectionSet: selectionSet,
-                        schema: schema,
-                        documents: documents
-                    ).resolve()
-                )
+            return .map(
+                try SelectionSetResolver(
+                    onType: .INTERFACE(interfaceType),
+                    selectionSet: selectionSet,
+                    schema: schema,
+                    documents: documents
+                ).resolve()
             )
         case .UNION(let unionType):
             guard let selectionSet = fieldSelection.selectionSet else {
                 throw missingSelectionSetError()
             }
-            return .optional(
-                innerType: .map(
-                    try SelectionSetResolver(
-                        onType: .UNION(unionType),
-                        selectionSet: selectionSet,
-                        schema: schema,
-                        documents: documents
-                    ).resolve()
-                )
+            return .map(
+                try SelectionSetResolver(
+                    onType: .UNION(unionType),
+                    selectionSet: selectionSet,
+                    schema: schema,
+                    documents: documents
+                ).resolve()
             )
         case .ENUM(let `enum`):
-            return .optional(innerType: .scalar(typeName: `enum`.ast.name, isEnum: true))
+            return .scalar(typeName: `enum`.ast.name, isEnum: true)
         case .LIST(let innerType):
-            let resolved = try resolveFieldType(innerType)
-            return .optional(innerType: .list(innerType: resolved))
-        case .NON_NULL(let innerType):
-            let resolved = try resolveFieldType(innerType)
-            switch resolved {
-            case .optional(let innerType): return innerType
-            case .list, .map, .scalar: return resolved // already non-null
-            }
+            return .list(innerType: try resolveFieldType(innerType))
         }
     }
 


### PR DESCRIPTION
## Summary

- restrict executable-document non-null nodes to named and list types
- restrict introspection non-null references to nullable inner references
- model resolved field and input nullability explicitly
- remove already-non-null recovery branches from source type and field resolution
- exclude list and non-null wrappers from the top-level schema type collection

## Why

The previous recursive enums allowed `NonNull(NonNull(...))` and top-level wrapper types even though GraphQL cannot produce those shapes. Downstream resolvers then carried fallback branches for impossible states.

## Impact

Valid schemas and generated source are unchanged. Malformed nested non-null introspection data now fails at the decoding boundary, while internal resolution operates only on representable GraphQL types.

## Checks

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `git diff --check`