### PR TITLE
Require macOS 26 and modernize internals

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build-lint-test:
-    runs-on: macos-latest
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -82,6 +82,7 @@ opt_in_rules:
 
 excluded:
   - .build/
+  - Examples/StarwarsExample/.build/
   - Examples/StarwarsExample/Sources/StarwarsExample/
   - Tests/GraphQLCodegenTests/Fixtures/Defaults/Generated/
   - Tests/GraphQLCodegenTests/GeneratedAPI/

--- a/Examples/StarwarsExample/Package.swift
+++ b/Examples/StarwarsExample/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "StarwarsExample",
     platforms: [
-        .macOS(.v14),
+        .macOS(.v26),
     ],
     dependencies: [
         .package(path: "../.."),

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "swift-graphql-codegen",
     platforms: [
-        .macOS(.v14),
+        .macOS(.v26),
     ],
     products: [
         .library(name: "GraphQLCodegen", targets: ["GraphQLCodegen"])

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/badge/Swift_Package_Manager-compatible-orange?style=flat-square" alt="Swift Package Manager compatible">
   </a>
   <a href="#platform-support">
-    <img src="https://img.shields.io/badge/generator-macOS%2014%2B-333333.svg" alt="Generator host: macOS 14 or newer" />
+    <img src="https://img.shields.io/badge/generator-macOS%2026%2B-333333.svg" alt="Generator host: macOS 26 or newer" />
   </a>
 </p>
 
@@ -35,7 +35,7 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 
 ## Platform Support
 
-The code generator runs on macOS 14 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation. The generated source uses portable Foundation APIs and can be included in iOS, macOS, tvOS, and watchOS applications, subject to the APIs enabled in your configuration.
+The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation. The generated source uses portable Foundation APIs and can be included in iOS, macOS, tvOS, and watchOS applications, subject to the APIs enabled in your configuration.
 
 ## Output directory ownership
 
@@ -85,7 +85,7 @@ import PackageDescription
 let package = Package(
     name: "MyCodegenCLI",
     platforms: [
-        .macOS(.v14)
+        .macOS(.v26)
     ],
     products: [
         .executable(name: "my-codegen-cli", targets: ["MyCodegenCLI"]),

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -292,7 +292,7 @@ final class FileOutput {
     }
 
     private func temporaryURL() -> URL {
-        temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        temporaryDirectory.appending(path: UUID().uuidString, directoryHint: .notDirectory)
     }
 }
 


### PR DESCRIPTION
## Summary

- raise the generator package and standalone example deployment targets from macOS 14 to macOS 26
- run CI on GitHub Actions' macOS 26 image and update installation documentation
- adopt the modern URL path-appending API now available at the new deployment target
- keep SwiftLint focused on source by excluding the standalone example's nested build artifacts

## Impact

The `GraphQLCodegen` package now requires macOS 26 or newer. Generated client source remains portable across Apple platforms as documented.

## Validation

- `swift test -Xswiftc -warnings-as-errors` — 25 tests passed
- `swiftlint lint --strict` — 0 violations
- `periphery scan --skip-build` — no unused code detected
- `git diff --check`
