### PR TITLE
Handle SSE complete events without data

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -172,7 +172,7 @@ extension URLSession {
             }
             guard !bytes.isEmpty else {
                 defer { reset() }
-                guard hasDataField else { return nil }
+                guard hasDataField || name == .complete else { return nil }
                 return ServerSentEvent(data: data, name: name)
             }
             guard bytes[0] != colon else { return nil }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -210,7 +210,7 @@ struct URLSessionWriter: APIOutput {
                     }
                     guard !bytes.isEmpty else {
                         defer { reset() }
-                        guard hasDataField else { return nil }
+                        guard hasDataField || name == .complete else { return nil }
                         return ServerSentEvent(data: data, name: name)
                     }
                     guard bytes[0] != colon else { return nil }

--- a/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -94,6 +94,8 @@ struct ServerSentEventTests {
                 switch url.path {
                 case "/standards":
                     body = Data("\u{FEFF}event: next\r\ndata: {\"data\":\rdata: {\"updates\":\"first\"}}\n\r\nevent: complete\rdata:\r\r".utf8)
+                case "/complete-without-data":
+                    body = Data("event: complete\n\n".utf8)
                 case "/missing-complete":
                     body = Data("event: next\ndata: {\"data\":{\"updates\":\"first\"}}\n\n".utf8)
                 case "/oversized":
@@ -174,6 +176,11 @@ struct ServerSentEventTests {
                     throw VerificationError.failed("Standards verification failed: \(error)")
                 }
                 do {
+                    try await harness.verifyCompletionWithoutData()
+                } catch {
+                    throw VerificationError.failed("Data-free completion verification failed: \(error)")
+                }
+                do {
                     try await harness.verifyMissingCompletionFails()
                 } catch {
                     throw VerificationError.failed("Completion verification failed: \(error)")
@@ -233,6 +240,15 @@ struct ServerSentEventTests {
                 }
                 guard values == ["first"] else {
                     throw VerificationError.failed("Standards-compliant event was not decoded")
+                }
+            }
+
+            private func verifyCompletionWithoutData() async throws {
+                let session = makeSession()
+                defer { session.invalidateAndCancel() }
+                let stream = try await session.subscribe(try makeRequest(path: "complete-without-data"))
+                for try await _ in stream {
+                    throw VerificationError.failed("Complete event unexpectedly yielded a result")
                 }
             }
 


### PR DESCRIPTION
## Summary

- dispatch GraphQL-over-SSE `complete` events even when they omit a `data` field
- add integration coverage for an `event: complete` block with no payload
- refresh the generated Star Wars fixture

## Root cause

The SSE accumulator only emitted an event block after observing a `data` field. GraphQL-over-SSE completion is fully represented by the `complete` event name, so a valid payload-free completion was discarded and the stream later failed with `missingCompleteEvent`.

## Impact

Subscription streams now finish normally when a compliant server sends `event: complete` without `data:`. Other payload-free SSE events remain ignored, and streams that genuinely omit completion still fail as before.

## Validation

- `swift test` (27 tests passed)
- `swiftlint lint --strict --quiet`
- `git diff --check`
