### PR TITLE
Emit indirect only on recursive nullable case

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
@@ -15,11 +15,11 @@ struct GraphQLNullableWriter: APIOutput {
     }
 
     var source: String {
-        let indirect = requiresIndirectNullable ? "indirect " : ""
+        let indirectCase = requiresIndirectNullable ? "indirect " : ""
         return """
-        \(header)\(accessLevel)\(indirect)enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
+        \(header)\(accessLevel)enum GraphQLNullable<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {
             case null
-            case value(T)
+            \(indirectCase)case value(T)
 
             \(accessLevel)func encode(to encoder: Encoder) throws {
                 var container = encoder.singleValueContainer()

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -96,6 +96,27 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func usesCaseLevelIndirectionForRecursiveInputObjects() async throws {
+        let output = try await runCodegen(
+            document: """
+            query Viewer($input: RecursiveInput) {
+              value(input: $input)
+            }
+            """,
+            schema: """
+            input RecursiveInput {
+              nested: RecursiveInput
+            }
+            type Query { value(input: RecursiveInput): String! }
+            """,
+            outputRelativePath: "API/GraphQLNullable.swift"
+        )
+
+        #expect(!output.contains("indirect enum GraphQLNullable"))
+        #expect(output.contains("indirect case value(T)"))
+    }
+
+    @Test
     func preservesConditionalityAcrossNestedTypeConditions() async throws {
         let output = try await runCodegen(
             document: """
@@ -535,6 +556,7 @@ struct GraphQLCodeGeneratorTests {
         document: String,
         schema: String,
         enumCaseConversion: Configuration.Output.Schema.Enums.CaseConversion? = nil,
+        outputRelativePath: String = "Operations/Viewer.graphql.swift",
         responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"]
     ) async throws -> String {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
@@ -576,7 +598,10 @@ struct GraphQLCodeGeneratorTests {
                 )
             )
         ).run()
-        return try String(contentsOf: documentURL.appendingPathExtension("swift"), encoding: .utf8)
+        return try String(
+            contentsOf: generatedDirectory.appending(path: outputRelativePath, directoryHint: .notDirectory),
+            encoding: .utf8
+        )
     }
 
     private func expectCodegenError(


### PR DESCRIPTION
## Summary

- emit `indirect` on `GraphQLNullable.value(T)` instead of the entire enum when recursive input objects are detected
- retain conditional recursion detection so nonrecursive schemas keep direct storage
- add integration coverage for the generated recursive-input API

## Why

Only the `.value(T)` payload can participate in the recursive value-type cycle. Applying `indirect` at the case level expresses that constraint precisely and avoids making unrelated future cases indirect.

## Impact

Generated call sites and encoding behavior are unchanged. Recursive schemas now produce `indirect case value(T)`; nonrecursive schemas continue to produce a direct value case.

## Validation

- `swift test -Xswiftc -warnings-as-errors` (47 tests passed)
