### PR TITLE
Use schema coordinates in diagnostics

### DIFF
--- a/Sources/GraphQLCodegen/Input/Schema/SchemaCoordinate.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaCoordinate.swift
@@ -1,0 +1,23 @@
+// https://spec.graphql.org/September2025/#sec-Schema-Coordinates
+enum SchemaCoordinate: CustomStringConvertible {
+    case argument(type: String, field: String, argument: String)
+    case directive(String)
+    case directiveArgument(directive: String, argument: String)
+    case member(type: String, member: String)
+    case type(String)
+
+    var description: String {
+        switch self {
+        case .argument(let type, let field, let argument):
+            "\(type).\(field)(\(argument):)"
+        case .directive(let directive):
+            "@\(directive)"
+        case .directiveArgument(let directive, let argument):
+            "@\(directive)(\(argument):)"
+        case .member(let type, let member):
+            "\(type).\(member)"
+        case .type(let type):
+            type
+        }
+    }
+}

--- a/Sources/GraphQLCodegen/Output/GeneratedTypeDeclaration.swift
+++ b/Sources/GraphQLCodegen/Output/GeneratedTypeDeclaration.swift
@@ -5,7 +5,7 @@ struct GeneratedTypeDeclaration {
         case api(String)
         case fragment(name: String, file: URL)
         case operation(name: String?, file: URL)
-        case schema(String)
+        case schema(SchemaCoordinate)
 
         var description: String {
             switch self {
@@ -15,8 +15,8 @@ struct GeneratedTypeDeclaration {
                 "Fragment: \(name)\nFile: \(file)"
             case .operation(let name, let file):
                 "Operation: \(name ?? "<unnamed>")\nFile: \(file)"
-            case .schema(let name):
-                "Schema type: \(name)"
+            case .schema(let coordinate):
+                "Schema coordinate: \(coordinate)"
             }
         }
 

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -38,7 +38,7 @@ struct SchemaWriter {
         typePlans.map { type in
             GeneratedTypeDeclaration(
                 name: SwiftTypeIdentifier(swiftName: type.name),
-                origin: .schema(type.name)
+                origin: .schema(.type(type.name))
             )
         }
     }

--- a/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
@@ -4,6 +4,7 @@ struct FieldResolver {
     let fieldSelection: GraphQLAST.Field
     let fieldSchema: __Schema.__Field
     let schema: Schema
+    let schemaCoordinate: SchemaCoordinate
     let documents: Documents
 
     func resolve() throws -> ResolvedField {
@@ -74,7 +75,7 @@ struct FieldResolver {
 
     private func missingSelectionSetError() -> Codegen.Error {
         Codegen.Error(description: """
-        Selected field \(fieldSelection.responseKey) which requires a selection set.
+        Selected field \(schemaCoordinate), which requires a selection set.
 
         Note: Turning on validation can help find other similar errors
         """)

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -48,6 +48,7 @@ struct SelectionSetResolver {
                         fieldSelection: field,
                         fieldSchema: onType.field(field),
                         schema: schema,
+                        schemaCoordinate: .member(type: onType.name, member: field.name.value),
                         documents: documents
                     ).resolve()
                 let conditional = typeCondition.isConditional ||

--- a/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
@@ -267,12 +267,16 @@ struct GeneratedTypeNameValidator {
         conflictingGraphQLValue: String,
         caseName: String
     ) -> Codegen.Error {
-        Codegen.Error(description: """
+        let coordinate = SchemaCoordinate.member(type: enumName, member: graphQLValue)
+        let conflictingCoordinate = SchemaCoordinate.member(
+            type: enumName,
+            member: conflictingGraphQLValue
+        )
+        return Codegen.Error(description: """
         GraphQL enum values produce conflicting Swift case names after case conversion.
-        Enum: \(enumName)
-        GraphQL values:
-        \(conflictingGraphQLValue)
-        \(graphQLValue)
+        Schema coordinates:
+        \(conflictingCoordinate)
+        \(coordinate)
         Swift case name: \(identifier(caseName))
 
         Change the enum case conversion or rename the GraphQL enum values so the generated case names are distinct.
@@ -353,7 +357,7 @@ struct GeneratedTypeNameValidator {
     ) -> Codegen.Error {
         Codegen.Error(description: """
         A generated schema type shadows a type referenced by generated code.
-        Schema type: \(schemaTypeName.source)
+        Schema coordinate: \(SchemaCoordinate.type(schemaTypeName.unescaped))
         Reference source: \(source)
         File: \(documentURL)
         """)

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -409,8 +409,8 @@ struct GraphQLCodeGeneratorTests {
         await expectCodegenError(
             containing: [
                 "GraphQL enum values produce conflicting Swift case names after case conversion",
-                "NORTH_WEST",
-                "NORTH__WEST",
+                "Direction.NORTH_WEST",
+                "Direction.NORTH__WEST",
                 "Swift case name: northWest",
             ]
         ) {
@@ -424,6 +424,20 @@ struct GraphQLCodeGeneratorTests {
                 type Query { direction: Direction! }
                 """,
                 enumCaseConversion: .conversion(from: .macro, to: .lowerCamel)
+            )
+        }
+    }
+
+    @Test
+    func reportsSchemaCoordinatesInsteadOfFieldAliases() async {
+        await expectCodegenError(containing: "Selected field Query.search, which requires a selection set") {
+            try await runCodegen(
+                document: "query Viewer { result: search }",
+                schema: """
+                type Query { search: SearchResult! }
+                type SearchResult { value: String! }
+                """,
+                validation: false
             )
         }
     }
@@ -619,7 +633,8 @@ struct GraphQLCodeGeneratorTests {
         schema: String,
         enumCaseConversion: Configuration.Output.Schema.Enums.CaseConversion? = nil,
         outputRelativePath: String = "Operations/Viewer.graphql.swift",
-        responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"]
+        responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"],
+        validation: Bool = true
     ) async throws -> String {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
@@ -642,6 +657,7 @@ struct GraphQLCodeGeneratorTests {
                     schemaSource: .SDLSchemaFile(schemaURL),
                     documentDirectories: [operationsDirectory]
                 ),
+                validation: validation,
                 output: .output(
                     schema: .schema(
                         directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory),

--- a/Tests/GraphQLCodegenTests/Tests/SchemaCoordinateTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/SchemaCoordinateTests.swift
@@ -1,0 +1,21 @@
+@testable import GraphQLCodegen
+import Testing
+
+struct SchemaCoordinateTests {
+    @Test
+    func formatsSchemaCoordinates() {
+        #expect(SchemaCoordinate.type("SearchInput").description == "SearchInput")
+        #expect(
+            SchemaCoordinate.member(type: "SearchInput", member: "term").description == "SearchInput.term"
+        )
+        #expect(
+            SchemaCoordinate.argument(type: "Query", field: "search", argument: "criteria").description ==
+                "Query.search(criteria:)"
+        )
+        #expect(SchemaCoordinate.directive("deprecated").description == "@deprecated")
+        #expect(
+            SchemaCoordinate.directiveArgument(directive: "deprecated", argument: "reason").description ==
+                "@deprecated(reason:)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add an internal formatter for the five standardized GraphQL schema coordinate forms
- use schema coordinates in field, enum collision, schema origin, and schema reference diagnostics
- ensure field diagnostics identify the schema field rather than an operation alias
- cover coordinate syntax and diagnostic behavior with unit and integration tests

## Why

Diagnostics previously assembled GraphQL element names ad hoc. This could surface an operation alias instead of the underlying schema field and rendered enum values without their containing type, making errors less precise and inconsistent with the September 2025 GraphQL specification.

## Impact

Diagnostics now identify schema elements with canonical coordinates such as `Query.search`, `Query.search(criteria:)`, and `SearchInput.term`. The formatter remains internal; no public parser or API is added.

## Validation

- `swift test -Xswiftc -warnings-as-errors` (59 tests)
- `mise run lint`
- `mise run periphery -- --format github-actions --relative-results --color never`
- `git diff --check`
