### PR TITLE
Bound SSE line buffering

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -41,7 +41,9 @@ extension URLSession {
         case invalidContentType(String?)
         case invalidMaximumBufferedResultCount(Int)
         case invalidMaximumEventByteCount(Int)
+        case invalidMaximumLineByteCount(Int)
         case invalidUTF8
+        case lineTooLarge(maximumByteCount: Int)
         case missingCompleteEvent
         case resultBufferOverflow(maximumBufferedResultCount: Int)
     }
@@ -52,23 +54,27 @@ extension URLSession {
     /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
     /// requests always include the full operation document.
     ///
-    /// Only use this API with a trusted GraphQL server. The parser buffers input until it encounters an SSE line
-    /// terminator, so the server must not send an arbitrarily long unterminated line. Complete events and queued
-    /// results remain bounded by `maximumEventByteCount` and `maximumBufferedResultCount`, respectively.
+    /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.
     ///   - decoder: The function used to turn response data into a Subscription.Data instance.
     ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
+    ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
+    ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
     ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
     func subscribe<Subscription: GraphQLSubscription>(
         _ request: GraphQLRequest<Subscription>,
         decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
         maximumEventByteCount: Int = 1_048_576,
+        maximumLineByteCount: Int = 1_052_672,
         maximumBufferedResultCount: Int = 16
     ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
         guard maximumEventByteCount > 0 else {
             throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
+        }
+        guard maximumLineByteCount > 0 else {
+            throw SubscriptionError.invalidMaximumLineByteCount(maximumLineByteCount)
         }
         guard maximumBufferedResultCount > 0 else {
             throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
@@ -86,15 +92,20 @@ extension URLSession {
             let task = Task {
                 do {
                     var accumulator = ServerSentEventAccumulator()
-                    var lineBuffer = ServerSentEventLineBuffer()
+                    var lineBuffer = ServerSentEventLineBuffer(
+                        maximumByteCount: maximumLineByteCount
+                    )
                     for try await byte in asyncBytes {
-                        guard let line = try lineBuffer.append(byte) else { continue }
-                        guard let event = try accumulator.consume(
-                            line,
-                            maximumByteCount: maximumEventByteCount
-                        ) else { continue }
+                        guard try lineBuffer.append(byte) else { continue }
+                        let event = try lineBuffer.consumeLine { line in
+                            try accumulator.consume(
+                                line,
+                                maximumByteCount: maximumEventByteCount
+                            )
+                        }
+                        guard let event else { continue }
                         switch event.name {
-                        case "next":
+                        case .next:
                             switch try decoder(event.data) {
                             case .success(let success):
                                 switch continuation.yield(success) {
@@ -110,10 +121,10 @@ extension URLSession {
                                 // TODO: Support automatic persisted operation fallback for subscriptions.
                                 throw requestError
                         }
-                        case "complete":
+                        case .complete:
                             continuation.finish()
                             return
-                        default: continue
+                        case .other: continue
                         }
                     }
                     throw SubscriptionError.missingCompleteEvent
@@ -129,72 +140,101 @@ extension URLSession {
 
     private struct ServerSentEvent {
         let data: Data
-        let name: String
+        let name: ServerSentEventName
+    }
+
+    private enum ServerSentEventName {
+        case complete
+        case next
+        case other
     }
 
     private struct ServerSentEventAccumulator {
+        private let colon: UInt8 = 0x3A
         private let dataFieldSeparator: UInt8 = 0x0A
+        private let space: UInt8 = 0x20
         private var data = Data()
         private var hasDataField = false
         private var isFirstLine = true
-        private var name = "message"
+        private var name = ServerSentEventName.other
 
         mutating func consume(
-            _ line: String,
+            _ line: UTF8Span,
             maximumByteCount: Int
         ) throws -> ServerSentEvent? {
-            var line = line
+            var bytes = line.span
             if isFirstLine {
                 isFirstLine = false
-                if line.first == "\u{FEFF}" {
-                    line.removeFirst()
+                if startsWithByteOrderMark(bytes) {
+                    bytes = bytes.extracting(droppingFirst: 3)
                 }
             }
-            guard !line.isEmpty else {
+            guard !bytes.isEmpty else {
                 defer { reset() }
                 guard hasDataField else { return nil }
                 return ServerSentEvent(data: data, name: name)
             }
-            guard !line.hasPrefix(":") else { return nil }
+            guard bytes[0] != colon else { return nil }
 
-            let field: Substring
-            let value: Substring
-            if let colonIndex = line.firstIndex(of: ":") {
-                field = line[..<colonIndex]
-                let valueStartIndex = line.index(after: colonIndex)
-                let untrimmedValue = line[valueStartIndex...]
-                value = untrimmedValue.first == " " ? untrimmedValue.dropFirst() : untrimmedValue
+            let field: Span<UInt8>
+            let value: Span<UInt8>
+            if let colonIndex = bytes.indices.first(where: { bytes[$0] == colon }) {
+                field = bytes.extracting(0..<colonIndex)
+                var valueStartIndex = colonIndex + 1
+                if valueStartIndex < bytes.count, bytes[valueStartIndex] == space {
+                    valueStartIndex += 1
+                }
+                value = bytes.extracting(valueStartIndex..<bytes.count)
             } else {
-                field = line[...]
-                value = line[line.endIndex...]
+                field = bytes
+                value = bytes.extracting(bytes.count..<bytes.count)
             }
 
-            switch field {
-            case "data":
+            if matches(field, "data".utf8) {
                 let separatorByteCount = hasDataField ? 1 : 0
                 guard data.count <= maximumByteCount - separatorByteCount else {
                     throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                 }
                 let remainingByteCount = maximumByteCount - separatorByteCount - data.count
-                guard value.utf8.count <= remainingByteCount else {
+                guard value.count <= remainingByteCount else {
                     throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                 }
                 if hasDataField {
                     data.append(dataFieldSeparator)
                 }
-                data.append(contentsOf: value.utf8)
+                value.withUnsafeBufferPointer { buffer in
+                    data.append(contentsOf: buffer)
+                }
                 hasDataField = true
-            case "event":
-                name = String(value)
-            default: break
+            } else if matches(field, "event".utf8) {
+                if matches(value, "complete".utf8) {
+                    name = .complete
+                } else if matches(value, "next".utf8) {
+                    name = .next
+                } else {
+                    name = .other
+                }
             }
             return nil
+        }
+
+        private func matches(
+            _ bytes: Span<UInt8>,
+            _ expected: String.UTF8View
+        ) -> Bool {
+            bytes.withUnsafeBufferPointer { buffer in
+                buffer.elementsEqual(expected)
+            }
         }
 
         private mutating func reset() {
             data.removeAll(keepingCapacity: true)
             hasDataField = false
-            name = "message"
+            name = .other
+        }
+
+        private func startsWithByteOrderMark(_ bytes: Span<UInt8>) -> Bool {
+            bytes.count >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF
         }
     }
 
@@ -203,32 +243,45 @@ extension URLSession {
     private struct ServerSentEventLineBuffer {
         private let carriageReturn: UInt8 = 0x0D
         private let lineFeed: UInt8 = 0x0A
+        private let maximumByteCount: Int
         private var buffer: [UInt8] = []
         private var previousByteWasCarriageReturn = false
 
-        mutating func append(_ byte: UInt8) throws -> String? {
+        init(maximumByteCount: Int) {
+            self.maximumByteCount = maximumByteCount
+        }
+
+        mutating func append(_ byte: UInt8) throws -> Bool {
             if byte == lineFeed {
                 if previousByteWasCarriageReturn {
                     previousByteWasCarriageReturn = false
-                    return nil
+                    return false
                 }
-                return try takeLine()
+                return true
             }
             previousByteWasCarriageReturn = false
             if byte == carriageReturn {
                 previousByteWasCarriageReturn = true
-                return try takeLine()
+                return true
+            }
+            guard buffer.count < maximumByteCount else {
+                throw SubscriptionError.lineTooLarge(maximumByteCount: maximumByteCount)
             }
             buffer.append(byte)
-            return nil
+            return false
         }
 
-        private mutating func takeLine() throws -> String {
+        mutating func consumeLine<Result>(
+            _ body: (UTF8Span) throws -> Result
+        ) throws -> Result {
             defer { buffer.removeAll(keepingCapacity: true) }
-            guard let line = String(bytes: buffer, encoding: .utf8) else {
+            let line: UTF8Span
+            do {
+                line = try UTF8Span(validating: buffer.span)
+            } catch {
                 throw SubscriptionError.invalidUTF8
             }
-            return line
+            return try body(line)
         }
     }
 }

--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -55,6 +55,8 @@ extension URLSession {
     /// requests always include the full operation document.
     ///
     /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
+    /// - Important: This API uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS,
+    ///   or visionOS.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.

--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -55,8 +55,7 @@ extension URLSession {
     /// requests always include the full operation document.
     ///
     /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
-    /// - Important: This API uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS,
-    ///   or visionOS.
+    /// - Important: This API requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 ## Platform Support
 
 The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation.
-Generated source deployment requirements depend on the APIs enabled in your configuration. Subscription support uses `UTF8Span`
-and requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
+Generated source deployment requirements depend on the APIs enabled in your configuration. Subscription support requires version
+26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
 
 ## Output directory ownership
 
@@ -53,8 +53,8 @@ generated output; if the scalar is no longer used by an operation, its file may 
 
 The generated GraphQL subscription API accepts LF, CRLF, and CR line endings and independently bounds SSE lines, complete event
 payloads, and decoded results waiting for the consumer. Configure these limits with `maximumLineByteCount`,
-`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing. This API uses `UTF8Span` and requires version 26 or
-newer of macOS, iOS, tvOS, watchOS, or visionOS.
+`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing. This API requires version 26 or newer of macOS, iOS,
+tvOS, watchOS, or visionOS.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweigh
 
 ## Platform Support
 
-The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation. The generated source uses portable Foundation APIs and can be included in iOS, macOS, tvOS, and watchOS applications, subject to the APIs enabled in your configuration.
+The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation.
+Generated source deployment requirements depend on the APIs enabled in your configuration. Subscription support uses `UTF8Span`
+and requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
 
 ## Output directory ownership
 
@@ -51,7 +53,8 @@ generated output; if the scalar is no longer used by an operation, its file may 
 
 The generated GraphQL subscription API accepts LF, CRLF, and CR line endings and independently bounds SSE lines, complete event
 payloads, and decoded results waiting for the consumer. Configure these limits with `maximumLineByteCount`,
-`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing.
+`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing. This API uses `UTF8Span` and requires version 26 or
+newer of macOS, iOS, tvOS, watchOS, or visionOS.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ When a schema category's `directoryName` is `nil`, that category writes directly
 schema root itself as an owned output directory. Customized scalar files are preserved while their scalar remains part of the
 generated output; if the scalar is no longer used by an operation, its file may be removed on the next run.
 
-## Server-Sent Events trust requirement
+## Server-Sent Event limits
 
-Only use the generated GraphQL subscription API with a trusted server. Its Foundation-based SSE parser accepts LF, CRLF, and CR line
-endings and bounds both complete event payloads and decoded results waiting for the consumer. The parser buffers bytes until an
-SSE line terminator arrives, however, so the server must not send an arbitrarily long unterminated line. This is an explicit trust
-boundary rather than protection against a malicious or compromised subscription endpoint.
+The generated GraphQL subscription API accepts LF, CRLF, and CR line endings and independently bounds SSE lines, complete event
+payloads, and decoded results waiting for the consumer. Configure these limits with `maximumLineByteCount`,
+`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing.
 
 ---
 
@@ -60,7 +59,7 @@ boundary rather than protection against a malicious or compromised subscription 
 
 1. [Platform Support](#platform-support)
 2. [Output directory ownership](#output-directory-ownership)
-3. [Server-Sent Events trust requirement](#server-sent-events-trust-requirement)
+3. [Server-Sent Event limits](#server-sent-event-limits)
 4. [Getting Started](#getting-started)
 5. [Example](#example-output)
 6. [Motivation](#motivation)

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
@@ -17,6 +17,7 @@ extension Configuration.Output.API {
         ///   https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#distinct-connections-mode. If your
         ///   graphql documents include one or more subscription operations, this will add a `subscribe` function to the generated URLSession
         ///   extension. The generated function bounds SSE lines, complete event payloads, and decoded results waiting for the consumer.
+        ///   Subscription support uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
         /// - Returns: A new `HTTPSupport` instance to be passed to the `API.api` factory function.
         public static func httpSupport(
             enableGETQueries: Bool = false,

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
@@ -16,8 +16,7 @@ extension Configuration.Output.API {
         ///   - subscriptionSupport: Pass `true` to enable support for subscription operations via GraphQL over Server-Sent Events:
         ///   https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#distinct-connections-mode. If your
         ///   graphql documents include one or more subscription operations, this will add a `subscribe` function to the generated URLSession
-        ///   extension. Only enable this for trusted GraphQL servers. The generated implementation buffers each SSE line until its
-        ///   terminator arrives, so an arbitrarily long unterminated line may be buffered indefinitely.
+        ///   extension. The generated function bounds SSE lines, complete event payloads, and decoded results waiting for the consumer.
         /// - Returns: A new `HTTPSupport` instance to be passed to the `API.api` factory function.
         public static func httpSupport(
             enableGETQueries: Bool = false,

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.HTTPSupport.swift
@@ -17,7 +17,7 @@ extension Configuration.Output.API {
         ///   https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#distinct-connections-mode. If your
         ///   graphql documents include one or more subscription operations, this will add a `subscribe` function to the generated URLSession
         ///   extension. The generated function bounds SSE lines, complete event payloads, and decoded results waiting for the consumer.
-        ///   Subscription support uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
+        ///   Subscription support requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
         /// - Returns: A new `HTTPSupport` instance to be passed to the `API.api` factory function.
         public static func httpSupport(
             enableGETQueries: Bool = false,

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -83,7 +83,9 @@ struct URLSessionWriter: APIOutput {
                 case invalidContentType(String?)
                 case invalidMaximumBufferedResultCount(Int)
                 case invalidMaximumEventByteCount(Int)
+                case invalidMaximumLineByteCount(Int)
                 case invalidUTF8
+                case lineTooLarge(maximumByteCount: Int)
                 case missingCompleteEvent
                 case resultBufferOverflow(maximumBufferedResultCount: Int)
             }
@@ -92,23 +94,27 @@ struct URLSessionWriter: APIOutput {
             /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
             /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode\(automaticPersistedOperationSubscriptionDocumentation())
             ///
-            /// Only use this API with a trusted GraphQL server. The parser buffers input until it encounters an SSE line
-            /// terminator, so the server must not send an arbitrarily long unterminated line. Complete events and queued
-            /// results remain bounded by `maximumEventByteCount` and `maximumBufferedResultCount`, respectively.
+            /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
             ///   `text/event-stream` set in the "accept" header.
             ///   - decoder: The function used to turn response data into a Subscription.Data instance.
             ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
+            ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
+            ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
             ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
             \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
                 decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
                 maximumEventByteCount: Int = 1_048_576,
+                maximumLineByteCount: Int = 1_052_672,
                 maximumBufferedResultCount: Int = 16
             ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
                 guard maximumEventByteCount > 0 else {
                     throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
+                }
+                guard maximumLineByteCount > 0 else {
+                    throw SubscriptionError.invalidMaximumLineByteCount(maximumLineByteCount)
                 }
                 guard maximumBufferedResultCount > 0 else {
                     throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
@@ -126,15 +132,20 @@ struct URLSessionWriter: APIOutput {
                     let task = Task {
                         do {
                             var accumulator = ServerSentEventAccumulator()
-                            var lineBuffer = ServerSentEventLineBuffer()
+                            var lineBuffer = ServerSentEventLineBuffer(
+                                maximumByteCount: maximumLineByteCount
+                            )
                             for try await byte in asyncBytes {
-                                guard let line = try lineBuffer.append(byte) else { continue }
-                                guard let event = try accumulator.consume(
-                                    line,
-                                    maximumByteCount: maximumEventByteCount
-                                ) else { continue }
+                                guard try lineBuffer.append(byte) else { continue }
+                                let event = try lineBuffer.consumeLine { line in
+                                    try accumulator.consume(
+                                        line,
+                                        maximumByteCount: maximumEventByteCount
+                                    )
+                                }
+                                guard let event else { continue }
                                 switch event.name {
-                                case "next":
+                                case .next:
                                     switch try decoder(event.data) {
                                     case .success(let success):
                                         switch continuation.yield(success) {
@@ -148,10 +159,10 @@ struct URLSessionWriter: APIOutput {
                                         }
                                     \(subscriptionRequestErrorHandling())
                                 }
-                                case "complete":
+                                case .complete:
                                     continuation.finish()
                                     return
-                                default: continue
+                                case .other: continue
                                 }
                             }
                             throw SubscriptionError.missingCompleteEvent
@@ -167,72 +178,101 @@ struct URLSessionWriter: APIOutput {
 
             private struct ServerSentEvent {
                 let data: Data
-                let name: String
+                let name: ServerSentEventName
+            }
+
+            private enum ServerSentEventName {
+                case complete
+                case next
+                case other
             }
 
             private struct ServerSentEventAccumulator {
+                private let colon: UInt8 = 0x3A
                 private let dataFieldSeparator: UInt8 = 0x0A
+                private let space: UInt8 = 0x20
                 private var data = Data()
                 private var hasDataField = false
                 private var isFirstLine = true
-                private var name = "message"
+                private var name = ServerSentEventName.other
 
                 mutating func consume(
-                    _ line: String,
+                    _ line: UTF8Span,
                     maximumByteCount: Int
                 ) throws -> ServerSentEvent? {
-                    var line = line
+                    var bytes = line.span
                     if isFirstLine {
                         isFirstLine = false
-                        if line.first == "\\u{FEFF}" {
-                            line.removeFirst()
+                        if startsWithByteOrderMark(bytes) {
+                            bytes = bytes.extracting(droppingFirst: 3)
                         }
                     }
-                    guard !line.isEmpty else {
+                    guard !bytes.isEmpty else {
                         defer { reset() }
                         guard hasDataField else { return nil }
                         return ServerSentEvent(data: data, name: name)
                     }
-                    guard !line.hasPrefix(":") else { return nil }
+                    guard bytes[0] != colon else { return nil }
 
-                    let field: Substring
-                    let value: Substring
-                    if let colonIndex = line.firstIndex(of: ":") {
-                        field = line[..<colonIndex]
-                        let valueStartIndex = line.index(after: colonIndex)
-                        let untrimmedValue = line[valueStartIndex...]
-                        value = untrimmedValue.first == " " ? untrimmedValue.dropFirst() : untrimmedValue
+                    let field: Span<UInt8>
+                    let value: Span<UInt8>
+                    if let colonIndex = bytes.indices.first(where: { bytes[$0] == colon }) {
+                        field = bytes.extracting(0..<colonIndex)
+                        var valueStartIndex = colonIndex + 1
+                        if valueStartIndex < bytes.count, bytes[valueStartIndex] == space {
+                            valueStartIndex += 1
+                        }
+                        value = bytes.extracting(valueStartIndex..<bytes.count)
                     } else {
-                        field = line[...]
-                        value = line[line.endIndex...]
+                        field = bytes
+                        value = bytes.extracting(bytes.count..<bytes.count)
                     }
 
-                    switch field {
-                    case "data":
+                    if matches(field, "data".utf8) {
                         let separatorByteCount = hasDataField ? 1 : 0
                         guard data.count <= maximumByteCount - separatorByteCount else {
                             throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                         }
                         let remainingByteCount = maximumByteCount - separatorByteCount - data.count
-                        guard value.utf8.count <= remainingByteCount else {
+                        guard value.count <= remainingByteCount else {
                             throw SubscriptionError.eventTooLarge(maximumByteCount: maximumByteCount)
                         }
                         if hasDataField {
                             data.append(dataFieldSeparator)
                         }
-                        data.append(contentsOf: value.utf8)
+                        value.withUnsafeBufferPointer { buffer in
+                            data.append(contentsOf: buffer)
+                        }
                         hasDataField = true
-                    case "event":
-                        name = String(value)
-                    default: break
+                    } else if matches(field, "event".utf8) {
+                        if matches(value, "complete".utf8) {
+                            name = .complete
+                        } else if matches(value, "next".utf8) {
+                            name = .next
+                        } else {
+                            name = .other
+                        }
                     }
                     return nil
+                }
+
+                private func matches(
+                    _ bytes: Span<UInt8>,
+                    _ expected: String.UTF8View
+                ) -> Bool {
+                    bytes.withUnsafeBufferPointer { buffer in
+                        buffer.elementsEqual(expected)
+                    }
                 }
 
                 private mutating func reset() {
                     data.removeAll(keepingCapacity: true)
                     hasDataField = false
-                    name = "message"
+                    name = .other
+                }
+
+                private func startsWithByteOrderMark(_ bytes: Span<UInt8>) -> Bool {
+                    bytes.count >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF
                 }
             }
 
@@ -241,32 +281,45 @@ struct URLSessionWriter: APIOutput {
             private struct ServerSentEventLineBuffer {
                 private let carriageReturn: UInt8 = 0x0D
                 private let lineFeed: UInt8 = 0x0A
+                private let maximumByteCount: Int
                 private var buffer: [UInt8] = []
                 private var previousByteWasCarriageReturn = false
 
-                mutating func append(_ byte: UInt8) throws -> String? {
+                init(maximumByteCount: Int) {
+                    self.maximumByteCount = maximumByteCount
+                }
+
+                mutating func append(_ byte: UInt8) throws -> Bool {
                     if byte == lineFeed {
                         if previousByteWasCarriageReturn {
                             previousByteWasCarriageReturn = false
-                            return nil
+                            return false
                         }
-                        return try takeLine()
+                        return true
                     }
                     previousByteWasCarriageReturn = false
                     if byte == carriageReturn {
                         previousByteWasCarriageReturn = true
-                        return try takeLine()
+                        return true
+                    }
+                    guard buffer.count < maximumByteCount else {
+                        throw SubscriptionError.lineTooLarge(maximumByteCount: maximumByteCount)
                     }
                     buffer.append(byte)
-                    return nil
+                    return false
                 }
 
-                private mutating func takeLine() throws -> String {
+                mutating func consumeLine<Result>(
+                    _ body: (UTF8Span) throws -> Result
+                ) throws -> Result {
                     defer { buffer.removeAll(keepingCapacity: true) }
-                    guard let line = String(bytes: buffer, encoding: .utf8) else {
+                    let line: UTF8Span
+                    do {
+                        line = try UTF8Span(validating: buffer.span)
+                    } catch {
                         throw SubscriptionError.invalidUTF8
                     }
-                    return line
+                    return try body(line)
                 }
             }
         """

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -95,8 +95,7 @@ struct URLSessionWriter: APIOutput {
             /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode\(automaticPersistedOperationSubscriptionDocumentation())
             ///
             /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
-            /// - Important: This API uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS,
-            ///   or visionOS.
+            /// - Important: This API requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
             ///   `text/event-stream` set in the "accept" header.

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -95,6 +95,8 @@ struct URLSessionWriter: APIOutput {
             /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode\(automaticPersistedOperationSubscriptionDocumentation())
             ///
             /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
+            /// - Important: This API uses `UTF8Span` and requires version 26 or newer of macOS, iOS, tvOS, watchOS,
+            ///   or visionOS.
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
             ///   `text/event-stream` set in the "accept" header.

--- a/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -68,6 +68,7 @@ struct ServerSentEventTests {
             encoding: .utf8
         )
         #expect(output.contains("maximumLineByteCount"))
+        #expect(output.contains("requires version 26 or newer"))
         #expect(output.contains("UTF8Span(validating: buffer.span)"))
         #expect(!output.contains("String(bytes: buffer, encoding: .utf8)"))
 

--- a/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -67,7 +67,9 @@ struct ServerSentEventTests {
             ),
             encoding: .utf8
         )
-        #expect(output.contains("Only use this API with a trusted GraphQL server"))
+        #expect(output.contains("maximumLineByteCount"))
+        #expect(output.contains("UTF8Span(validating: buffer.span)"))
+        #expect(!output.contains("String(bytes: buffer, encoding: .utf8)"))
 
         try #"""
         import Dispatch
@@ -87,16 +89,22 @@ struct ServerSentEventTests {
                     client?.urlProtocol(self, didFailWithError: URLError(.badURL))
                     return
                 }
-                let body: String
+                let body: Data
                 switch url.path {
                 case "/standards":
-                    body = "\u{FEFF}event: next\r\ndata: {\"data\":\rdata: {\"updates\":\"first\"}}\n\r\nevent: complete\rdata:\r\r"
+                    body = Data("\u{FEFF}event: next\r\ndata: {\"data\":\rdata: {\"updates\":\"first\"}}\n\r\nevent: complete\rdata:\r\r".utf8)
                 case "/missing-complete":
-                    body = "event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\n"
+                    body = Data("event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\n".utf8)
                 case "/oversized":
-                    body = "event: next\ndata: {\"data\":{\"updates\":\"too large\"}}\n\n"
+                    body = Data("event: next\ndata: {\"data\":{\"updates\":\"too large\"}}\n\n".utf8)
+                case "/oversized-line":
+                    body = Data(repeating: 0x61, count: 9)
+                case "/maximum-line":
+                    body = Data(":12345678901234\r\nevent: complete\r\ndata:\r\n\r\n".utf8)
+                case "/invalid-utf8":
+                    body = Data([0x3A, 0xC3, 0x28, 0x0A])
                 case "/overflow":
-                    body = "event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\nevent: next\ndata: {\"data\":{\"updates\":\"second\"}}\n\nevent: complete\ndata:\n\n"
+                    body = Data("event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\nevent: next\ndata: {\"data\":{\"updates\":\"second\"}}\n\nevent: complete\ndata:\n\n".utf8)
                 default:
                     client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
                     return
@@ -108,7 +116,7 @@ struct ServerSentEventTests {
                     headerFields: ["Content-Type": "text/event-stream"]
                 )!
                 client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: Data(body.utf8))
+                client?.urlProtocol(self, didLoad: body)
                 client?.urlProtocolDidFinishLoading(self)
             }
 
@@ -175,6 +183,26 @@ struct ServerSentEventTests {
                     throw VerificationError.failed("Event size verification failed: \(error)")
                 }
                 do {
+                    try await harness.verifyLineSizeIsBounded()
+                } catch {
+                    throw VerificationError.failed("Line size verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyMaximumLineSizeIsAccepted()
+                } catch {
+                    throw VerificationError.failed("Maximum line size verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyInvalidLineSizeFails()
+                } catch {
+                    throw VerificationError.failed("Invalid line size verification failed: \(error)")
+                }
+                do {
+                    try await harness.verifyInvalidUTF8Fails()
+                } catch {
+                    throw VerificationError.failed("UTF-8 verification failed: \(error)")
+                }
+                do {
                     try await harness.verifyResultBufferIsBounded()
                 } catch {
                     throw VerificationError.failed("Result buffer verification failed: \(error)")
@@ -232,6 +260,61 @@ struct ServerSentEventTests {
                         throw VerificationError.failed("Event limit error contained the wrong limit")
                     }
                 }
+            }
+
+            private func verifyLineSizeIsBounded() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                do {
+                    let stream = try await session.subscribe(
+                        try makeRequest(path: "oversized-line"),
+                        maximumLineByteCount: 8
+                    )
+                    for try await _ in stream {}
+                    throw VerificationError.failed("Oversized line succeeded")
+                } catch URLSession.SubscriptionError.lineTooLarge(let maximumByteCount) {
+                    guard maximumByteCount == 8 else {
+                        throw VerificationError.failed("Line limit error contained the wrong limit")
+                    }
+                }
+            }
+
+            private func verifyMaximumLineSizeIsAccepted() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                let stream = try await session.subscribe(
+                    try makeRequest(path: "maximum-line"),
+                    maximumLineByteCount: 15
+                )
+                for try await _ in stream {
+                    throw VerificationError.failed("Complete event unexpectedly yielded a result")
+                }
+            }
+
+            private func verifyInvalidLineSizeFails() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                do {
+                    _ = try await session.subscribe(
+                        try makeRequest(path: "unused"),
+                        maximumLineByteCount: 0
+                    )
+                    throw VerificationError.failed("Invalid line limit succeeded")
+                } catch URLSession.SubscriptionError.invalidMaximumLineByteCount(let maximumByteCount) {
+                    guard maximumByteCount == 0 else {
+                        throw VerificationError.failed("Invalid line limit error contained the wrong limit")
+                    }
+                }
+            }
+
+            private func verifyInvalidUTF8Fails() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                do {
+                    let stream = try await session.subscribe(try makeRequest(path: "invalid-utf8"))
+                    for try await _ in stream {}
+                    throw VerificationError.failed("Invalid UTF-8 succeeded")
+                } catch URLSession.SubscriptionError.invalidUTF8 {}
             }
 
             private func verifyResultBufferIsBounded() async throws {


### PR DESCRIPTION
## Summary

- add a configurable `maximumLineByteCount` limit to generated GraphQL SSE subscriptions
- validate completed lines without a temporary `String` allocation by borrowing the line buffer through `UTF8Span`
- parse SSE fields and recognized event names directly from UTF-8 bytes
- regenerate the Star Wars example and document all subscription buffering limits
- cover oversized lines, exact-boundary lines, invalid limits, and malformed UTF-8

## Why

The generated SSE parser bounded accumulated event data and decoded results, but its line buffer continued growing until a line terminator arrived. A compromised endpoint could therefore exhaust client memory with an arbitrarily long unterminated line.

## Impact

Generated subscriptions now default to a 1 MiB + 4 KiB line limit, providing framing headroom for a default maximum-sized event payload. Callers can configure the limit independently. Exceeding it terminates the stream with `SubscriptionError.lineTooLarge`, while invalid limits fail before the request starts.

The parser no longer allocates a full-line `String`; `UTF8Span` validates and borrows the existing byte storage, and only event data is copied into its required persistent buffer.

Generated subscription support requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS. This deployment requirement is documented in the platform overview, configuration API, and generated subscription API.

## Validation

- `swift test` — 27 tests passed
- focused `ServerSentEventTests` after the documentation follow-up
- `swiftlint lint --strict`
- `mise run periphery -- --format xcode --relative-results --color never`
- `swift build -c release`
- `git diff --check`
