### PR TITLE
Preserve nested type conditionality

### DIFF
--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -12,6 +12,7 @@ struct SelectionSetResolver {
         try collect(
             selectionSet: selectionSet,
             onType: onType,
+            inConditionalTypeCondition: false,
             inOptionalDirective: false
         )
     }
@@ -19,6 +20,7 @@ struct SelectionSetResolver {
     private func collect(
         selectionSet: GraphQLAST.SelectionSet,
         onType: Schema.SelectionSet,
+        inConditionalTypeCondition: Bool,
         inOptionalDirective: Bool
     ) throws -> ResolvedSelectionSet {
         var resolvedSelectionSet = ResolvedSelectionSet()
@@ -35,7 +37,7 @@ struct SelectionSetResolver {
                         schema: schema,
                         documents: documents
                     ).resolve()
-                let conditional = self.onType.name != onType.name ||
+                let conditional = inConditionalTypeCondition ||
                     inOptionalDirective ||
                     selection.hasOptionalDirective
                 try resolvedSelectionSet.addSelection(
@@ -79,15 +81,20 @@ struct SelectionSetResolver {
                         let fragmentGroupedSelections = try collect(
                             selectionSet: fragment.ast.selectionSet,
                             onType: fragmentType,
+                            inConditionalTypeCondition: inConditionalTypeCondition ||
+                                !schema.isFragment(fragmentType, alwaysFulfilledBy: onType),
                             inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
                         )
                         try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
                     }
                 }
             case .inlineFragment(let inlineFragment):
+                let fragmentType = try schema.fragmentType(inlineFragment) ?? onType
                 let fragmentGroupedSelections = try collect(
                     selectionSet: inlineFragment.selectionSet,
-                    onType: try schema.fragmentType(inlineFragment) ?? onType,
+                    onType: fragmentType,
+                    inConditionalTypeCondition: inConditionalTypeCondition ||
+                        !schema.isFragment(fragmentType, alwaysFulfilledBy: onType),
                     inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
                 )
                 try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -84,6 +84,31 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func preservesConditionalityAcrossNestedTypeConditions() async throws {
+        let output = try await runCodegen(
+            document: """
+            query Hero {
+              hero {
+                ... on Human {
+                  ... on Character {
+                    name
+                  }
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { name: String! }
+            type Human implements Character { name: String! }
+            type Droid implements Character { name: String! }
+            """
+        )
+
+        #expect(output.contains("let name: String?"))
+    }
+
+    @Test
     func rejectsAliasesThatProduceConflictingNestedTypeNames() async {
         await expectCodegenError(containing: "conflicting Swift nested type names") {
             try await runCodegen(


### PR DESCRIPTION
## Summary

- carry conditional type state through recursive selection-set collection
- evaluate nested type conditions relative to their immediate parent type
- add a regression test for `Character → Human → Character`

## Root cause

`SelectionSetResolver` determined field conditionality by comparing only the current type name with the original selection-set root. A nested condition that narrowed from `Character` to `Human` and then widened back to `Character` therefore appeared unconditional, even though the field is absent when the runtime object is a `Droid`.

## Impact

Generated fields retain optionality whenever any ancestor type condition is conditional, preventing decoding failures when a response legitimately omits those fields.

## Validation

- `swift test` (28 tests passed)
- `mise run lint` (0 violations)
- `git diff --check`
