### PR TITLE
Update introspection to September 2025

### DIFF
--- a/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
@@ -10,19 +10,14 @@ extension Configuration.Input {
         ///   [September 2025 GraphQL specification](https://spec.graphql.org/September2025/#sec-Schema-Introspection).
         ///   Earlier introspection schemas are not supported.
         ///   - headers: Additional HTTP headers, such as authorization, to send to this endpoint.
-        ///   - includeDeprecatedFields: Pass `true` if the GraphQL schema should include fields that have been
-        ///   deprecated by the server. When deprecated fields are included, your GraphQL operations may query against these fields,
-        ///   but they will be annotated with a Swift warning. Pass `false` to exclude deprecated fields. When deprecated fields are excluded
-        ///   codegen will fail if your operations query against those fields.
-        ///   - includeDeprecatedEnumValues: Pass `true` if the GraphQL schema should include enum values (cases) that have
-        ///   been deprecated by the server. When deprecated enum values are included, the generated enum will include those cases,
-        ///   but they will be annotated with a Swift warning. Pass `false` to excluded deprecated enum values. When deprecated enum
-        ///   values are excluded, your code will not be able to reference those values.
+        ///   - includeDeprecated: Pass `true` if the GraphQL schema should include deprecated fields, arguments,
+        ///   input fields, directive arguments, and enum values. Deprecated generated declarations are annotated with a Swift
+        ///   warning where supported. Pass `false` to exclude deprecated schema members. Codegen will fail if an operation
+        ///   references an excluded member.
         case introspectionEndpoint(
             url: URL,
             headers: [String: String] = [:],
-            includeDeprecatedFields: Bool = true,
-            includeDeprecatedEnumValues: Bool = true
+            includeDeprecated: Bool = true
         )
 
         /// Instructs codegen to load your GraphQL schema from a .json file on the local filesystem.
@@ -34,8 +29,7 @@ extension Configuration.Input {
         /// The file should be formatted in valid Server Definition Langauge (SDL)
         case SDLSchemaFile(
             URL,
-            includeDeprecatedFields: Bool = true,
-            includeDeprecatedEnumValues: Bool = true
+            includeDeprecated: Bool = true
         )
     }
 }

--- a/Sources/GraphQLCodegen/Configuration/Configuration.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.swift
@@ -52,7 +52,7 @@ public struct Configuration: Sendable {
                 parameter: "JSONSchemaFile",
                 configuration: "schema source"
             )
