### PR TITLE
Preserve GraphQL enum wire values

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/Codegen.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/Codegen.swift
@@ -16,7 +16,8 @@ struct StarwarsCodegen {
                 ),
                 output: .output(
                     schema: .schema(
-                        directory: currentFileDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
+                        directory: currentFileDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory),
+                        enums: .enums(caseConversion: .conversion(from: .macro, to: .lowerCamel))
                     ),
                     api: .api(
                         directory: currentFileDirectory.appending(path: "API", directoryHint: .isDirectory),

--- a/Examples/StarwarsExample/Sources/StarwarsExample/SchemaTypes/Enums/Episode.graphqls.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/SchemaTypes/Enums/Episode.graphqls.swift
@@ -1,8 +1,8 @@
 // @generated
 
 enum Episode: String, Encodable, Sendable {
-    case NEW_HOPE
-    case EMPIRE
-    case JEDI
+    case newHope = "NEW_HOPE"
+    case empire = "EMPIRE"
+    case jedi = "JEDI"
 }
 

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaEnumBuilder.swift
@@ -2,6 +2,7 @@ struct SchemaEnumBuilder: SwiftTypeBuildable {
     let `enum`: Schema.Enum
 
     func build(configuration: Configuration) -> [String] {
+        let caseConversion = configuration.output.schema.enums.caseConversion
         var builder = SwiftEnumBuilder(
             description: `enum`.ast.description,
             isPublic: configuration.output.schema.accessLevel == .public,
@@ -9,16 +10,12 @@ struct SchemaEnumBuilder: SwiftTypeBuildable {
             conformances: ["String"] + configuration.output.schema.enums.conformances
         )
         for enumValue in `enum`.ast.enumValues {
-            let caseName: String
-            if let caseConversion = configuration.output.schema.enums.caseConversion {
-                caseName = caseConversion.convert(enumValue.name)
-            } else {
-                caseName = enumValue.name
-            }
+            let caseName = caseConversion?.convert(enumValue.name) ?? enumValue.name
             builder.addCase(
                 description: enumValue.description,
                 deprecation: enumValue.isDeprecated ? Deprecation(reason: enumValue.deprecationReason) : nil,
-                name: caseName
+                name: caseName,
+                rawValue: caseConversion == nil ? nil : enumValue.name
             )
         }
         return builder.build(configuration: configuration)

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
@@ -23,7 +23,8 @@ struct SwiftEnumBuilder: SwiftTypeBuildable {
     mutating func addCase(
         description: String?,
         deprecation: Deprecation?,
-        name: String
+        name: String,
+        rawValue: String? = nil
     ) {
         if let description {
             builder.addComment(description)
@@ -31,6 +32,10 @@ struct SwiftEnumBuilder: SwiftTypeBuildable {
         if let deprecation {
             builder.addDeprecation(deprecation.reason)
         }
-        builder.addLine("case \(identifier(name))")
+        var declaration = "case \(identifier(name))"
+        if let rawValue {
+            declaration.append(" = \(SwiftSource(value: rawValue).singleLineStringLiteral)")
+        }
+        builder.addLine(declaration)
     }
 }

--- a/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
@@ -16,6 +16,7 @@ struct GeneratedTypeNameValidator {
 
     func validate() throws {
         try validateTopLevelDeclarations()
+        try validateSchemaEnumCaseNames()
         try validateDocumentScopes()
     }
 
@@ -33,6 +34,26 @@ struct GeneratedTypeNameValidator {
                 )
             }
             declarationByTypeName[declaration.name] = declaration
+        }
+    }
+
+    private func validateSchemaEnumCaseNames() throws {
+        guard let caseConversion = configuration.output.schema.enums.caseConversion else { return }
+        for typePlan in outputPlan.schemaWriter.typePlans {
+            guard case .enum(let `enum`) = typePlan else { continue }
+            var graphQLValueByCaseName: [String: String] = [:]
+            for enumValue in `enum`.ast.enumValues {
+                let caseName = caseConversion.convert(enumValue.name)
+                if let conflictingGraphQLValue = graphQLValueByCaseName[caseName] {
+                    throw enumCaseNameConflictError(
+                        enumName: `enum`.ast.name,
+                        graphQLValue: enumValue.name,
+                        conflictingGraphQLValue: conflictingGraphQLValue,
+                        caseName: caseName
+                    )
+                }
+                graphQLValueByCaseName[caseName] = enumValue.name
+            }
         }
     }
 
@@ -237,6 +258,24 @@ struct GeneratedTypeNameValidator {
         Swift type name: \(declaration.name.source)
 
         \(declaration.origin.resolution)
+        """)
+    }
+
+    private func enumCaseNameConflictError(
+        enumName: String,
+        graphQLValue: String,
+        conflictingGraphQLValue: String,
+        caseName: String
+    ) -> Codegen.Error {
+        Codegen.Error(description: """
+        GraphQL enum values produce conflicting Swift case names after case conversion.
+        Enum: \(enumName)
+        GraphQL values:
+        \(conflictingGraphQLValue)
+        \(graphQLValue)
+        Swift case name: \(identifier(caseName))
+
+        Change the enum case conversion or rename the GraphQL enum values so the generated case names are distinct.
         """)
     }
 

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -61,7 +61,8 @@ struct GraphQLCodeGeneratorTests {
                 ),
                 output: .output(
                     schema: .schema(
-                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
+                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory),
+                        enums: .enums(caseConversion: .conversion(from: .macro, to: .lowerCamel))
                     ),
                     documents: .documents(
                         directory: .directory(
@@ -249,6 +250,30 @@ struct GraphQLCodeGeneratorTests {
                 enum ViewerQuery { VALUE }
                 type Query { value: ViewerQuery! }
                 """
+            )
+        }
+    }
+
+    @Test
+    func rejectsEnumCaseNamesThatCollideAfterConversion() async {
+        await expectCodegenError(
+            containing: [
+                "GraphQL enum values produce conflicting Swift case names after case conversion",
+                "NORTH_WEST",
+                "NORTH__WEST",
+                "Swift case name: northWest",
+            ]
+        ) {
+            try await runCodegen(
+                document: "query Compass { direction }",
+                schema: """
+                enum Direction {
+                  NORTH_WEST
+                  NORTH__WEST
+                }
+                type Query { direction: Direction! }
+                """,
+                enumCaseConversion: .conversion(from: .macro, to: .lowerCamel)
             )
         }
     }
@@ -442,6 +467,7 @@ struct GraphQLCodeGeneratorTests {
     private func runCodegen(
         document: String,
         schema: String,
+        enumCaseConversion: Configuration.Output.Schema.Enums.CaseConversion? = nil,
         responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"]
     ) async throws -> String {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
@@ -467,7 +493,8 @@ struct GraphQLCodeGeneratorTests {
                 ),
                 output: .output(
                     schema: .schema(
-                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
+                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory),
+                        enums: .enums(caseConversion: enumCaseConversion)
                     ),
                     documents: .documents(
                         directory: .directory(operationsDirectory),

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLRequestTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLRequestTests.swift
@@ -68,12 +68,19 @@ struct GraphQLRequestTests {
     }
 
     private let endpoint = URL(string: "https://example.com/graphql")!
-    private let operation = HeroQuery(episode: .JEDI)
+    private let operation = HeroQuery(episode: .jedi)
+
+    @Test
+    func convertedEnumCasesPreserveGraphQLWireValues() throws {
+        #expect(Episode.newHope.rawValue == "NEW_HOPE")
+        let decoded = try JSONDecoder().decode(GraphQLEnum<Episode>.self, from: Data(#""NEW_HOPE""#.utf8))
+        #expect(decoded == .known(.newHope))
+    }
 
     @Test
     func compiledFixtureSupportsMutationAndSubscriptionRequests() throws {
         let mutationRequest = try GraphQLRequest(
-            operation: SetFavoriteEpisodeMutation(episode: .JEDI),
+            operation: SetFavoriteEpisodeMutation(episode: .jedi),
             endpoint: endpoint
         )
         #expect(mutationRequest.urlRequest.httpMethod == "POST")


### PR DESCRIPTION
## Summary

- emit explicit GraphQL raw values for enum cases when Swift case conversion is enabled
- reject converted enum case-name collisions before writing generated output
- exercise converted enums through compiled request encoding and response decoding coverage

## Root cause

`SchemaEnumBuilder` converted the Swift case identifier but omitted an explicit raw value. Swift therefore synthesized the converted identifier as the raw value, changing the GraphQL wire representation. The same conversion could also map distinct GraphQL values to one Swift case name and produce invalid generated code.

## Impact

Generated converted cases now preserve their schema values, for example:

```swift
case northWest = "NORTH_WEST"
```

Variables encode the original GraphQL value, responses decode as known cases, and ambiguous converted names produce a targeted code generation error.

## Validation

- `swift test -Xswiftc -warnings-as-errors` — 29 tests passed
- `mise run lint` — 0 violations
- `mise run periphery` — no unused code detected
- `git diff --check`
