### PR TITLE
Preserve codegen source projections

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -1,3 +1,4 @@
+// periphery:ignore:all - Retain the complete document projection for future codegen features.
 import Foundation
 
 /// Mirrors the executable-document AST produced by the bundled graphql-js parser.

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -1,3 +1,4 @@
+// periphery:ignore:all - Retain the complete schema projection for future codegen features.
 /// Mirrors the schema introspection response produced by `IntrospectionQuery`.
 ///
 /// Keep this boundary model aligned with:


### PR DESCRIPTION
## Summary

- retain the complete GraphQL document AST projection for future codegen work
- retain the complete introspection schema projection for future codegen work
- add documented file-wide Periphery ignores so intentionally unused projection fields are not suggested for cleanup

## Why

These boundary models make the full data available after parsing documents and introspecting a schema. Keeping the complete projections visible makes future codegen features easier to design without rediscovering or reconstructing the source shapes.

This supersedes and closes #45 and #46.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swiftlint lint --strict`
- `periphery scan --skip-build` (no findings from either ignored projection file)
- `git diff --check`