### PR TITLE
Align document AST decoding with GraphQL 17

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Mirrors the executable-document AST produced by the bundled graphql-js parser.
 ///
 /// Keep this boundary model aligned with the executable definitions in:
-/// https://github.com/graphql/graphql-js/blob/16.x.x/src/language/ast.ts
+/// https://github.com/graphql/graphql-js/blob/17.x.x/src/language/ast.ts
 enum GraphQLAST {
     /// Verified against the bundled graphql-js parser: location offsets are UTF-16 code units.
     struct Location: Decodable, Hashable {
@@ -48,8 +48,8 @@ enum GraphQLAST {
         let loc: Location
         let operation: OperationType
         let name: Name?
-        let variableDefinitions: [VariableDefinition]
-        let directives: [Directive]
+        let variableDefinitions: [VariableDefinition]?
+        let directives: [Directive]?
         let selectionSet: SelectionSet
     }
 
@@ -90,9 +90,9 @@ enum GraphQLAST {
 
         private var directives: [Directive] {
             switch self {
-            case .field(let field): field.directives
-            case .fragmentSpread(let fragmentSpread): fragmentSpread.directives
-            case .inlineFragment(let inlineFragment): inlineFragment.directives
+            case .field(let field): field.directives ?? []
+            case .fragmentSpread(let fragmentSpread): fragmentSpread.directives ?? []
+            case .inlineFragment(let inlineFragment): inlineFragment.directives ?? []
             }
         }
 
@@ -116,8 +116,8 @@ enum GraphQLAST {
         let loc: Location
         let alias: Name?
         let name: Name
-        let arguments: [Argument]
-        let directives: [Directive]
+        let arguments: [Argument]?
+        let directives: [Directive]?
         let selectionSet: SelectionSet?
 
         var responseKey: String {
@@ -140,13 +140,13 @@ enum GraphQLAST {
     struct FragmentSpread: Decodable {
         let loc: Location
         let name: Name
-        let directives: [Directive]
+        let directives: [Directive]?
     }
 
     struct InlineFragment: Decodable {
         let loc: Location
         let typeCondition: NamedType?
-        let directives: [Directive]
+        let directives: [Directive]?
         let selectionSet: SelectionSet
     }
 
@@ -154,7 +154,7 @@ enum GraphQLAST {
         let loc: Location
         let name: Name
         let typeCondition: NamedType
-        let directives: [Directive]
+        let directives: [Directive]?
         let selectionSet: SelectionSet
     }
 

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -130,7 +130,7 @@ struct OperationBuilder {
     }
 
     private func addVariablesProperty(to operationStruct: inout SwiftStructBuilder) {
-        let variableDefinitions = operation.ast.variableDefinitions
+        let variableDefinitions = operation.ast.variableDefinitions ?? []
         guard !variableDefinitions.isEmpty else {
             operationStruct.addProperty(
                 description: nil,
@@ -186,7 +186,7 @@ struct OperationBuilder {
     }
 
     private func addVariablesStruct(to operationStruct: inout SwiftStructBuilder) {
-        let variableDefinitions = operation.ast.variableDefinitions
+        let variableDefinitions = operation.ast.variableDefinitions ?? []
         guard !variableDefinitions.isEmpty else { return }
         let typeNames = variableDefinitions.map(\.typeName)
         var variablesStruct = SwiftStructBuilder(

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -121,7 +121,7 @@ struct DocumentsResolver {
                 switch definition {
                 case .operation(let resolvedOperation):
                     selectionSets.append(resolvedOperation.resolvedSelectionSet)
-                    for variableDefinition in resolvedOperation.operation.ast.variableDefinitions {
+                    for variableDefinition in resolvedOperation.operation.ast.variableDefinitions ?? [] {
                         try addUsedInputTypes(variableDefinition, to: &usage.usedTypes)
                     }
                     switch resolvedOperation.operation.ast.operation {

--- a/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
@@ -83,7 +83,7 @@ struct GeneratedTypeNameValidator {
                 responseKey: nil
             ),
         ]
-        let variableDefinitions = operation.operation.ast.variableDefinitions
+        let variableDefinitions = operation.operation.ast.variableDefinitions ?? []
         if !variableDefinitions.isEmpty {
             operationTypes[.variables] = NestedTypeSource(
                 description: "Generated operation variables type: Variables",

--- a/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+@testable import GraphQLCodegen
+import Testing
+
+struct GraphQL17BoundaryModelTests {
+    @Test
+    func decodesMissingEmptyDocumentCollections() throws {
+        let data = Data(
+            #"""
+            {
+              "loc": { "start": 0, "end": 16 },
+              "definitions": [
+                {
+                  "kind": "OperationDefinition",
+                  "loc": { "start": 0, "end": 16 },
+                  "operation": "query",
+                  "selectionSet": {
+                    "loc": { "start": 6, "end": 16 },
+                    "selections": [
+                      {
+                        "kind": "Field",
+                        "loc": { "start": 8, "end": 14 },
+                        "name": {
+                          "loc": { "start": 8, "end": 14 },
+                          "value": "viewer"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+            """#.utf8
+        )
+
+        let document = try JSONDecoder().decode(GraphQLAST.Document.self, from: data)
+        guard case .operation(let operation) = try #require(document.definitions.first) else {
+            Issue.record("Expected an operation definition")
+            return
+        }
+        let selection = try #require(operation.selectionSet.selections.first)
+
+        #expect(operation.variableDefinitions == nil)
+        #expect(!selection.hasOptionalDirective)
+    }
+
+    @Test
+    func decodesDirectiveDefinitionLocation() throws {
+        let data = Data(#""DIRECTIVE_DEFINITION""#.utf8)
+
+        let location = try JSONDecoder().decode(__Schema.__DirectiveLocation.self, from: data)
+
+        #expect(location == .DIRECTIVE_DEFINITION)
+    }
+}


### PR DESCRIPTION
## Summary

- allow GraphQL 17 to omit empty executable-AST collections
- normalize missing variable definitions and directives to empty arrays at consumers
- add boundary coverage for omitted collections
- preserve coverage for the GraphQL 17 `DIRECTIVE_DEFINITION` introspection location already present on `main`

## Why

GraphQL 17 omits empty AST collections instead of serializing them as `[]`. Required Swift array properties therefore fail decoding for otherwise valid parsed documents.

## Validation

- `swift test`
- `mise run lint`
- `mise run periphery`
- combined test against regenerated GraphQL 17.0.2 bundle (40 tests passed)
