### PR TITLE
Simplify file output lifecycle

### DIFF
--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -52,11 +52,11 @@ public struct Codegen: Sendable {
         // Output
         let fileOutput = FileOutput()
         do {
-            try await outputPlan.write(using: fileOutput)
+            try outputPlan.write(using: fileOutput)
         } catch {
             let generationError = error
             do {
-                try await fileOutput.discard()
+                try fileOutput.discard()
             } catch {
                 throw Codegen.Error(description: """
                 Failed to generate output: \(generationError)
@@ -65,7 +65,7 @@ public struct Codegen: Sendable {
             }
             throw generationError
         }
-        try await fileOutput.execute()
+        try fileOutput.execute()
         print("Codegen completed in \((Date().timeIntervalSince(start) * 1000).rounded() / 1000) seconds")
     }
 }

--- a/Sources/GraphQLCodegen/Output/API/APIOutput.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIOutput.swift
@@ -12,12 +12,12 @@ protocol APIOutput: Sendable {
     var topLevelTypeNames: [SwiftTypeIdentifier] { get }
 
     /// Writes this output to its configured destination.
-    func write(using fileOutput: FileOutput) async throws
+    func write(using fileOutput: FileOutput) throws
 }
 
 extension APIOutput {
-    func write(using fileOutput: FileOutput) async throws {
-        try await source.write(
+    func write(using fileOutput: FileOutput) throws {
+        try source.write(
             to: configuration.output.api.directory.appending(
                 path: relativePath,
                 directoryHint: .notDirectory

--- a/Sources/GraphQLCodegen/Output/API/APIWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIWriter.swift
@@ -57,16 +57,16 @@ struct APIWriter {
         )
     }
 
-    func write(using fileOutput: FileOutput) async throws {
+    func write(using fileOutput: FileOutput) throws {
         let destinationPath = configuration.output.api.directory
-        await fileOutput.createDirectory(at: destinationPath)
+        fileOutput.createDirectory(at: destinationPath)
         if configuration.output.api.HTTPSupport != nil {
-            await fileOutput.createDirectory(at: httpSupportDirectory)
+            fileOutput.createDirectory(at: httpSupportDirectory)
         } else {
-            await fileOutput.remove(at: httpSupportDirectory)
+            fileOutput.remove(at: httpSupportDirectory)
         }
         for output in outputs {
-            try await output.write(using: fileOutput)
+            try output.write(using: fileOutput)
         }
     }
 }

--- a/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
+++ b/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
@@ -49,10 +49,10 @@ struct CodegenOutputPlan {
         try GeneratedTypeNameValidator(outputPlan: self).validate()
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await documentsWriter.write(using: fileOutput)
-        try await schemaWriter.write(using: fileOutput)
-        try await apiWriter.write(using: fileOutput)
-        try await manifestWriter?.write(using: fileOutput)
+    func write(using fileOutput: FileOutput) throws {
+        try documentsWriter.write(using: fileOutput)
+        try schemaWriter.write(using: fileOutput)
+        try apiWriter.write(using: fileOutput)
+        try manifestWriter?.write(using: fileOutput)
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -74,12 +74,12 @@ struct DocumentsWriter {
         documentPlans.flatMap(\.definitions).map(\.declaration)
     }
 
-    func write(using fileOutput: FileOutput) async throws {
+    func write(using fileOutput: FileOutput) throws {
         try validateOutputURLs()
         switch configuration.output.documents.directory {
         case .definition: break
         case .directory(let url):
-            await fileOutput.createDirectory(at: url)
+            fileOutput.createDirectory(at: url)
         }
         for plannedDocument in documentPlans {
             let document = plannedDocument.document
@@ -115,14 +115,14 @@ struct DocumentsWriter {
             }
             let outputURL = document.outputURL(configuration)
             if emptyFile {
-                await fileOutput.remove(at: outputURL)
+                fileOutput.remove(at: outputURL)
             } else {
-                try await file.write(to: outputURL, configuration: configuration, using: fileOutput)
+                try file.write(to: outputURL, configuration: configuration, using: fileOutput)
             }
         }
         let generated = documentPlans.map { $0.document.outputURL(configuration) }
         let removed = Set(previouslyGenerated).subtracting(generated)
-        await fileOutput.remove(at: removed)
+        fileOutput.remove(at: removed)
     }
 
     private func validateOutputURLs() throws {

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-actor FileOutput {
+final class FileOutput {
     struct TransactionError: Swift.Error, CustomStringConvertible {
         let description: String
     }
@@ -27,36 +27,25 @@ actor FileOutput {
         var published: [StagedFile] = []
     }
 
-    private enum State {
-        case staging
-        case recoveryRequired
-        case finished
-    }
-
     private let temporaryDirectory = FileManager.default.temporaryDirectory
     private var directoriesToCreate: Set<URL> = []
     private var urlsToRemove: Set<URL> = []
     private var urlsToSave: Set<URL> = []
     private var stagedFiles: [StagedFile] = []
-    private var state = State.staging
 
     func createDirectory(at destination: URL) {
-        requireStaging()
         directoriesToCreate.insert(destination)
     }
 
     func remove(at url: URL) {
-        requireStaging()
         urlsToRemove.insert(url)
     }
 
     func remove(at urls: any Sequence<URL>) {
-        requireStaging()
         urlsToRemove.formUnion(urls)
     }
 
     func save(at url: URL) {
-        requireStaging()
         urlsToSave.insert(url)
     }
 
@@ -66,14 +55,12 @@ actor FileOutput {
     }
 
     func write(_ data: Data, to url: URL) throws {
-        requireStaging()
         let tempURL = temporaryURL()
         try data.write(to: tempURL)
         stagedFiles.append(StagedFile(temporaryURL: tempURL, finalURL: url, kind: .generated))
     }
 
     func execute() throws {
-        requireStaging()
         var commitState = CommitState()
         do {
             try urlsToSave.sorted(by: pathOrder).forEach { url in
@@ -115,15 +102,12 @@ actor FileOutput {
             }
 
             removeCommittedBackups(commitState.backups)
-            finish()
         } catch {
             let commitError = error
             let recoveryFailures = rollback(commitState)
             if recoveryFailures.isEmpty {
-                finish()
                 throw commitError
             }
-            state = .recoveryRequired
             throw TransactionError(description: """
             Failed to commit generated output: \(commitError)
             Automatic recovery was incomplete. Recovery files were retained in the temporary directory.
@@ -133,7 +117,6 @@ actor FileOutput {
     }
 
     func discard() throws {
-        requireStaging()
         var failures: [String] = []
         for stagedFile in stagedFiles where fileExists(at: stagedFile.temporaryURL) {
             if let failure = recoveryFailure(
@@ -149,7 +132,6 @@ actor FileOutput {
             \(failures.joined(separator: "\n"))
             """)
         }
-        finish()
     }
 
     private func rollback(_ commitState: CommitState) -> [String] {
@@ -312,24 +294,10 @@ actor FileOutput {
     private func temporaryURL() -> URL {
         temporaryDirectory.appendingPathComponent(UUID().uuidString)
     }
-
-    private func requireStaging() {
-        guard case .staging = state else {
-            preconditionFailure("FileOutput can only stage changes before commit or discard")
-        }
-    }
-
-    private func finish() {
-        directoriesToCreate.removeAll()
-        urlsToRemove.removeAll()
-        urlsToSave.removeAll()
-        stagedFiles.removeAll()
-        state = .finished
-    }
 }
 
 extension String {
-    func write(to url: URL, using fileOutput: FileOutput) async throws {
-        try await fileOutput.write(Data(utf8), to: url)
+    func write(to url: URL, using fileOutput: FileOutput) throws {
+        try fileOutput.write(Data(utf8), to: url)
     }
 }

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -4,7 +4,7 @@ struct PersistedOperationManifestWriter {
     let manifestURL: URL
     let documents: Documents
 
-    func write(using fileOutput: FileOutput) async throws {
+    func write(using fileOutput: FileOutput) throws {
         var operations: [PersistedOperationManifest.Operation] = []
         for document in documents.documents {
             for definition in document.definitions {
@@ -27,6 +27,6 @@ struct PersistedOperationManifestWriter {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(manifest)
-        try await fileOutput.write(data, to: manifestURL)
+        try fileOutput.write(data, to: manifestURL)
     }
 }

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -45,50 +45,50 @@ struct SchemaWriter {
         configuration.output.schema.directory
     }
 
-    func write(using fileOutput: FileOutput) async throws {
-        try await writeCustomScalars(using: fileOutput)
-        try await writeEnums(using: fileOutput)
-        try await writeInputObjects(using: fileOutput)
+    func write(using fileOutput: FileOutput) throws {
+        try writeCustomScalars(using: fileOutput)
+        try writeEnums(using: fileOutput)
+        try writeInputObjects(using: fileOutput)
     }
 
-    private func writeCustomScalars(using fileOutput: FileOutput) async throws {
+    private func writeCustomScalars(using fileOutput: FileOutput) throws {
         var scalarsDir = schemaDirectory
         if let scalarDirectoryName = configuration.output.schema.scalars.directoryName {
             scalarsDir.append(path: scalarDirectoryName, directoryHint: .isDirectory)
         }
-        await fileOutput.remove(at: scalarsDir)
-        await fileOutput.createDirectory(at: scalarsDir)
+        fileOutput.remove(at: scalarsDir)
+        fileOutput.createDirectory(at: scalarsDir)
         for type in typePlans {
             guard case .scalar(let scalar) = type else { continue }
             let filename = "\(scalar.ast.name).graphqls.swift"
             let url = scalarsDir.appending(path: filename, directoryHint: .notDirectory)
             guard !FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
                 // Will not overwrite existing scalar file
-                await fileOutput.save(at: url)
+                fileOutput.save(at: url)
                 continue
             }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.scalars.header)
             file.setImports(configuration.output.schema.scalars.importedModules)
             file.addType(SchemaScalarBuilder(scalar: scalar))
-            try await file.write(to: url, configuration: configuration, using: fileOutput)
+            try file.write(to: url, configuration: configuration, using: fileOutput)
         }
     }
 
-    private func writeEnums(using fileOutput: FileOutput) async throws {
+    private func writeEnums(using fileOutput: FileOutput) throws {
         var enumsDir = schemaDirectory
         if let enumDirectoryName = configuration.output.schema.enums.directoryName {
             enumsDir.append(path: enumDirectoryName, directoryHint: .isDirectory)
         }
-        await fileOutput.remove(at: enumsDir)
-        await fileOutput.createDirectory(at: enumsDir)
+        fileOutput.remove(at: enumsDir)
+        fileOutput.createDirectory(at: enumsDir)
         for type in typePlans {
             guard case .enum(let `enum`) = type else { continue }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.enums.header)
             file.setImports(configuration.output.schema.enums.importedModules)
             file.addType(SchemaEnumBuilder(enum: `enum`, configuration: configuration))
-            try await file.write(
+            try file.write(
                 to: enumsDir.appending(path: "\(`enum`.ast.name).graphqls.swift", directoryHint: .notDirectory),
                 configuration: configuration,
                 using: fileOutput
@@ -96,20 +96,20 @@ struct SchemaWriter {
         }
     }
 
-    private func writeInputObjects(using fileOutput: FileOutput) async throws {
+    private func writeInputObjects(using fileOutput: FileOutput) throws {
         var inputObjectsDir = schemaDirectory
         if let inputObjectDirectoryName = configuration.output.schema.inputObjects.directoryName {
             inputObjectsDir.append(path: inputObjectDirectoryName, directoryHint: .isDirectory)
         }
-        await fileOutput.remove(at: inputObjectsDir)
-        await fileOutput.createDirectory(at: inputObjectsDir)
+        fileOutput.remove(at: inputObjectsDir)
+        fileOutput.createDirectory(at: inputObjectsDir)
         for type in typePlans {
             guard case .inputObject(let inputObject) = type else { continue }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.inputObjects.header)
             file.setImports(configuration.output.schema.inputObjects.importedModules)
             file.addType(SchemaInputObjectBuilder(inputObject: inputObject))
-            try await file.write(
+            try file.write(
                 to: inputObjectsDir.appending(
                     path: "\(inputObject.ast.name).graphqls.swift",
                     directoryHint: .notDirectory

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
@@ -5,7 +5,7 @@ struct SwiftFileWriter {
     private var imports: [String] = []
     private var types: [SwiftTypeBuildable] = []
 
-    func write(to file: URL, configuration: Configuration, using fileOutput: FileOutput) async throws {
+    func write(to file: URL, configuration: Configuration, using fileOutput: FileOutput) throws {
         var lines: [String] = []
         if let header {
             lines.append(header)
@@ -16,7 +16,7 @@ struct SwiftFileWriter {
             lines.append(contentsOf: type.build(configuration: configuration))
             lines.append("")
         }
-        try await fileOutput.write(lines, to: file)
+        try fileOutput.write(lines, to: file)
     }
 
     mutating func setHeader(_ header: String?) {


### PR DESCRIPTION
## Summary

- replace private FileOutput actor isolation with a final class
- remove unreachable staging, recovery-required, and finished lifecycle state
- remove output-only async propagation from writers
- preserve staging, backup, commit, rollback, and recovery diagnostics

## Why

FileOutput is created inside one Codegen.run invocation, called sequentially, and discarded immediately after commit or discard. It cannot be concurrently accessed or reused after completion, so actor isolation and lifecycle guards defended against call sequences the library does not make.

## Impact

Output remains transactional. The writer graph is synchronous again, while Codegen.run remains async for schema introspection.

## Checks

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `git diff --check`