-        case .SDLSchemaFile(let url, _, _):
+        case .SDLSchemaFile(let url, _):
             try verifyLocalURL(
                 url,
                 expectedExtension: ["graphqls", "sdl"],

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
@@ -3,10 +3,8 @@ import Foundation
 struct IntrospectionQuery: Encodable {
     let query: String
 
-    init(
-        includeDeprecatedFields: Bool,
-        includeDeprecatedEnumValues: Bool
-    ) {
+    init(includeDeprecated: Bool) {
+        let includeDeprecatedArgument = includeDeprecated ? "true" : "false"
         query = """
         query IntrospectionQuery {
           __schema {
@@ -31,7 +29,7 @@ struct IntrospectionQuery: Encodable {
               description
               locations
               isRepeatable
-              args {
+              args(includeDeprecated: \(includeDeprecatedArgument)) {
                 ...InputValue
               }
             }
@@ -44,10 +42,10 @@ struct IntrospectionQuery: Encodable {
           description
           specifiedByURL
           isOneOf
-          fields(includeDeprecated: \(includeDeprecatedFields ? "true" : "false")) {
+          fields(includeDeprecated: \(includeDeprecatedArgument)) {
             name
             description
-            args {
+            args(includeDeprecated: \(includeDeprecatedArgument)) {
               ...InputValue
             }
             type {
@@ -56,13 +54,13 @@ struct IntrospectionQuery: Encodable {
             isDeprecated
             deprecationReason
           }
-          inputFields {
+          inputFields(includeDeprecated: \(includeDeprecatedArgument)) {
             ...InputValue
           }
           interfaces {
             ...TypeRef
           }
-          enumValues(includeDeprecated: \(includeDeprecatedEnumValues ? "true" : "false")) {
+          enumValues(includeDeprecated: \(includeDeprecatedArgument)) {
             name
             description
             isDeprecated
@@ -80,6 +78,8 @@ struct IntrospectionQuery: Encodable {
             ...TypeRef
           }
           defaultValue
+          isDeprecated
+          deprecationReason
         }
 
         fragment TypeRef on __Type {

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionRunner.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionRunner.swift
@@ -3,8 +3,7 @@ import Foundation
 struct IntrospectionRunner {
     let endpoint: URL
     let headers: [String: String]
-    let includeDeprecatedFields: Bool
-    let includeDeprecatedEnumValues: Bool
+    let includeDeprecated: Bool
     let urlSession: URLSession
 
     func run() async throws -> Data {
@@ -31,10 +30,7 @@ struct IntrospectionRunner {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }
         urlRequest.httpBody = try JSONEncoder().encode(
-            IntrospectionQuery(
-                includeDeprecatedFields: includeDeprecatedFields,
-                includeDeprecatedEnumValues: includeDeprecatedEnumValues
-            )
+            IntrospectionQuery(includeDeprecated: includeDeprecated)
         )
         return urlRequest
     }

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -275,32 +275,8 @@ struct __Schema: Decodable {
     struct __Directive: Decodable {
         let name: String
         let description: String?
-        let locations: [__DirectiveLocation]
         let args: [__InputValue]
         let isRepeatable: Bool
-    }
-
-    enum __DirectiveLocation: String, Decodable {
-        case QUERY
-        case MUTATION
-        case SUBSCRIPTION
-        case FIELD
-        case FRAGMENT_DEFINITION
-        case FRAGMENT_SPREAD
-        case INLINE_FRAGMENT
-        case VARIABLE_DEFINITION
-        case SCHEMA
-        case SCALAR
-        case OBJECT
-        case FIELD_DEFINITION
-        case ARGUMENT_DEFINITION
-        case INTERFACE
-        case UNION
-        case ENUM
-        case ENUM_VALUE
-        case INPUT_OBJECT
-        case INPUT_FIELD_DEFINITION
-        case DIRECTIVE_DEFINITION
     }
 
     struct __Field: Decodable {
@@ -324,6 +300,8 @@ struct __Schema: Decodable {
         let description: String?
         let type: __TypeRef
         let defaultValue: String?
+        let isDeprecated: Bool
+        let deprecationReason: String?
     }
 
     private enum __TypeKind: String, Decodable {

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -104,26 +104,22 @@ struct SchemaLoader {
         case .introspectionEndpoint(
             let endpoint,
             let headers,
-            let includeDeprecatedFields,
-            let includeDeprecatedEnumValues
+            let includeDeprecated
         ):
             try await loadSchemaFromIntrospectionEndpoint(
                 endpoint: endpoint,
                 headers: headers,
-                includeDeprecatedFields: includeDeprecatedFields,
-                includeDeprecatedEnumValues: includeDeprecatedEnumValues
+                includeDeprecated: includeDeprecated
             )
         case .JSONSchemaFile(let schemaFile):
             try loadSchemaFromJSONFile(schemaFile)
         case .SDLSchemaFile(
             let schemaFile,
-            let includeDeprecatedFields,
-            let includeDeprecatedEnumValues
+            let includeDeprecated
         ):
             try loadSchemaFromSDLFile(
                 schemaFile,
-                includeDeprecatedFields: includeDeprecatedFields,
-                includeDeprecatedEnumValues: includeDeprecatedEnumValues
+                includeDeprecated: includeDeprecated
             )
         }
     }
@@ -131,14 +127,12 @@ struct SchemaLoader {
     private func loadSchemaFromIntrospectionEndpoint(
         endpoint: URL,
         headers: [String: String],
-        includeDeprecatedFields: Bool = false,
-        includeDeprecatedEnumValues: Bool = false
+        includeDeprecated: Bool
     ) async throws -> (LoadedSchema.Validation, __Schema) {
         let data = try await IntrospectionRunner(
             endpoint: endpoint,
             headers: headers,
-            includeDeprecatedFields: includeDeprecatedFields,
-            includeDeprecatedEnumValues: includeDeprecatedEnumValues,
+            includeDeprecated: includeDeprecated,
             urlSession: urlSession
         ).run()
         let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
@@ -160,14 +154,10 @@ struct SchemaLoader {
 
     private func loadSchemaFromSDLFile(
         _ schemaFile: URL,
-        includeDeprecatedFields: Bool,
-        includeDeprecatedEnumValues: Bool
+        includeDeprecated: Bool
     ) throws -> (LoadedSchema.Validation, __Schema) {
         let sdlSchemaString = try String(contentsOf: schemaFile, encoding: .utf8)
-        let introspectionQuery = IntrospectionQuery(
-            includeDeprecatedFields: includeDeprecatedFields,
-            includeDeprecatedEnumValues: includeDeprecatedEnumValues
-        ).query
+        let introspectionQuery = IntrospectionQuery(includeDeprecated: includeDeprecated).query
         let jsonSchema = try graphQLJS.convertSDLSchema(
             sdlSchemaString,
             introspectionQuery: introspectionQuery

--- a/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
@@ -98,13 +98,4 @@ struct GraphQL17BoundaryModelTests {
 
         #expect(try graphQLJS.canonicalize(described) == graphQLJS.canonicalize(undescribed))
     }
-
-    @Test
-    func decodesDirectiveDefinitionLocation() throws {
-        let data = Data(#""DIRECTIVE_DEFINITION""#.utf8)
-
-        let location = try JSONDecoder().decode(__Schema.__DirectiveLocation.self, from: data)
-
-        #expect(location == .DIRECTIVE_DEFINITION)
-    }
 }

--- a/Tests/GraphQLCodegenTests/Tests/IntrospectionQueryTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/IntrospectionQueryTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+@testable import GraphQLCodegen
+import Testing
+
+struct IntrospectionQueryTests {
+    @Test(arguments: [true, false])
+    func appliesDeprecationPolicyToEverySupportedCollection(includeDeprecated: Bool) {
+        let query = IntrospectionQuery(includeDeprecated: includeDeprecated).query
+        let argument = includeDeprecated ? "true" : "false"
+
+        #expect(query.contains("fields(includeDeprecated: \(argument))"))
+        #expect(query.contains("args(includeDeprecated: \(argument))"))
+        #expect(query.contains("inputFields(includeDeprecated: \(argument))"))
+        #expect(query.contains("enumValues(includeDeprecated: \(argument))"))
+        #expect(query.components(separatedBy: "args(includeDeprecated: \(argument))").count == 3)
+    }
+
+    @Test
+    func requestsAndDecodesSeptember2025IntrospectionFields() throws {
+        let query = IntrospectionQuery(includeDeprecated: true).query
+        let inputObjectData = Data(
+            #"{"description":null,"name":"Choice","inputFields":[],"isOneOf":true}"#.utf8
+        )
+        let inputValueData = Data(
+            #"{"name":"oldValue","description":null,"type":{"kind":"SCALAR","name":"String"},"defaultValue":null,"isDeprecated":true,"deprecationReason":"Use newValue."}"#.utf8
+        )
+
+        let inputObject = try JSONDecoder().decode(__Schema.__NamedType.InputObject.self, from: inputObjectData)
+        let inputValue = try JSONDecoder().decode(__Schema.__InputValue.self, from: inputValueData)
+
+        #expect(query.contains("isOneOf"))
+        #expect(query.contains("isDeprecated deprecationReason"))
+        #expect(inputObject.isOneOf)
+        #expect(inputValue.isDeprecated)
+        #expect(inputValue.deprecationReason == "Use newValue.")
+    }
+}


### PR DESCRIPTION
## Summary

- update the introspection query and decoding boundary to the September 2025 schema
- request deprecated fields, arguments, input fields, directive arguments, and enum values under one coherent `includeDeprecated` policy
- decode `__Type.isOneOf` and `__InputValue` deprecation metadata
- stop modeling the post-edition `DIRECTIVE_DEFINITION` location

## Why

The prior query omitted `includeDeprecated` on arguments and input fields, so GraphQL's default of `false` could silently remove deprecated schema members during code generation. The configuration also split deprecation behavior across field and enum-value booleans without covering the other supported collections.

This is intentionally a breaking configuration change: `includeDeprecatedFields` and `includeDeprecatedEnumValues` are replaced by a single `includeDeprecated` value for introspection endpoints and SDL schema files.

## Validation

- `swift test` — 47 tests passed
- SwiftLint on all changed Swift files
- `git diff --check`
