### PR TITLE
Preserve named fragment conditionality

### DIFF
--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -34,7 +34,7 @@ extension SwiftStructBuilder {
                             .direct(defaultValue: nil) : nil
                     )
                 )
-            case .fragmentSpread(let fragmentSpreadName, let checkTypename):
+            case .fragmentSpread(let fragmentSpreadName, let checkTypenames):
                 addProperty(
                     description: nil,
                     deprecation: nil,
@@ -44,7 +44,7 @@ extension SwiftStructBuilder {
                     name: responseKey,
                     value: .unassigned(
                         type: SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source +
-                            (checkTypename != nil ? "?" : ""),
+                            (checkTypenames != nil ? "?" : ""),
                         initialized: configuration.output.documents.memberwiseInitializer ?
                             .direct(defaultValue: nil) : nil
                     )
@@ -175,14 +175,19 @@ extension SwiftStructBuilder {
         for (responseKey, selection) in selectionSet {
             switch selection {
             case .field: break
-            case .fragmentSpread(let fragmentSpreadName, let checkTypename):
+            case .fragmentSpread(let fragmentSpreadName, let checkTypenames):
                 let fragmentTypeName = SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source
                 var assignment = "\(identifier(responseKey)) = "
-                if let checkTypename {
+                if let checkTypenames {
                     if !hasNonnilTypenameField {
                         throw SelectionSetError.fragmentSpreadNeedsTypename(fragmentSpread: fragmentSpreadName)
                     }
-                    assignment.append("__typename == \"\(checkTypename)\" ? ")
+                    assignment.append(
+                        checkTypenames
+                            .sorted()
+                            .map { "__typename == \"\($0)\"" }
+                            .joined(separator: " || ") + " ? "
+                    )
                     assignment.append("try \(fragmentTypeName)(from: decoder) : nil")
                 } else {
                     assignment.append("try \(fragmentTypeName)(from: decoder)")

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -3,14 +3,18 @@ import OrderedCollections
 typealias ResolvedSelectionSet = OrderedDictionary<String, ResolvedSelection>
 
 enum ResolvedSelection {
-    case fragmentSpread(String, checkTypename: String?)
+    case fragmentSpread(String, checkTypenames: Set<String>?)
     case field(ResolvedField, conditional: Bool)
 
     func merging(with other: ResolvedSelection) throws -> ResolvedSelection {
         switch self {
-        case .fragmentSpread:
+        case .fragmentSpread(let name, let checkTypenames):
             switch other {
-            case .fragmentSpread: return self
+            case .fragmentSpread(_, let otherCheckTypenames):
+                guard let checkTypenames, let otherCheckTypenames else {
+                    return .fragmentSpread(name, checkTypenames: nil)
+                }
+                return .fragmentSpread(name, checkTypenames: checkTypenames.union(otherCheckTypenames))
             case .field: throw MergeError.incompatibleSelectionTypes(self, other)
             }
         case .field(let field, let conditional):

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -1,6 +1,19 @@
 import OrderedCollections
 
 struct SelectionSetResolver {
+    private enum TypeCondition {
+        case abstract
+        case always
+        case typename(String)
+
+        var isConditional: Bool {
+            switch self {
+            case .abstract, .typename: true
+            case .always: false
+            }
+        }
+    }
+
     let onType: Schema.SelectionSet
     let selectionSet: GraphQLAST.SelectionSet
     let schema: Schema
@@ -12,7 +25,7 @@ struct SelectionSetResolver {
         try collect(
             selectionSet: selectionSet,
             onType: onType,
-            inConditionalTypeCondition: false,
+            typeCondition: .always,
             inOptionalDirective: false
         )
     }
@@ -20,7 +33,7 @@ struct SelectionSetResolver {
     private func collect(
         selectionSet: GraphQLAST.SelectionSet,
         onType: Schema.SelectionSet,
-        inConditionalTypeCondition: Bool,
+        typeCondition: TypeCondition,
         inOptionalDirective: Bool
     ) throws -> ResolvedSelectionSet {
         var resolvedSelectionSet = ResolvedSelectionSet()
@@ -37,7 +50,7 @@ struct SelectionSetResolver {
                         schema: schema,
                         documents: documents
                     ).resolve()
-                let conditional = inConditionalTypeCondition ||
+                let conditional = typeCondition.isConditional ||
                     inOptionalDirective ||
                     selection.hasOptionalDirective
                 try resolvedSelectionSet.addSelection(
@@ -62,45 +75,64 @@ struct SelectionSetResolver {
                 }
                 let fragment = try documents.fragment(fragmentName)
                 let fragmentType = try schema.fragmentType(fragment.ast)
-                if schema.isFragment(fragmentType, alwaysFulfilledBy: self.onType) {
+                let fragmentTypeCondition = nestedTypeCondition(
+                    typeCondition,
+                    fragmentType: fragmentType,
+                    onType: onType
+                )
+                switch fragmentTypeCondition {
+                case .always:
                     try resolvedSelectionSet.addSelection(
-                        .fragmentSpread(fragmentName, checkTypename: nil),
+                        .fragmentSpread(fragmentName, checkTypenames: nil),
                         responseKey: "__" + fragmentName
                     )
-                } else {
-                    switch fragmentType {
-                    case .OBJECT(let object):
-                        try resolvedSelectionSet.addSelection(
-                            .fragmentSpread(fragmentName, checkTypename: object.ast.name),
-                            responseKey: "__" + fragmentName
-                        )
-                    case .INTERFACE, .UNION:
-                        // Because we can't verify whether these fragments are fulfilled, we'll
-                        // roll their fields up to the response type, rather than using the fragment type.
-                        // https://github.com/graphql/graphql-spec/pull/879
-                        let fragmentGroupedSelections = try collect(
-                            selectionSet: fragment.ast.selectionSet,
-                            onType: fragmentType,
-                            inConditionalTypeCondition: inConditionalTypeCondition ||
-                                !schema.isFragment(fragmentType, alwaysFulfilledBy: onType),
-                            inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
-                        )
-                        try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
-                    }
+                case .typename(let typename):
+                    try resolvedSelectionSet.addSelection(
+                        .fragmentSpread(fragmentName, checkTypenames: [typename]),
+                        responseKey: "__" + fragmentName
+                    )
+                case .abstract:
+                    // Because we can't verify whether these fragments are fulfilled, we'll
+                    // roll their fields up to the response type, rather than using the fragment type.
+                    // https://github.com/graphql/graphql-spec/pull/879
+                    let fragmentGroupedSelections = try collect(
+                        selectionSet: fragment.ast.selectionSet,
+                        onType: fragmentType,
+                        typeCondition: fragmentTypeCondition,
+                        inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
+                    )
+                    try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
                 }
             case .inlineFragment(let inlineFragment):
                 let fragmentType = try schema.fragmentType(inlineFragment) ?? onType
                 let fragmentGroupedSelections = try collect(
                     selectionSet: inlineFragment.selectionSet,
                     onType: fragmentType,
-                    inConditionalTypeCondition: inConditionalTypeCondition ||
-                        !schema.isFragment(fragmentType, alwaysFulfilledBy: onType),
+                    typeCondition: nestedTypeCondition(
+                        typeCondition,
+                        fragmentType: fragmentType,
+                        onType: onType
+                    ),
                     inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
                 )
                 try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
             }
         }
         return resolvedSelectionSet
+    }
+
+    private func nestedTypeCondition(
+        _ inherited: TypeCondition,
+        fragmentType: Schema.SelectionSet,
+        onType: Schema.SelectionSet
+    ) -> TypeCondition {
+        guard !schema.isFragment(fragmentType, alwaysFulfilledBy: onType) else {
+            return inherited
+        }
+        return switch fragmentType {
+        case .OBJECT(let object): .typename(object.ast.name)
+        case .INTERFACE, .UNION: .abstract
+        }
     }
 }
 

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -110,6 +110,62 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func requiresTypenameForNamedFragmentSpreadInsideConditionalType() async {
+        await expectCodegenError(containing: "'__typename' needed in selection set under the 'hero' field") {
+            try await runCodegen(
+                document: """
+                fragment CharacterFields on Character { name }
+
+                query Hero {
+                  hero {
+                    ... on Human {
+                      ...CharacterFields
+                    }
+                  }
+                }
+                """,
+                schema: """
+                type Query { hero: Character! }
+                interface Character { name: String! }
+                type Human implements Character { name: String! }
+                type Droid implements Character { name: String! }
+                """
+            )
+        }
+    }
+
+    @Test
+    func preservesConditionalityForNamedFragmentSpread() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment CharacterFields on Character { name }
+
+            query Hero {
+              hero {
+                __typename
+                ... on Human {
+                  ...CharacterFields
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { name: String! }
+            type Human implements Character { name: String! }
+            type Droid implements Character { name: String! }
+            """
+        )
+
+        #expect(output.contains("let __CharacterFields: CharacterFields?"))
+        #expect(
+            output.contains(
+                "__CharacterFields = __typename == \"Human\" ? try CharacterFields(from: decoder) : nil"
+            )
+        )
+    }
+
+    @Test
     func rejectsAliasesThatProduceConflictingNestedTypeNames() async {
         await expectCodegenError(containing: "conflicting Swift nested type names") {
             try await runCodegen(


### PR DESCRIPTION
## Summary

- carry inherited type-condition fulfillment into named fragment spreads
- generate optional fragment properties guarded by every concrete `__typename` that fulfills the spread
- roll abstract interface or union conditions into conditional response fields when fulfillment cannot be verified safely
- require `__typename` rather than generating an unconditional decoder for a conditional named fragment

## Root cause

PR #72 preserved inherited conditionality for fields, but named fragment spreads still decided fulfillment relative to the original selection-set root. A spread such as `...CharacterFields` inside `... on Human` was therefore emitted as required when the root type was `Character`, even though a `Droid` response legitimately omitted the fragment fields.

## Impact

Named fragment wrappers now remain conditional across enclosing type conditions. With `__typename` selected, generated decoding checks the inherited concrete type before constructing the fragment. Without `__typename`, codegen reports the existing requirement instead of producing an unsafe decoder.

## Validation

- `swift test` — 35 tests passed
- `mise run lint` — 0 violations
- `mise run periphery` — no unused code
- `git diff --check`
