### PR TITLE
Enforce persisted manifest invariant

### DIFF
--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -10,15 +10,19 @@ struct PersistedOperationManifestWriter {
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    guard case .registered(let hash) = operation.persistence else { continue }
-                    operations.append(
-                        PersistedOperationManifest.Operation(
-                            id: hash,
-                            body: operation.canonicalText,
-                            name: operation.ast.name?.value,
-                            type: operation.ast.operation.rawValue
+                    switch operation.persistence {
+                    case .registered(let hash):
+                        operations.append(
+                            PersistedOperationManifest.Operation(
+                                id: hash,
+                                body: operation.canonicalText,
+                                name: operation.ast.name?.value,
+                                type: operation.ast.operation.rawValue
+                            )
                         )
-                    )
+                    case .standard:
+                        preconditionFailure("A registered operation manifest requires registered operations")
+                    }
                 case .fragment: break
                 }
             }


### PR DESCRIPTION
## Summary

- replace the silent non-registered-operation skip with an exhaustive persistence switch
- fail immediately if a registered manifest writer receives a standard operation

## Why

The manifest writer is created only for registered persistence, and the same configuration marks every loaded operation as registered. Silently continuing handled an unreachable state and could hide a future internal regression by emitting an incomplete manifest.

## Impact

Valid registered manifests are unchanged. An internal persistence mismatch now fails at its invariant instead of producing partial output.

## Checks

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `git diff --check`