### PR TITLE
Enforce unused code checks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           swift-version: "6.3"
 
+      - uses: jdx/mise-action@v3
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -51,15 +53,13 @@ jobs:
       - name: Build
         run: swift build --build-tests -v
 
+      - name: Periphery
+        run: mise run periphery -- --format github-actions --relative-results --color never
+
       - name: Lint
         run: |
           brew install swiftlint
           swiftlint lint --strict
-
-      - name: Unused code
-        run: |
-          brew install periphery
-          periphery scan --strict
 
       - name: Test
         run: swift test --skip-build -v

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,5 +56,10 @@ jobs:
           brew install swiftlint
           swiftlint lint --strict
 
+      - name: Unused code
+        run: |
+          brew install periphery
+          periphery scan --strict
+
       - name: Test
         run: swift test --skip-build -v

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,7 +1,8 @@
 retain_public: true
 report_exclude:
-  - "Sources/GraphQLCodegen/Input/Documents/AST/DocumentAST.swift"
+  - "Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift"
   - "Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift"
   - "Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifest.swift"
 exclude_targets:
+  - "GraphQLCodegenTests"
   - "StarwarsExample"

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -3,6 +3,7 @@ report_exclude:
   - "Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift"
   - "Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift"
   - "Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifest.swift"
+  - "Tests/GraphQLCodegenTests/Fixtures/Defaults/Generated/**"
+  - "Tests/GraphQLCodegenTests/GeneratedAPI/**"
 exclude_targets:
-  - "GraphQLCodegenTests"
   - "StarwarsExample"

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Operations.ResponseData.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Operations.ResponseData.swift
@@ -11,8 +11,7 @@ extension Configuration.Output.Documents.Operations {
         /// - Returns: A new `ResponseData` instance to be passed to the `Operations.operations` factory function.
         public static func responseData(
             immutable: Bool = true,
-            conformances: [String] = ["Decodable", "Sendable", "Hashable"],
-            memberwiseInitializer: Bool = false
+            conformances: [String] = ["Decodable", "Sendable", "Hashable"]
         ) -> ResponseData {
             ResponseData(
                 immutable: immutable,

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -87,7 +87,7 @@ struct SchemaWriter {
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.enums.header)
             file.setImports(configuration.output.schema.enums.importedModules)
-            file.addType(SchemaEnumBuilder(enum: `enum`, configuration: configuration))
+            file.addType(SchemaEnumBuilder(enum: `enum`))
             try file.write(
                 to: enumsDir.appending(path: "\(`enum`.ast.name).graphqls.swift", directoryHint: .notDirectory),
                 configuration: configuration,

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
@@ -1,6 +1,5 @@
 struct SchemaEnumBuilder: SwiftTypeBuildable {
     let `enum`: Schema.Enum
-    let configuration: Configuration
 
     func build(configuration: Configuration) -> [String] {
         var builder = SwiftEnumBuilder(

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+periphery = "3.8.0"
+
+[tasks.periphery]
+description = "Scan for unused Swift code using the existing debug index store"
+run = "periphery scan --skip-build --index-store-path .build/debug/index/store --strict"


### PR DESCRIPTION
## What changed

- corrects the stale `GraphQLAST.swift` report-exclusion path
- excludes generated test fixture paths while continuing to analyze the test target
- removes a no-op response-data factory parameter and a redundant stored configuration value
- pins Periphery 3.8.0 with mise and provides `mise run periphery` for local scans
- runs the strict Periphery task in CI immediately after building, reusing `.build/debug/index/store`

## Why

The repository carried a Periphery configuration that was not enforced and already referenced a nonexistent file. Running it exposed two real production declarations that had no effect, alongside expected warnings from decoded AST fields and generated fixtures. mise makes the tool version and local command reproducible.

## Impact

New unused production and test code will fail CI without triggering a second build. The removed `memberwiseInitializer` argument on `ResponseData.responseData` never influenced generated output; the document-level initializer option remains unchanged.

## Validation

- `swift build --build-tests`
- `mise run periphery` reports no unused code
- `swiftlint lint --strict` reports no violations
- `swift test --skip-build` passes all 22 tests
- CI workflow YAML parses successfully
- `git diff --check`
