### PR TITLE
Omit absent GraphQL GET parameters

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/DefaultEncoders.swift
@@ -19,12 +19,20 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
         )
         let encoder = JSONEncoder()
         return [
-            URLQueryItem(name: "operationName", value: body.operationName),
+            body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
             body.query.map { URLQueryItem(name: "query", value: $0) },
-            URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-            URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                String(decoding: try encoder.encode(extensions), as: UTF8.self)
-            })
+            try body.variables.map { variables in
+                URLQueryItem(
+                    name: "variables",
+                    value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                )
+            },
+            try body.extensions.map { extensions in
+                URLQueryItem(
+                    name: "extensions",
+                    value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                )
+            }
         ].compactMap { $0 }
     }
 }
@@ -73,7 +81,7 @@ private struct Body: Encodable {
         }
         self.operationName = Operation.operationName
         self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
-        self.variables = AnyEncodable(operation.variables)
+        self.variables = operation.requestVariables
         self.extensions = extensions
     }
 }

--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -20,11 +20,26 @@ protocol GraphQLOperation: Sendable {
     /// https://spec.graphql.org/October2021/#sec-Language.Variables
     var variables: Variables { get }
 
+    /// The operation's variables erased for request encoding.
+    /// Variable-free operations return `nil` so request encoders omit them.
+    var requestVariables: AnyEncodable? { get }
+
     /// Metadata associated with the operation to include in the request.
     var extensions: [String: AnyEncodable]? { get }
 
     associatedtype Variables: Encodable, Sendable
     associatedtype Data: Decodable, Sendable
+}
+
+extension GraphQLOperation {
+    var requestVariables: AnyEncodable? {
+        let requestVariables: AnyEncodable = AnyEncodable(variables)
+        return requestVariables
+    }
+}
+
+extension GraphQLOperation where Variables == Never? {
+    var requestVariables: AnyEncodable? { nil }
 }
 
 /// A `GraphQLSingleResponseOperation` produces one response and can be executed with `URLSession.request`.

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -77,12 +77,20 @@ struct DefaultEncodersWriter: APIOutput {
                 )
                 let encoder = JSONEncoder()
                 return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
+                    try body.variables.map { variables in
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                        )
+                    },
+                    try body.extensions.map { extensions in
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                        )
+                    }
                 ].compactMap { $0 }
             }
         }
@@ -104,12 +112,20 @@ struct DefaultEncodersWriter: APIOutput {
                 let body = Body(operation: query)
                 let encoder = JSONEncoder()
                 return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
-                ]
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
+                    try body.variables.map { variables in
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                        )
+                    },
+                    try body.extensions.map { extensions in
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                        )
+                    }
+                ].compactMap { $0 }
             }\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
@@ -136,12 +152,20 @@ struct DefaultEncodersWriter: APIOutput {
                 )
                 let encoder = JSONEncoder()
                 return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
+                    try body.variables.map { variables in
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                        )
+                    },
+                    try body.extensions.map { extensions in
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                        )
+                    }
                 ].compactMap { $0 }
             }\(subscriptionSupportWithNoPersistedOperations())
         }
@@ -221,7 +245,7 @@ struct DefaultEncodersWriter: APIOutput {
                 }
                 self.operationName = Operation.operationName
                 self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : query
-                self.variables = AnyEncodable(operation.variables)
+                self.variables = operation.requestVariables
                 self.extensions = extensions
             }
         }
@@ -255,7 +279,7 @@ struct DefaultEncodersWriter: APIOutput {
                     "sha256Hash": AnyEncodable(Operation.hash)
                 ])
                 self.operationName = Operation.operationName
-                self.variables = AnyEncodable(operation.variables)
+                self.variables = operation.requestVariables
                 self.extensions = extensions
             }
         }
@@ -295,7 +319,7 @@ struct DefaultEncodersWriter: APIOutput {
             ) {
                 self.operationName = Operation.operationName
                 self.query = minifyDocument ? Operation.minifiedDocument : Operation.document
-                self.variables = AnyEncodable(operation.variables)
+                self.variables = operation.requestVariables
                 self.extensions = operation.extensions
             }
 
@@ -312,12 +336,20 @@ struct DefaultEncodersWriter: APIOutput {
                 let body = Body(operation: subscription)
                 let encoder = JSONEncoder()
                 return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
-                ]
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
+                    try body.variables.map { variables in
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                        )
+                    },
+                    try body.extensions.map { extensions in
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                        )
+                    }
+                ].compactMap { $0 }
             }
         """
     }
@@ -337,12 +369,20 @@ struct DefaultEncodersWriter: APIOutput {
                 )
                 let encoder = JSONEncoder()
                 return [
-                    URLQueryItem(name: "operationName", value: body.operationName),
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    URLQueryItem(name: "variables", value: String(data: try encoder.encode(body.variables), encoding: .utf8)),
-                    URLQueryItem(name: "extensions", value: try body.extensions.map { extensions in
-                        String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                    })
+                    try body.variables.map { variables in
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                        )
+                    },
+                    try body.extensions.map { extensions in
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                        )
+                    }
                 ].compactMap { $0 }
             }
         """

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -44,11 +44,26 @@ struct GraphQLOperationWriter: APIOutput {
             /// https://spec.graphql.org/October2021/#sec-Language.Variables
             var variables: Variables { get }
 
+            /// The operation's variables erased for request encoding.
+            /// Variable-free operations return `nil` so request encoders omit them.
+            var requestVariables: AnyEncodable? { get }
+
             /// Metadata associated with the operation to include in the request.
             var extensions: [String: AnyEncodable]? { get }
 
             associatedtype Variables: Encodable, Sendable
             associatedtype Data: Decodable, Sendable
+        }
+
+        extension GraphQLOperation {
+            \(accessLevel)var requestVariables: AnyEncodable? {
+                let requestVariables: AnyEncodable = AnyEncodable(variables)
+                return requestVariables
+            }
+        }
+
+        extension GraphQLOperation where Variables == Never? {
+            \(accessLevel)var requestVariables: AnyEncodable? { nil }
         }
 
         /// A `GraphQLSingleResponseOperation` produces one response and can be executed with `URLSession.request`.

