### PR TITLE
Remove redundant resolution checks

### DIFF
--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -140,9 +140,7 @@ struct DocumentsResolver {
                 switch selection {
                 case .fragmentSpread(let name, _):
                     guard usage.fulfilledFragments.insert(name).inserted else { continue }
-                    guard let resolvedFragment = resolvedFragments[name] else {
-                        throw Codegen.Error(description: "Resolved fragment is missing: \(name)")
-                    }
+                    let resolvedFragment = resolvedFragments[name]!
                     selectionSets.append(resolvedFragment.resolvedSelectionSet)
                 case .field(let field, _):
                     var fieldType: ResolvedFieldType? = field.type

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -8,12 +8,9 @@ enum ResolvedSelection {
 
     func merging(with other: ResolvedSelection) throws -> ResolvedSelection {
         switch self {
-        case .fragmentSpread(let name, let checkTypename):
+        case .fragmentSpread:
             switch other {
-            case .fragmentSpread(let otherName, let otherCheckTypename):
-                assert(name == otherName)
-                assert(checkTypename == otherCheckTypename)
-                return self
+            case .fragmentSpread: return self
             case .field: throw MergeError.incompatibleSelectionTypes(self, other)
             }
         case .field(let field, let conditional):


### PR DESCRIPTION
## Summary

- remove the missing-resolved-fragment error branch from usage traversal
- remove fragment-name and typename assertions when merging identical synthetic response keys

## Why

Reachable fragment names are collected before fragments are resolved, and the resolved lookup is built from that same collection. Fragment selections merge under a key derived from their fragment name, with typename behavior derived from that same fragment and root context. The removed checks repeated invariants already guaranteed by construction.

## Impact

Resolution behavior and generated output are unchanged. The internal path now states its existing invariants directly instead of rechecking them.

## Checks

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `git diff --check`