### PR TITLE
Normalize anonymous operation Swift type names

### DIFF
--- a/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
@@ -33,7 +33,25 @@ struct SwiftTypeIdentifier: Hashable {
                 """)
             }
             let fileName = document.url.deletingPathExtension().lastPathComponent
-            unescaped = fileName.hasSuffix(operationType) ? fileName : fileName + operationType
+            let fileNameParts = fileName.split {
+                !$0.isLetter && !$0.isNumber && $0 != "_"
+            }
+            guard let firstFileNamePart = fileNameParts.first else {
+                throw Codegen.Error(description: """
+                Unable to derive a Swift type name for the unnamed operation because its filename contains no Swift identifier characters.
+                URL: \(document.url)
+
+                Name the GraphQL operation or rename the file.
+                """)
+            }
+            var typeName = String(firstFileNamePart)
+            for fileNamePart in fileNameParts.dropFirst() {
+                typeName += String(fileNamePart).capitalizedFirst
+            }
+            if typeName.first?.isNumber == true {
+                typeName = "_" + typeName
+            }
+            unescaped = typeName.hasSuffix(operationType) ? typeName : typeName + operationType
         }
     }
 

--- a/Tests/GraphQLCodegenTests/Tests/Integration/AnonymousOperationTypeNameTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/AnonymousOperationTypeNameTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import GraphQLCodegen
+import Testing
+
+struct AnonymousOperationTypeNameTests {
+    @Test(
+        arguments: [
+            (fileName: "current-user.graphql", typeName: "currentUserQuery"),
+            (fileName: "current_user.graphql", typeName: "current_userQuery"),
+            (fileName: "2-current-users.graphql", typeName: "_2CurrentUsersQuery"),
+        ]
+    )
+    func derivesValidTypeName(fileName: String, typeName: String) async throws {
+        let fixture = try makeFixture(documentFileName: fileName)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        try await Codegen(configuration(for: fixture)).run()
+
+        let generatedDocument = fixture.output
+            .appending(path: "Operations", directoryHint: .isDirectory)
+            .appending(path: fileName + ".swift", directoryHint: .notDirectory)
+        let source = try String(contentsOf: generatedDocument, encoding: .utf8)
+        #expect(source.contains("struct \(typeName):"))
+    }
+
+    @Test
+    func rejectsFileNameWithoutSwiftIdentifierCharacters() async throws {
+        let fixture = try makeFixture(documentFileName: "---.graphql")
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        do {
+            try await Codegen(configuration(for: fixture)).run()
+            Issue.record("Expected codegen to reject the filename")
+        } catch {
+            #expect(
+                String(describing: error).contains(
+                    "filename contains no Swift identifier characters"
+                )
+            )
+        }
+    }
+
+    private func configuration(for fixture: AnonymousOperationFixture) -> Configuration {
+        .configuration(
+            input: .input(
+                schemaSource: .SDLSchemaFile(fixture.schema),
+                documentDirectories: [fixture.operations]
+            ),
+            output: .output(
+                schema: .schema(
+                    directory: fixture.output.appending(path: "Schema", directoryHint: .isDirectory)
+                ),
+                documents: .documents(
+                    directory: .directory(
+                        fixture.output.appending(path: "Operations", directoryHint: .isDirectory)
+                    )
+                ),
+                api: .api(
+                    directory: fixture.output.appending(path: "API", directoryHint: .isDirectory)
+                )
+            )
+        )
+    }
+
+    private func makeFixture(documentFileName: String) throws -> AnonymousOperationFixture {
+        let root = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        let definitions = root.appending(path: "Definitions", directoryHint: .isDirectory)
+        let operations = definitions.appending(path: "Operations", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: operations, withIntermediateDirectories: true)
+        let schema = definitions.appending(path: "schema.sdl", directoryHint: .notDirectory)
+        try Data("type Query { currentUser: String! }".utf8).write(to: schema)
+        try Data("query { currentUser }".utf8).write(
+            to: operations.appending(path: documentFileName, directoryHint: .notDirectory)
+        )
+        return AnonymousOperationFixture(
+            root: root,
+            schema: schema,
+            operations: operations,
+            output: root.appending(path: "Output", directoryHint: .isDirectory)
+        )
+    }
+}
+
+private struct AnonymousOperationFixture {
+    let root: URL
+    let schema: URL
+    let operations: URL
+    let output: URL
+}


### PR DESCRIPTION
## Summary

- normalize anonymous operation filenames into valid Swift type names
- treat invalid filename characters as word boundaries while preserving valid underscores
- prefix identifiers derived from digit-leading filenames and report an actionable error when no identifier characters remain
- add integration coverage for separator, underscore, digit-leading, and invalid filenames

## Root cause

Anonymous operations derive their Swift type name from the GraphQL document filename. Unlike named GraphQL operations, filenames are not constrained to identifier-safe characters, so names such as `current-user.graphql` produced invalid Swift source.

## Impact

Anonymous operations now generate valid, readable Swift type identifiers without changing already-valid underscore-based names. Existing generated-type collision validation continues to report filenames that normalize to the same type.

## Testing

- `swift test` — 24 tests across 7 suites passed
