### PR TITLE
Clean up generated GraphQL response API

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/GraphQLError.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/GraphQLError.swift
@@ -1,6 +1,6 @@
 // @generated
 
-/// https://spec.graphql.org/October2021/#sec-Errors
+/// https://spec.graphql.org/September2025/#sec-Errors
 struct GraphQLError: Decodable, Sendable {
     struct Location: Decodable, Sendable {
         let line: Int
@@ -15,14 +15,14 @@ struct GraphQLError: Decodable, Sendable {
             let container = try decoder.singleValueContainer()
             if let stringValue = try? container.decode(String.self) {
                 self = .field(stringValue)
-            } else if let intValue = try? container.decode(Int.self) {
+            } else if let intValue = try? container.decode(Int.self), intValue >= 0 {
                 self = .listIndex(intValue)
             } else {
                 throw DecodingError.dataCorruptedError(
                     in: container,
                     debugDescription: """
-                    Path segments that represent fields should be strings, and path segments that represent list indices should be 0-indexed integers.
-                    https://spec.graphql.org/October2021/#sel-HAPHRPJABnEBpIx8Z
+                    Path segments that represent fields should be strings, and path segments that represent list indices should be non-negative integers.
+                    https://spec.graphql.org/September2025/#sec-Response-Position
                     """
                 )
             }

--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/GraphQLResponse.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/GraphQLResponse.swift
@@ -1,9 +1,9 @@
 // @generated
 
 enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
-    struct Success: Sendable {
-        let data: Data
-        let fieldErrors: [GraphQLError]?
+    struct ExecutionResult: Sendable {
+        let data: Data?
+        let errors: [GraphQLError]?
         let extensions: [String: JSONValue]?
     }
 
@@ -12,7 +12,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let extensions: [String: JSONValue]?
     }
 
-    case success(Success)
+    case executionResult(ExecutionResult)
     case requestError(RequestError)
 
     private enum CodingKeys: String, CodingKey {
@@ -25,21 +25,22 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
         let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
-        if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
+        if container.contains(.data) {
+            let data = try container.decodeIfPresent(Data.self, forKey: .data)
             guard errors?.isEmpty != true else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .errors,
                     in: container,
                     debugDescription: """
                     The errors entry in the response is a non-empty list of errors
-                    https://spec.graphql.org/October2021/#sel-FAPHRDCAACC0B59K
+                    https://spec.graphql.org/September2025/#sec-Execution-Result
                     """
                 )
             }
-            self = .success(
-                GraphQLResponse<Data>.Success(
+            self = .executionResult(
+                GraphQLResponse<Data>.ExecutionResult(
                     data: data,
-                    fieldErrors: errors,
+                    errors: errors,
                     extensions: extensions
                 )
             )
@@ -50,7 +51,7 @@ enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
                     in: container,
                     debugDescription: """
                     If the data entry in the response is not present, the errors entry in the response must not be empty
-                    https://spec.graphql.org/October2021/#sel-FAPHRHCAACEoBpjW
+                    https://spec.graphql.org/September2025/#sec-Request-Error-Result
                     """
                 )
             }

--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/URLSession+GraphQL.swift
@@ -14,13 +14,13 @@ extension URLSession {
     func request<Operation: GraphQLSingleResponseOperation>(
         _ request: GraphQLRequest<Operation>,
         decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
-    ) async throws -> GraphQLResponse<Operation.Data>.Success {
+    ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
         if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
             throw HTTPError(response: httpResponse)
         }
         switch try decoder(data) {
-        case .success(let success): return success
+        case .executionResult(let executionResult): return executionResult
         case .requestError(let requestError):
             let containsPersistedQueryNotFound = requestError.errors.contains { error in
                 error.message == "PersistedQueryNotFound"
@@ -70,7 +70,7 @@ extension URLSession {
         maximumEventByteCount: Int = 1_048_576,
         maximumLineByteCount: Int = 1_052_672,
         maximumBufferedResultCount: Int = 16
-    ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
+    ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.ExecutionResult, Error> {
         guard maximumEventByteCount > 0 else {
             throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
         }
@@ -108,8 +108,8 @@ extension URLSession {
                         switch event.name {
                         case .next:
                             switch try decoder(event.data) {
-                            case .success(let success):
-                                switch continuation.yield(success) {
+                            case .executionResult(let executionResult):
+                                switch continuation.yield(executionResult) {
                                 case .enqueued: break
                                 case .dropped:
                                     throw SubscriptionError.resultBufferOverflow(

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -17,8 +17,8 @@ struct __Schema: Decodable {
             let name: String
             let specifiedByURL: String?
 
-            var isNativeSwiftType: Bool {
-                SourceTypeName(nativeGraphQLScalarName: name) != nil
+            var requiresGeneratedTypeDefinition: Bool {
+                name == "ID" || SourceTypeName(nativeGraphQLScalarName: name) == nil
             }
 
             var swiftName: String {

--- a/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
@@ -15,7 +15,7 @@ struct GraphQLErrorWriter: APIOutput {
 
     var source: String {
         """
-        \(header)/// https://spec.graphql.org/October2021/#sec-Errors
+        \(header)/// https://spec.graphql.org/September2025/#sec-Errors
         \(accessLevel)struct GraphQLError: Decodable, Sendable {
             \(accessLevel)struct Location: Decodable, Sendable {
                 \(accessLevel)let line: Int
@@ -30,14 +30,14 @@ struct GraphQLErrorWriter: APIOutput {
                     let container = try decoder.singleValueContainer()
                     if let stringValue = try? container.decode(String.self) {
                         self = .field(stringValue)
-                    } else if let intValue = try? container.decode(Int.self) {
+                    } else if let intValue = try? container.decode(Int.self), intValue >= 0 {
                         self = .listIndex(intValue)
                     } else {
                         throw DecodingError.dataCorruptedError(
                             in: container,
                             debugDescription: \"\"\"
-                            Path segments that represent fields should be strings, and path segments that represent list indices should be 0-indexed integers.
-                            https://spec.graphql.org/October2021/#sel-HAPHRPJABnEBpIx8Z
+                            Path segments that represent fields should be strings, and path segments that represent list indices should be non-negative integers.
+                            https://spec.graphql.org/September2025/#sec-Response-Position
                             \"\"\"
                         )
                     }

--- a/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
@@ -16,9 +16,9 @@ struct GraphQLResponseWriter: APIOutput {
     var source: String {
         """
         \(header)\(accessLevel)enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
-            \(accessLevel)struct Success: Sendable {
-                \(accessLevel)let data: Data
-                \(accessLevel)let fieldErrors: [GraphQLError]?
+            \(accessLevel)struct ExecutionResult: Sendable {
+                \(accessLevel)let data: Data?
+                \(accessLevel)let errors: [GraphQLError]?
                 \(accessLevel)let extensions: [String: JSONValue]?
             }
 
@@ -27,7 +27,7 @@ struct GraphQLResponseWriter: APIOutput {
                 \(accessLevel)let extensions: [String: JSONValue]?
             }
 
-            case success(Success)
+            case executionResult(ExecutionResult)
             case requestError(RequestError)
 
             private enum CodingKeys: String, CodingKey {
@@ -40,21 +40,22 @@ struct GraphQLResponseWriter: APIOutput {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
                 let errors = try container.decodeIfPresent([GraphQLError].self, forKey: .errors)
                 let extensions = try container.decodeIfPresent([String: JSONValue].self, forKey: .extensions)
-                if let data = try container.decodeIfPresent(Data.self, forKey: .data) {
+                if container.contains(.data) {
+                    let data = try container.decodeIfPresent(Data.self, forKey: .data)
                     guard errors?.isEmpty != true else {
                         throw DecodingError.dataCorruptedError(
                             forKey: .errors,
                             in: container,
                             debugDescription: \"\"\"
                             The errors entry in the response is a non-empty list of errors
-                            https://spec.graphql.org/October2021/#sel-FAPHRDCAACC0B59K
+                            https://spec.graphql.org/September2025/#sec-Execution-Result
                             \"\"\"
                         )
                     }
-                    self = .success(
-                        GraphQLResponse<Data>.Success(
+                    self = .executionResult(
+                        GraphQLResponse<Data>.ExecutionResult(
                             data: data,
-                            fieldErrors: errors,
+                            errors: errors,
                             extensions: extensions
                         )
                     )
@@ -65,7 +66,7 @@ struct GraphQLResponseWriter: APIOutput {
                             in: container,
                             debugDescription: \"\"\"
                             If the data entry in the response is not present, the errors entry in the response must not be empty
-                            https://spec.graphql.org/October2021/#sel-FAPHRHCAACEoBpjW
+                            https://spec.graphql.org/September2025/#sec-Request-Error-Result
                             \"\"\"
                         )
                     }

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -37,13 +37,13 @@ struct URLSessionWriter: APIOutput {
             \(accessLevel)func request<Operation: GraphQLSingleResponseOperation>(
                 _ request: GraphQLRequest<Operation>,
                 decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
-            ) async throws -> GraphQLResponse<Operation.Data>.Success {
+            ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
                 let (data, response) = try await data(for: request.urlRequest)
                 if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
                     throw HTTPError(response: httpResponse)
                 }
                 switch try decoder(data) {
-                case .success(let success): return success
+                case .executionResult(let executionResult): return executionResult
                 \(requestErrorHandling())
                 }
             }\(subscriptions())
@@ -110,7 +110,7 @@ struct URLSessionWriter: APIOutput {
                 maximumEventByteCount: Int = 1_048_576,
                 maximumLineByteCount: Int = 1_052_672,
                 maximumBufferedResultCount: Int = 16
-            ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.Success, Error> {
+            ) async throws -> AsyncThrowingStream<GraphQLResponse<Subscription.Data>.ExecutionResult, Error> {
                 guard maximumEventByteCount > 0 else {
                     throw SubscriptionError.invalidMaximumEventByteCount(maximumEventByteCount)
                 }
@@ -148,8 +148,8 @@ struct URLSessionWriter: APIOutput {
                                 switch event.name {
                                 case .next:
                                     switch try decoder(event.data) {
-                                    case .success(let success):
-                                        switch continuation.yield(success) {
+                                    case .executionResult(let executionResult):
+                                        switch continuation.yield(executionResult) {
                                         case .enqueued: break
                                         case .dropped:
                                             throw SubscriptionError.resultBufferOverflow(

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -25,7 +25,7 @@ struct SchemaWriter {
         self.indirectOneOfInputObjectFields = resolvedDocuments.indirectOneOfInputObjectFields
         self.typePlans = resolvedDocuments.usedTypes.sorted().compactMap { name -> TypePlan? in
             if let scalar = schema.typeCache.scalars[name] {
-                return scalar.ast.isNativeSwiftType ? nil : .scalar(scalar)
+                return scalar.ast.requiresGeneratedTypeDefinition ? .scalar(scalar) : nil
             }
             if let `enum` = schema.typeCache.enums[name] {
                 return `enum`.ast.isSystemType ? nil : .enum(`enum`)

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -9,6 +9,7 @@ indirect enum SourceTypeName {
         case "Int": self = .name("Int")
         case "Float": self = .name("Double")
         case "Boolean": self = .name("Bool")
+        case "ID": self = .name("ID")
         default: return nil
         }
     }

--- a/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/GraphQL17BoundaryModelTests.swift
@@ -4,6 +4,11 @@ import Testing
 
 struct GraphQL17BoundaryModelTests {
     @Test
+    func mapsBuiltInIDToTheCustomizableGeneratedAlias() {
+        #expect(SourceTypeName(nativeGraphQLScalarName: "ID")?.formatted() == "ID")
+    }
+
+    @Test
     func decodesExecutableDescriptions() throws {
         let document = try DocumentASTParser(
             graphQLJS: GraphQLJS(),

--- a/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLResponseTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/GraphQLResponseTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+@testable import StarwarsExample
+import Testing
+
+struct GraphQLResponseTests {
+    @Test
+    func treatsExplicitNullDataAsAnExecutionResult() throws {
+        let response = try JSONDecoder().decode(
+            GraphQLResponse<Payload>.self,
+            from: Data(
+                #"""
+                {
+                  "data": null,
+                  "errors": [{ "message": "The root result could not be resolved." }]
+                }
+                """#.utf8
+            )
+        )
+
+        guard case .executionResult(let executionResult) = response else {
+            Issue.record("Expected an execution result")
+            return
+        }
+        #expect(executionResult.data == nil)
+        #expect(executionResult.errors?.count == 1)
+    }
+
+    @Test
+    func treatsAbsentDataAsARequestErrorResult() throws {
+        let response = try JSONDecoder().decode(
+            GraphQLResponse<Payload>.self,
+            from: Data(
+                #"""
+                { "errors": [{ "message": "The request is invalid." }] }
+                """#.utf8
+            )
+        )
+
+        guard case .requestError(let requestError) = response else {
+            Issue.record("Expected a request error result")
+            return
+        }
+        #expect(requestError.errors.count == 1)
+    }
+
+    @Test
+    func rejectsNegativeErrorPathListIndices() {
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(
+                GraphQLError.self,
+                from: Data(
+                    #"""
+                    { "message": "Invalid path", "path": ["items", -1] }
+                    """#.utf8
+                )
+            )
+        }
+    }
+
+    private struct Payload: Decodable, Sendable {}
+}

--- a/Tests/GraphQLCodegenTests/Tests/Integration/OutputTransactionTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/OutputTransactionTests.swift
@@ -38,23 +38,35 @@ struct OutputTransactionTests {
     }
 
     @Test
-    func preservesCustomScalarSource() async throws {
+    func preservesCustomScalarSourcesIncludingBuiltInID() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let customScalarURL = fixture.output
-            .appending(path: "Schema/Scalars", directoryHint: .isDirectory)
-            .appending(path: "Custom.graphqls.swift", directoryHint: .notDirectory)
+        let scalarsDirectory = fixture.output.appending(
+            path: "Schema/Scalars",
+            directoryHint: .isDirectory
+        )
         try FileManager.default.createDirectory(
-            at: customScalarURL.deletingLastPathComponent(),
+            at: scalarsDirectory,
             withIntermediateDirectories: true
+        )
+        let customScalarURL = scalarsDirectory.appending(
+            path: "Custom.graphqls.swift",
+            directoryHint: .notDirectory
         )
         let customSource = "typealias Custom = UUID\n"
         try Data(customSource.utf8).write(to: customScalarURL)
+        let idScalarURL = scalarsDirectory.appending(
+            path: "ID.graphqls.swift",
+            directoryHint: .notDirectory
+        )
+        let idSource = "struct ID: Codable, Sendable { let rawValue: String }\n"
+        try Data(idSource.utf8).write(to: idScalarURL)
 
         try await Codegen(try configuration(for: fixture)).run()
 
         #expect(try String(contentsOf: customScalarURL, encoding: .utf8) == customSource)
+        #expect(try String(contentsOf: idScalarURL, encoding: .utf8) == idSource)
     }
 
     @Test
@@ -142,12 +154,13 @@ struct OutputTransactionTests {
             scalar Custom
             enum Choice { A }
             input Filter { value: Custom, choice: Choice }
-            type Query { value(filter: Filter): Custom! }
+            type Query { id: ID!, value(filter: Filter): Custom! }
             """.utf8
         ).write(to: schema)
         try Data(
             """
             query Value($filter: Filter) {
+              id
               value(filter: $filter)
             }
             """.utf8

--- a/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/ServerSentEventTests.swift
@@ -12,7 +12,7 @@ struct ServerSentEventTests {
         let stream = try await session.subscribe(try makeRequest(path: "standards"))
         var values: [GraphQLEnum<Episode>] = []
         for try await response in stream {
-            values.append(response.data.favoriteEpisodeChanged)
+            values.append(try #require(response.data).favoriteEpisodeChanged)
         }
 
         #expect(values == [.known(.jedi)])
@@ -154,10 +154,10 @@ struct ServerSentEventTests {
                 if text.contains("EMPIRE") {
                     secondResultDecoded.signal()
                 }
-                return .success(
-                    GraphQLResponse<OverflowProbeData>.Success(
+                return .executionResult(
+                    GraphQLResponse<OverflowProbeData>.ExecutionResult(
                         data: OverflowProbeData(),
-                        fieldErrors: nil,
+                        errors: nil,
                         extensions: nil
                     )
                 )


### PR DESCRIPTION
## Summary

- rename the generated response success model to `ExecutionResult` and the enum case to `.executionResult`
- rename `fieldErrors` to `errors` and propagate the API rename through generated URLSession helpers
- distinguish an absent `data` entry from an explicit `null` value so `{"data": null, "errors": [...]}` decodes as an execution result
- reject negative list indices in GraphQL error response paths
- recognize built-in `ID` as a known GraphQL mapping while retaining the generated, user-preserved `typealias ID = String`
- regenerate the Star Wars example and add regression coverage

## Why

The September 2025 GraphQL specification uses “execution error” terminology, requires execution results to contain a `data` entry whose value may be null, and specifies that ID results serialize as strings.

The previous decoder used `decodeIfPresent` to decide the response kind. That API returns nil for both a missing key and an explicit null, causing valid execution results with root-level null data to be misclassified as request-error results.

Keeping the generated ID alias preserves the existing customization path: users may replace the alias file with their own `ID` type, while the default remains String-backed.

## Impact

This intentionally renames generated API symbols:

- `GraphQLResponse.Success` → `GraphQLResponse.ExecutionResult`
- `.success` → `.executionResult`
- `fieldErrors` → `errors`

`ExecutionResult.data` is now optional to model explicit null data.

## Validation

- `swift test` — 61 tests passed
- `mise run lint` — no violations
- `mise run periphery` — no unused code
- `git diff --check`
