### PR TITLE
Document destructive output ownership

### DIFF
--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.API.swift
@@ -4,15 +4,21 @@ extension Configuration.Output {
     /// Options controlling the code shared by your operations.
     /// This "infrastructure" code  includes types for accurately modeling server responses to
     /// operations (including errors) enums and nullable fields.
+    ///
+    /// Codegen reserves the `HTTPSupport` subdirectory within the configured API directory. If HTTP support
+    /// is disabled, Codegen may remove that subdirectory and all of its contents.
     public struct API: Sendable {
         /// Call this function to create a new `API` instance.
         ///
         /// - Parameters:
-        ///   - directory: A `URL` to a location on the local file-system to write API files.
+        ///   - directory: A `URL` to a location on the local file system to write API files. Codegen reserves
+        ///   the `HTTPSupport` subdirectory at this location and may remove all of its contents when HTTP support
+        ///   is disabled. Do not store unrelated or independently maintained files in that subdirectory.
         ///   - header: An optional string to include at the top of generated document files.
         ///   - accessLevel: The `AccessLevel` for the generated API code.
-        ///   - HTTPSupport: Options controlling API files that generated to support HTTP requests to GraphQL servers.
-        ///   Passing `nil` will cause codegen to not generate these files.
+        ///   - HTTPSupport: Options controlling API files generated to support HTTP requests to GraphQL servers.
+        ///   Passing `nil` prevents Codegen from generating these files and may remove the entire `HTTPSupport`
+        ///   subdirectory from the configured API directory.
         /// - Returns: A new `API` instance to be passed to the `Output.output` factory function.
         public static func api(
             directory: URL,

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.swift
@@ -2,10 +2,16 @@ import Foundation
 
 extension Configuration.Output {
     public enum DocumentOutputLocation: Sendable {
-        /// Places generated swift documents in the same
-        /// directory as its definition
+        /// Places each generated Swift document in the same directory as its definition.
+        ///
+        /// On each run, Codegen removes obsolete files ending in `.graphql.swift` from the configured
+        /// document directories. Do not use that suffix for independently maintained files in those directories.
         case definition
-        /// Places generated swift documents in an explicity directory
+
+        /// Places generated Swift documents in a separate directory.
+        ///
+        /// Codegen assumes exclusive ownership of this directory and may remove all of its existing contents
+        /// before writing the current generated output. Do not store unrelated or independently maintained files here.
         case directory(URL)
     }
 
@@ -16,7 +22,9 @@ extension Configuration.Output {
         /// Call this function to create a new `Documents` instance.
         ///
         /// - Parameters:
-        ///   - directory: Where the generated fragment files will be located
+        ///   - directory: Where generated document files will be located. A separately configured directory is
+        ///   exclusively owned by Codegen and may have all of its existing contents removed on each run. When files
+        ///   are placed beside their definitions, obsolete files ending in `.graphql.swift` may be removed instead.
         ///   - header: An optional string to include at the top of generated document files.
         ///   - importedModules: A list of modules to import into generated document files.
         ///   Just include the module name, the "import" keyword will be added automatically.


### PR DESCRIPTION
## Summary

- document that separate document output directories are exclusively owned and replaced by Codegen
- explain obsolete `.graphql.swift` cleanup when output is placed beside definitions
- document that disabling HTTP support may remove the reserved `HTTPSupport` subdirectory

## Why

Configuration API documentation described where generated files are written but did not warn callers about every destructive cleanup path. This could lead users to place unrelated or independently maintained files in directories that Codegen later removes.

## Impact

Callers now see ownership and deletion warnings at the configuration points where they select these output locations. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- `mise run lint`