--- a/Tests/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -102,6 +102,7 @@ struct DefaultURLQueryEncoderTests {
         ]
 
         struct Variables: Encodable, Sendable {
+            // periphery:ignore - Used through the synthesized Encodable implementation.
             let includeDetails: Bool
         }
     }

--- a/Tests/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -11,7 +11,8 @@ struct DefaultURLQueryEncoderTests {
             minifyDocument: true
         )
 
-        #expect(queryItems.map(\.name) == ["operationName", "variables", "extensions"])
+        #expect(queryItems.map(\.name) == ["operationName", "extensions"])
+        #expect(queryItems.allSatisfy { $0.value != nil })
     }
 
     @Test
@@ -22,7 +23,51 @@ struct DefaultURLQueryEncoderTests {
             minifyDocument: true
         )
 
+        #expect(queryItems.map(\.name) == ["operationName", "query"])
+        #expect(queryItems.allSatisfy { $0.value != nil })
+    }
+
+    @Test
+    func omitsAbsentOperationName() throws {
+        let queryItems = try DefaultURLQueryEncoder().encode(
+            operation: AnonymousQuery(),
+            automaticPersistedOperationPhase: nil,
+            minifyDocument: true
+        )
+
+        #expect(queryItems.map(\.name) == ["query"])
+    }
+
+    @Test
+    func encodesPresentVariablesAndExtensionsAsJSONMaps() throws {
+        let queryItems = try DefaultURLQueryEncoder().encode(
+            operation: ParameterizedQuery(),
+            automaticPersistedOperationPhase: nil,
+            minifyDocument: true
+        )
+
         #expect(queryItems.map(\.name) == ["operationName", "query", "variables", "extensions"])
+
+        let variablesValue = try #require(queryItems.first { $0.name == "variables" }?.value)
+        let variablesData = try #require(variablesValue.data(using: .utf8))
+        let variables = try JSONDecoder().decode(EncodedVariables.self, from: variablesData)
+        #expect(variables.includeDetails)
+
+        let extensionsValue = try #require(queryItems.first { $0.name == "extensions" }?.value)
+        let extensionsData = try #require(extensionsValue.data(using: .utf8))
+        let extensions = try JSONDecoder().decode(EncodedExtensions.self, from: extensionsData)
+        #expect(extensions.requestID == "request-id")
+    }
+
+    private struct AnonymousQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = nil
+        static let document = "{ viewer { id } }"
+        static let minifiedDocument = "{viewer{id}}"
+
+        let variables: Never? = nil
+        let extensions: [String: StarwarsExample.AnyEncodable]? = nil
     }
 
     private struct CurrentUserQuery: GraphQLQuery {
@@ -34,5 +79,30 @@ struct DefaultURLQueryEncoderTests {
 
         let variables: Never? = nil
         let extensions: [String: StarwarsExample.AnyEncodable]? = nil
+    }
+
+    private struct EncodedExtensions: Decodable {
+        let requestID: String
+    }
+
+    private struct EncodedVariables: Decodable {
+        let includeDetails: Bool
+    }
+
+    private struct ParameterizedQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = "Parameterized"
+        static let document = "query Parameterized($includeDetails: Boolean!) { viewer { id } }"
+        static let minifiedDocument = "query Parameterized($includeDetails:Boolean!){viewer{id}}"
+
+        let variables = Variables(includeDetails: true)
+        let extensions: [String: StarwarsExample.AnyEncodable]? = [
+            "requestID": StarwarsExample.AnyEncodable("request-id")
+        ]
+
+        struct Variables: Encodable, Sendable {
+            let includeDetails: Bool
+        }
     }
 }


### PR DESCRIPTION
## Summary

- omit absent `operationName`, `variables`, and `extensions` from generated GET query items
- preserve variable absence through generic operation encoding with a specialized `requestVariables` representation
- continue encoding present variables and extensions as JSON maps
- regenerate the Star Wars example output and replace the legacy expectations with regression coverage

## Root cause

The GET encoder constructed `URLQueryItem` values before checking whether their payloads were absent, so `compactMap` retained items with nil values. It also encoded the optional variables container directly, which serialized a variable-free operation as JSON `null`.

Generic type erasure additionally wrapped the generated `Never? = nil` variables marker. The new computed protocol capability preserves that semantic absence before erasure while leaving generated operations' typed `variables` API unchanged.

## Impact

Variable-free requests no longer produce `variables=null`, and anonymous or extension-free requests no longer produce bare query parameters. Present variables and extensions remain JSON objects as required by GraphQL-over-HTTP.

## Validation

- `swift test --filter DefaultURLQueryEncoderTests`
- `swift test` (26 tests across 7 suites)
- regenerated Star Wars example output and verified generated-output equality
