### PR TITLE
Model GraphQL OneOf inputs as Swift enums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
             ],
             exclude: [
                 "Fixtures/Defaults/Definitions",
+                "Fixtures/OneOf/Definitions",
                 "GraphQLCodegen.xctestplan",
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The code generator runs on macOS 26 or newer because it uses JavaScriptCore to e
 Generated source deployment requirements depend on the APIs enabled in your configuration. Subscription support requires version
 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
 
+## GraphQL Compatibility
+
+Swift GraphQL Codegen targets the [September 2025 edition of the GraphQL specification](https://spec.graphql.org/September2025/).
+Schemas and introspection endpoints must conform to that edition. Earlier introspection schemas are not supported; in particular,
+an introspection endpoint must expose `__Type.isOneOf`.
+
 ## Output directory ownership
 
 Codegen assumes exclusive ownership of the configured schema output directories. Each run may remove and recreate the scalar,
@@ -61,14 +67,15 @@ tvOS, watchOS, or visionOS.
 ## Table of Contents
 
 1. [Platform Support](#platform-support)
-2. [Output directory ownership](#output-directory-ownership)
-3. [Server-Sent Event limits](#server-sent-event-limits)
-4. [Getting Started](#getting-started)
-5. [Example](#example-output)
-6. [Motivation](#motivation)
-7. [Design](#design)
-8. [Contributing](#contributing)
-9. [License](#license)
+2. [GraphQL Compatibility](#graphql-compatibility)
+3. [Output directory ownership](#output-directory-ownership)
+4. [Server-Sent Event limits](#server-sent-event-limits)
+5. [Getting Started](#getting-started)
+6. [Example](#example-output)
+7. [Motivation](#motivation)
+8. [Design](#design)
+9. [Contributing](#contributing)
+10. [License](#license)
 
 ---
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
@@ -6,8 +6,9 @@ extension Configuration.Input {
         /// Instructs codegen to obtain your GraphQL schema by introspecting a GraphQL endpoint.
         ///
         /// - Parameters:
-        ///   - url: The URL of the GraphQL endpoint. Make sure the GraphQL endpoint has introspection enabled.
-        ///   Refer to the spec for more info on introspection.
+        ///   - url: The URL of the GraphQL endpoint. The endpoint must enable and implement introspection from the
+        ///   [September 2025 GraphQL specification](https://spec.graphql.org/September2025/#sec-Schema-Introspection).
+        ///   Earlier introspection schemas are not supported.
         ///   - headers: Additional HTTP headers, such as authorization, to send to this endpoint.
         ///   - includeDeprecatedFields: Pass `true` if the GraphQL schema should include fields that have been
         ///   deprecated by the server. When deprecated fields are included, your GraphQL operations may query against these fields,
@@ -26,7 +27,7 @@ extension Configuration.Input {
 
         /// Instructs codegen to load your GraphQL schema from a .json file on the local filesystem.
         /// The JSON must match the object returned in the `data` field by the introspection query bundled with
-        /// this version of the codegen.
+        /// this version of the codegen and conform to the September 2025 GraphQL specification.
         case JSONSchemaFile(URL)
 
         /// Instructs codegen to load your GraphQL schema from a  .graphqls file on the local filesystem.

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
@@ -43,6 +43,7 @@ struct IntrospectionQuery: Encodable {
           name
           description
           specifiedByURL
+          isOneOf
           fields(includeDeprecated: \(includeDeprecatedFields ? "true" : "false")) {
             name
             description

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -2,7 +2,7 @@
 /// Mirrors the schema introspection response produced by `IntrospectionQuery`.
 ///
 /// Keep this boundary model aligned with:
-/// https://spec.graphql.org/October2021/#sec-Schema-Introspection.Schema-Introspection-Schema
+/// https://spec.graphql.org/September2025/#sec-Schema-Introspection.Schema-Introspection-Schema
 struct __Schema: Decodable {
     enum __NamedType: Decodable {
         case SCALAR(Scalar)
@@ -43,7 +43,7 @@ struct __Schema: Decodable {
         struct Union: Decodable {
             let description: String?
             let name: String
-            let possibleTypes: [__TypeRef.Object] // https://spec.graphql.org/October2021/#sec-Unions.Type-Validation
+            let possibleTypes: [__TypeRef.Object] // https://spec.graphql.org/September2025/#sec-Unions.Type-Validation
         }
 
         struct Enum: Decodable {
@@ -62,6 +62,7 @@ struct __Schema: Decodable {
             let description: String?
             let name: String
             let inputFields: [__InputValue]
+            let isOneOf: Bool
         }
 
         private enum CodingKeys: CodingKey {

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -17,10 +17,12 @@ struct SchemaWriter {
 
     let configuration: Configuration
 
+    let indirectOneOfInputObjectFields: [String: Set<String>]
     let typePlans: [TypePlan]
 
     init(configuration: Configuration, schema: Schema, resolvedDocuments: ResolvedDocuments) {
         self.configuration = configuration
+        self.indirectOneOfInputObjectFields = resolvedDocuments.indirectOneOfInputObjectFields
         self.typePlans = resolvedDocuments.usedTypes.sorted().compactMap { name -> TypePlan? in
             if let scalar = schema.typeCache.scalars[name] {
                 return scalar.ast.isNativeSwiftType ? nil : .scalar(scalar)
@@ -108,7 +110,12 @@ struct SchemaWriter {
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.inputObjects.header)
             file.setImports(configuration.output.schema.inputObjects.importedModules)
-            file.addType(SchemaInputObjectBuilder(inputObject: inputObject))
+            file.addType(
+                SchemaInputObjectBuilder(
+                    inputObject: inputObject,
+                    indirectInputFields: indirectOneOfInputObjectFields[inputObject.ast.name, default: []]
+                )
+            )
             try file.write(
                 to: inputObjectsDir.appending(
                     path: "\(inputObject.ast.name).graphqls.swift",

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
@@ -1,7 +1,100 @@
 struct SchemaInputObjectBuilder: SwiftTypeBuildable {
     let inputObject: Schema.InputObject
+    let indirectInputFields: Set<String>
 
     func build(configuration: Configuration) -> [String] {
+        if inputObject.ast.isOneOf {
+            return buildOneOf(configuration: configuration)
+        }
+
+        return buildStruct(configuration: configuration)
+    }
+
+    private func buildOneOf(configuration: Configuration) -> [String] {
+        let isPublic = configuration.output.schema.accessLevel == .public
+        let accessLevel = isPublic ? "public " : ""
+        let indentation = configuration.output.indentation.string
+        var builder = SwiftTypeBuilder(
+            description: inputObject.ast.description,
+            isPublic: isPublic,
+            type: "enum",
+            name: SwiftTypeIdentifier(swiftName: inputObject.ast.name).source,
+            conformances: configuration.output.schema.inputObjects.conformances
+        )
+        for inputField in inputObject.ast.inputFields {
+            if let description = inputField.description, !description.isEmpty {
+                builder.addComment(description)
+            }
+            let indirect = indirectInputFields.contains(inputField.name) ? "indirect " : ""
+            builder.addLine("\(indirect)case \(identifier(inputField.name))(\(inputField.oneOfTypeName))")
+        }
+
+        let includesDecodable = configuration.output.schema.inputObjects.conformances.contains { conformance in
+            SwiftConformanceName(source: conformance).includesDecodable
+        }
+        if includesDecodable {
+            addDecodableInitializer(
+                to: &builder,
+                accessLevel: accessLevel,
+                indentation: indentation
+            )
+        }
+
+        builder.addEmptyLine()
+        builder.addLine("\(accessLevel)func encode(to encoder: Encoder) throws {")
+        builder.addLine("\(indentation)var container = encoder.container(keyedBy: __CodingKeys.self)")
+        builder.addLine("\(indentation)switch self {")
+        for inputField in inputObject.ast.inputFields {
+            let caseName = identifier(inputField.name)
+            builder.addLine("\(indentation)case .\(caseName)(let value):")
+            builder.addLine("\(indentation)\(indentation)try container.encode(value, forKey: .\(caseName))")
+        }
+        builder.addLine("\(indentation)}")
+        builder.addLine("}")
+
+        builder.addEmptyLine()
+        builder.addLine("private enum __CodingKeys: String, CodingKey {")
+        for inputField in inputObject.ast.inputFields {
+            builder.addLine("\(indentation)case \(identifier(inputField.name))")
+        }
+        builder.addLine("}")
+        return builder.build(configuration: configuration)
+    }
+
+    private func addDecodableInitializer(
+        to builder: inout SwiftTypeBuilder,
+        accessLevel: String,
+        indentation: String
+    ) {
+        builder.addEmptyLine()
+        builder.addLine("\(accessLevel)init(from decoder: Decoder) throws {")
+        builder.addLine("\(indentation)let container = try decoder.container(keyedBy: __CodingKeys.self)")
+        builder.addLine("\(indentation)let keys = container.allKeys")
+        builder.addLine("\(indentation)guard keys.count == 1, let key = keys.first else {")
+        builder.addLine("\(indentation)\(indentation)throw DecodingError.dataCorrupted(")
+        builder.addLine("\(indentation)\(indentation)\(indentation)DecodingError.Context(")
+        builder.addLine("\(indentation)\(indentation)\(indentation)\(indentation)codingPath: decoder.codingPath,")
+        builder.addLine(
+            "\(indentation)\(indentation)\(indentation)\(indentation)debugDescription: " +
+                SwiftSource(value: "Expected exactly one field for \(inputObject.ast.name).").singleLineStringLiteral
+        )
+        builder.addLine("\(indentation)\(indentation)\(indentation))")
+        builder.addLine("\(indentation)\(indentation))")
+        builder.addLine("\(indentation)}")
+        builder.addLine("\(indentation)switch key {")
+        for inputField in inputObject.ast.inputFields {
+            let caseName = identifier(inputField.name)
+            builder.addLine("\(indentation)case .\(caseName):")
+            builder.addLine(
+                "\(indentation)\(indentation)self = .\(caseName)(" +
+                    "try container.decode(\(inputField.oneOfTypeName).self, forKey: .\(caseName)))"
+            )
+        }
+        builder.addLine("\(indentation)}")
+        builder.addLine("}")
+    }
+
+    private func buildStruct(configuration: Configuration) -> [String] {
         let isPublic = configuration.output.schema.accessLevel == .public
         var builder = SwiftStructBuilder(
             description: inputObject.ast.description,
@@ -47,5 +140,9 @@ struct SchemaInputObjectBuilder: SwiftTypeBuildable {
 extension __Schema.__InputValue {
     var typeName: String {
         type.swiftName.inputTypeName(hasDefaultValue: defaultValue != nil)
+    }
+
+    var oneOfTypeName: String {
+        type.swiftName.requiredInputTypeName()
     }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -58,4 +58,11 @@ extension SourceTypeName {
         case .list, .name: return "GraphQLHasDefault<\(typeName)>"
         }
     }
+
+    func requiredInputTypeName() -> String {
+        switch self {
+        case .optional(let inner): inner.inputTypeName(hasDefaultValue: false)
+        case .list, .name: inputTypeName(hasDefaultValue: false)
+        }
+    }
 }

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -1,6 +1,12 @@
 import OrderedCollections
 
 struct DocumentsResolver {
+    private struct InputObjectDependency: Hashable {
+        let fieldName: String
+        let inputObjectName: String
+        let nestedInputObjectName: String
+    }
+
     private struct Usage {
         var fulfilledFragments: Set<String> = []
         var hasMutation = false
@@ -19,11 +25,12 @@ struct DocumentsResolver {
         return ResolvedDocuments(
             documents: resolvedDocuments,
             fragmentLookup: resolvedFragments,
-            usedTypes: usage.usedTypes,
-            requiresIndirectNullable: try requiresIndirectNullable(in: usage.usedTypes),
             fulfilledFragments: usage.fulfilledFragments,
             hasMutation: usage.hasMutation,
-            hasSubscription: usage.hasSubscription
+            hasSubscription: usage.hasSubscription,
+            indirectOneOfInputObjectFields: try indirectOneOfInputObjectFields(in: usage.usedTypes),
+            requiresIndirectNullable: try requiresIndirectNullable(in: usage.usedTypes),
+            usedTypes: usage.usedTypes
         )
     }
 
@@ -180,35 +187,79 @@ struct DocumentsResolver {
     }
 
     private func requiresIndirectNullable(in usedTypes: Set<String>) throws -> Bool {
-        var visited: Set<String> = []
-        var visiting: Set<String> = []
-
-        func visit(_ inputObject: Schema.InputObject) throws -> Bool {
-            let name = inputObject.ast.name
-            if visiting.contains(name) {
-                return true
-            }
-            guard visited.insert(name).inserted else { return false }
-
-            visiting.insert(name)
-            defer { visiting.remove(name) }
-
-            for field in inputObject.ast.inputFields {
-                let type = try schema.inputType(field)
-                guard case .INPUT_OBJECT(let nestedInputObject) = type.value else { continue }
-                if try visit(nestedInputObject) {
-                    return true
+        try !recursiveInputObjectDependencies(in: usedTypes) { inputObject in
+            try inputObject.ast.inputFields.compactMap { field in
+                guard case .INPUT_OBJECT(let nestedInputObject) = try schema.inputType(field).value else {
+                    return nil
                 }
+                return InputObjectDependency(
+                    fieldName: field.name,
+                    inputObjectName: inputObject.ast.name,
+                    nestedInputObjectName: nestedInputObject.ast.name
+                )
             }
-            return false
+        }.isEmpty
+    }
+
+    private func indirectOneOfInputObjectFields(in usedTypes: Set<String>) throws -> [String: Set<String>] {
+        let recursiveDependencies = try recursiveInputObjectDependencies(in: usedTypes) { inputObject in
+            try directlyStoredInputObjectDependencies(in: inputObject)
+        }
+        return recursiveDependencies.reduce(into: [:]) { result, dependency in
+            guard schema.typeCache.inputObjects[dependency.inputObjectName]?.ast.isOneOf == true else { return }
+            result[dependency.inputObjectName, default: []].insert(dependency.fieldName)
+        }
+    }
+
+    private func directlyStoredInputObjectDependencies(
+        in inputObject: Schema.InputObject
+    ) throws -> [InputObjectDependency] {
+        try inputObject.ast.inputFields.compactMap { field in
+            let type = try schema.inputType(field)
+            let storesWithoutNullableWrapper =
+                switch type {
+                case .nullable: inputObject.ast.isOneOf
+                case .nonNull: true
+                }
+            guard storesWithoutNullableWrapper,
+                  case .INPUT_OBJECT(let nestedInputObject) = type.value else {
+                return nil
+            }
+            return InputObjectDependency(
+                fieldName: field.name,
+                inputObjectName: inputObject.ast.name,
+                nestedInputObjectName: nestedInputObject.ast.name
+            )
+        }
+    }
+
+    private func recursiveInputObjectDependencies(
+        in usedTypes: Set<String>,
+        dependencies: (Schema.InputObject) throws -> [InputObjectDependency]
+    ) throws -> Set<InputObjectDependency> {
+        var dependenciesByInputObject: [String: [InputObjectDependency]] = [:]
+        for name in usedTypes.sorted() {
+            guard let inputObject = schema.typeCache.inputObjects[name] else { continue }
+            dependenciesByInputObject[name] = try dependencies(inputObject)
         }
 
-        for name in usedTypes {
-            guard let inputObject = schema.typeCache.inputObjects[name] else { continue }
-            if try visit(inputObject) {
+        func canReach(_ destination: String, from source: String, visited: inout Set<String>) -> Bool {
+            if source == destination {
                 return true
             }
+            guard visited.insert(source).inserted else { return false }
+            return dependenciesByInputObject[source, default: []].contains { dependency in
+                canReach(destination, from: dependency.nestedInputObjectName, visited: &visited)
+            }
         }
-        return false
+
+        return Set(dependenciesByInputObject.values.joined().filter { dependency in
+            var visited: Set<String> = []
+            return canReach(
+                dependency.inputObjectName,
+                from: dependency.nestedInputObjectName,
+                visited: &visited
+            )
+        })
     }
 }

--- a/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
@@ -3,11 +3,12 @@ import Foundation
 struct ResolvedDocuments {
     let documents: [ResolvedDocument]
     let fragmentLookup: [String: ResolvedFragment]
-    let usedTypes: Set<String>
-    let requiresIndirectNullable: Bool
     let fulfilledFragments: Set<String>
     let hasMutation: Bool
     let hasSubscription: Bool
+    let indirectOneOfInputObjectFields: [String: Set<String>]
+    let requiresIndirectNullable: Bool
+    let usedTypes: Set<String>
 }
 
 struct ResolvedDocument {

--- a/Tests/GraphQLCodegenTests/Fixtures/OneOf/Definitions/Operations/SearchQuery.graphql
+++ b/Tests/GraphQLCodegenTests/Fixtures/OneOf/Definitions/Operations/SearchQuery.graphql
@@ -1,0 +1,3 @@
+query Search($by: SearchInput!) {
+  search(by: $by)
+}

--- a/Tests/GraphQLCodegenTests/Fixtures/OneOf/Definitions/schema.sdl
+++ b/Tests/GraphQLCodegenTests/Fixtures/OneOf/Definitions/schema.sdl
@@ -1,0 +1,17 @@
+type Query {
+  search(by: SearchInput!): String!
+}
+
+input SearchInput @oneOf {
+  id: Int
+  name: String
+  tags: [String!]
+  next: SearchInput
+  filter: SearchFilterInput
+  CodingKeys: String
+}
+
+input SearchFilterInput @oneOf {
+  name: String
+  search: SearchInput
+}

--- a/Tests/GraphQLCodegenTests/Fixtures/OneOf/Generated/SearchFilterInput.graphqls.swift
+++ b/Tests/GraphQLCodegenTests/Fixtures/OneOf/Generated/SearchFilterInput.graphqls.swift
@@ -1,0 +1,40 @@
+// @generated
+
+enum SearchFilterInput: Codable, Hashable, Sendable {
+    case name(String)
+    indirect case search(SearchInput)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: __CodingKeys.self)
+        let keys = container.allKeys
+        guard keys.count == 1, let key = keys.first else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected exactly one field for SearchFilterInput."
+                )
+            )
+        }
+        switch key {
+        case .name:
+            self = .name(try container.decode(String.self, forKey: .name))
+        case .search:
+            self = .search(try container.decode(SearchInput.self, forKey: .search))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: __CodingKeys.self)
+        switch self {
+        case .name(let value):
+            try container.encode(value, forKey: .name)
+        case .search(let value):
+            try container.encode(value, forKey: .search)
+        }
+    }
+
+    private enum __CodingKeys: String, CodingKey {
+        case name
+        case search
+    }
+}

--- a/Tests/GraphQLCodegenTests/Fixtures/OneOf/Generated/SearchInput.graphqls.swift
+++ b/Tests/GraphQLCodegenTests/Fixtures/OneOf/Generated/SearchInput.graphqls.swift
@@ -1,0 +1,64 @@
+// @generated
+
+enum SearchInput: Codable, Hashable, Sendable {
+    case id(Int)
+    case name(String)
+    case tags([String])
+    indirect case next(SearchInput)
+    indirect case filter(SearchFilterInput)
+    case CodingKeys(String)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: __CodingKeys.self)
+        let keys = container.allKeys
+        guard keys.count == 1, let key = keys.first else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Expected exactly one field for SearchInput."
+                )
+            )
+        }
+        switch key {
+        case .id:
+            self = .id(try container.decode(Int.self, forKey: .id))
+        case .name:
+            self = .name(try container.decode(String.self, forKey: .name))
+        case .tags:
+            self = .tags(try container.decode([String].self, forKey: .tags))
+        case .next:
+            self = .next(try container.decode(SearchInput.self, forKey: .next))
+        case .filter:
+            self = .filter(try container.decode(SearchFilterInput.self, forKey: .filter))
+        case .CodingKeys:
+            self = .CodingKeys(try container.decode(String.self, forKey: .CodingKeys))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: __CodingKeys.self)
+        switch self {
+        case .id(let value):
+            try container.encode(value, forKey: .id)
+        case .name(let value):
+            try container.encode(value, forKey: .name)
+        case .tags(let value):
+            try container.encode(value, forKey: .tags)
+        case .next(let value):
+            try container.encode(value, forKey: .next)
+        case .filter(let value):
+            try container.encode(value, forKey: .filter)
+        case .CodingKeys(let value):
+            try container.encode(value, forKey: .CodingKeys)
+        }
+    }
+
+    private enum __CodingKeys: String, CodingKey {
+        case id
+        case name
+        case tags
+        case next
+        case filter
+        case CodingKeys
+    }
+}

--- a/Tests/GraphQLCodegenTests/Tests/GraphQLOneOfGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/GraphQLOneOfGeneratorTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import GraphQLCodegen
+import Testing
+
+struct GraphQLOneOfGeneratorTests {
+    private static let testsDirectory = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    private let fixtureDirectory = GraphQLOneOfGeneratorTests.testsDirectory
+        .appending(path: "Fixtures/OneOf", directoryHint: .isDirectory)
+
+    @Test
+    func generatesEnumsWithGraphQLObjectEncodingAndIndirectRecursion() async throws {
+        let generatedDirectory = FileManager.default.temporaryDirectory.appending(
+            path: UUID().uuidString,
+            directoryHint: .isDirectory
+        )
+        try FileManager.default.createDirectory(at: generatedDirectory, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: generatedDirectory)
+        }
+        let definitionsDirectory = fixtureDirectory.appending(path: "Definitions", directoryHint: .isDirectory)
+        let operationsDirectory = generatedDirectory.appending(path: "Operations", directoryHint: .isDirectory)
+        try FileManager.default.copyItem(
+            at: definitionsDirectory.appending(path: "Operations", directoryHint: .isDirectory),
+            to: operationsDirectory
+        )
+        let schemaURL = definitionsDirectory.appending(path: "schema.sdl", directoryHint: .notDirectory)
+        let schemaTypesDirectory = generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
+
+        try await Codegen(
+            .configuration(
+                input: .input(
+                    schemaSource: .SDLSchemaFile(schemaURL),
+                    documentDirectories: [operationsDirectory]
+                ),
+                output: .output(
+                    schema: .schema(
+                        directory: schemaTypesDirectory,
+                        inputObjects: .inputObjects(conformances: ["Codable", "Hashable", "Sendable"])
+                    ),
+                    documents: .documents(directory: .directory(operationsDirectory)),
+                    api: .api(directory: generatedDirectory.appending(path: "API", directoryHint: .isDirectory))
+                )
+            )
+        ).run()
+
+        let generated = try String(
+            contentsOf: schemaTypesDirectory.appending(path: "InputObjects/SearchInput.graphqls.swift"),
+            encoding: .utf8
+        ).trimmingCharacters(in: .newlines)
+        let expected = try String(
+            contentsOf: fixtureDirectory.appending(path: "Generated/SearchInput.graphqls.swift"),
+            encoding: .utf8
+        ).trimmingCharacters(in: .newlines)
+        #expect(generated == expected)
+
+        let generatedFilter = try String(
+            contentsOf: schemaTypesDirectory.appending(path: "InputObjects/SearchFilterInput.graphqls.swift"),
+            encoding: .utf8
+        ).trimmingCharacters(in: .newlines)
+        let expectedFilter = try String(
+            contentsOf: fixtureDirectory.appending(path: "Generated/SearchFilterInput.graphqls.swift"),
+            encoding: .utf8
+        ).trimmingCharacters(in: .newlines)
+        #expect(generatedFilter == expectedFilter)
+    }
+
+    @Test
+    func encodesOnlyTheSelectedField() throws {
+        let data = try JSONEncoder().encode(SearchInput.name("Leia"))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+
+        #expect(object == ["name": "Leia"])
+    }
+
+    @Test
+    func encodesFieldNamedCodingKeys() throws {
+        let data = try JSONEncoder().encode(SearchInput.CodingKeys("Leia"))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+
+        #expect(object == ["CodingKeys": "Leia"])
+    }
+
+    @Test
+    func decodesGraphQLObjectEncoding() throws {
+        let input = SearchInput.id(7)
+        let data = try JSONEncoder().encode(input)
+
+        #expect(try JSONDecoder().decode(SearchInput.self, from: data) == input)
+    }
+
+    @Test
+    func rejectsMultipleDecodedFields() {
+        let data = Data(#"{"id":7,"name":"Leia"}"#.utf8)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(SearchInput.self, from: data)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- request `isOneOf` in schema introspection
- generate OneOf input objects as associated-value Swift enums
- encode the selected enum case as the single GraphQL input-object field
- make associated values non-optional while preserving nested list nullability
- add generation and wire-format coverage

## Why

GraphQL OneOf inputs require exactly one non-null field. The existing struct representation can express zero or multiple fields, so it cannot enforce the schema invariant. An associated-value enum makes invalid OneOf values unrepresentable.

## Validation

- `swift test`
- `mise run lint`
- `mise run periphery`
- combined test against regenerated GraphQL 17.0.2 bundle (40 tests passed)
