### PR TITLE
Document schema output directory ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 
 The code generator runs on macOS 14 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation. The generated source uses portable Foundation APIs and can be included in iOS, macOS, tvOS, and watchOS applications, subject to the APIs enabled in your configuration.
 
+## Output directory ownership
+
+Codegen assumes exclusive ownership of the configured schema output directories. Each run may remove and recreate the scalar,
+enum, and input-object directories, including files that are not part of the current generated output. Do not store unrelated or
+independently maintained files in these directories.
+
+When a schema category's `directoryName` is `nil`, that category writes directly into `Schema.directory`, and Codegen treats the
+schema root itself as an owned output directory. Customized scalar files are preserved while their scalar remains part of the
+generated output; if the scalar is no longer used by an operation, its file may be removed on the next run.
+
 ## Server-Sent Events trust requirement
 
 Only use the generated GraphQL subscription API with a trusted server. Its Foundation-based SSE parser accepts LF, CRLF, and CR line
@@ -49,13 +59,14 @@ boundary rather than protection against a malicious or compromised subscription 
 ## Table of Contents
 
 1. [Platform Support](#platform-support)
-2. [Server-Sent Events trust requirement](#server-sent-events-trust-requirement)
-3. [Getting Started](#getting-started)
-4. [Example](#example-output)
-5. [Motivation](#motivation)
-6. [Design](#design)
-7. [Contributing](#contributing)
-8. [License](#license)
+2. [Output directory ownership](#output-directory-ownership)
+3. [Server-Sent Events trust requirement](#server-sent-events-trust-requirement)
+4. [Getting Started](#getting-started)
+5. [Example](#example-output)
+6. [Motivation](#motivation)
+7. [Design](#design)
+8. [Contributing](#contributing)
+9. [License](#license)
 
 ---
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.swift
@@ -5,7 +5,8 @@ extension Configuration.Output.Schema {
     /// This differs from Enum and Input Object files which will always override existing code.
     /// This behavior allows you to customize scalar types. By default, scalars are simple String typealiases
     /// but you are free to change that and create full types for scalars, or use a typealias to an already existing
-    /// type (i.e. `Foundation.URL` or `Foundation.UUID`)
+    /// type (i.e. `Foundation.URL` or `Foundation.UUID`). A customized scalar file is preserved while its scalar
+    /// remains part of the generated output; if the scalar is no longer used, its file may be removed on the next run.
     public struct Scalars: Sendable {
         /// Call this function to create a new `Scalars` instance.
         ///

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.swift
@@ -3,12 +3,16 @@ import Foundation
 extension Configuration.Output {
     /// Options controlling generated schema types.
     /// A GraphQL schema defines scalars, enums and input objects which can be used by your operations.
+    /// Codegen assumes exclusive ownership of the schema output directories selected by this configuration
+    /// and may remove their existing contents before writing the current generated output.
     public struct Schema: Sendable {
         /// Call this function to create a new `Schema` instance.
         ///
         /// - Parameters:
-        ///   - directory: A directory URL on the local file system where generated schema files will
-        ///   be written to.
+        ///   - directory: The root directory on the local file system for generated schema files. Codegen may
+        ///   remove and recreate the configured scalar, enum, and input-object directories within this root.
+        ///   If a schema category's `directoryName` is `nil`, Codegen treats this root itself as that category's
+        ///   exclusively owned output directory. Do not store unrelated files in directories owned by Codegen.
         ///   - scalars: Options controlling the code generated to represent scalar types.
         ///   - enums: Options controlling the code generated to represent enum types
         ///   - inputObjects: Options controlling the code generated to represent input object types.


### PR DESCRIPTION
## Summary

- document exclusive ownership of configured schema output directories in the README
- clarify that disabling category nesting makes the schema root an owned output directory
- explain when customized scalar files are preserved or removed
- improve the public configuration documentation for the schema output directory

## Why

Schema generation intentionally removes and recreates its owned output directories. Users need this contract at configuration time so unrelated or independently maintained files are not placed where Codegen may delete them.

## Validation

- `git diff --check`
- `swiftlint lint --strict`
- `swift test` (22 tests passed)