### PR TITLE
Clean up Periphery configuration

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,8 +1,5 @@
 retain_public: true
 report_exclude:
-  - "Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift"
-  - "Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift"
-  - "Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifest.swift"
   - "Tests/GraphQLCodegenTests/Fixtures/Defaults/Generated/**"
   - "Tests/GraphQLCodegenTests/GeneratedAPI/**"
 exclude_targets:

--- a/mise.toml
+++ b/mise.toml
@@ -9,4 +9,4 @@ run = "swiftlint lint --strict"
 
 [tasks.periphery]
 description = "Scan for unused Swift code using the existing debug index store"
-run = "periphery scan --skip-build --index-store-path .build/debug/index/store --strict"
+run = "periphery scan --skip-build --index-store-path .build/debug/index/store --strict --no-superfluous-ignore-comments --disable-update-check"


### PR DESCRIPTION
## Summary

- remove redundant report exclusions for the GraphQL AST and introspection models, which already use file-local `periphery:ignore:all` directives
- remove the stale `PersistedOperationManifest.swift` report exclusion because Periphery reports no unused code there
- disable superfluous-ignore diagnostics and automatic update checks in the shared Periphery task

## Why

Keeping intentional file-wide retention beside the affected source avoids duplicating exceptions in `.periphery.yml`. Disabling update checks also keeps the mise-pinned Periphery invocation deterministic in local development and CI.

This changes code-analysis configuration only; it does not affect generated output or runtime behavior.

## Validation

- `swift build --build-tests`
- `mise run lint`
- `mise run periphery -- --format github-actions --relative-results --color never`
- `swift test --skip-build` (33 tests passed)
