### PR TITLE
Update GraphQL spec links and tighten README

### DIFF
--- a/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
+++ b/Examples/StarwarsExample/Sources/StarwarsExample/API/HTTPSupport/GraphQLOperation.swift
@@ -4,12 +4,12 @@
 protocol GraphQLOperation: Sendable {
 
     /// The optional name of the operation.
-    /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
+    /// https://spec.graphql.org/September2025/#sel-FAFTDCFABAADFCBAAD-zM
     static var operationName: String? { get }
 
     /// The executable string operated on by a GraphQL service, containing
     /// an operation definition and zero or more fragment definitions.
-    /// https://spec.graphql.org/October2021/#sec-Document
+    /// https://spec.graphql.org/September2025/#sec-Document
     static var document: String { get }
 
     /// A precomputed, execution-equivalent document with executable descriptions and ignored characters removed.
@@ -18,7 +18,7 @@ protocol GraphQLOperation: Sendable {
     static var minifiedDocument: String { get }
 
     /// The parameterized variables to execute the operation with.
-    /// https://spec.graphql.org/October2021/#sec-Language.Variables
+    /// https://spec.graphql.org/September2025/#sec-Language.Variables
     var variables: Variables { get }
 
     /// The operation's variables erased for request encoding.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://raw.githubusercontent.com/apollographql/apollo-ios/main/LICENSE">
+  <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-lightgrey.svg?maxAge=2592000" alt="MIT license">
   </a>
   <a href="https://github.com/apple/swift">
@@ -15,29 +15,27 @@
 
 # Swift GraphQL Codegen
 
-Everything you need and nothing you don't. Swift GraphQL Codegen is a lightweight Swift library for generating type-safe Swift code from your GraphQL schema and operations. This library’s goal is to provide simple and customizable generation of Swift types to mirror your GraphQL documents, with optional built-in networking helpers tailored to your specific usage.
+Swift GraphQL Codegen generates type-safe Swift models from GraphQL schemas and operation documents. It emits concrete models
+with stored properties and can optionally generate networking helpers tailored to the enabled features.
 
-- [x] All types are structs
-- [x] Stored properties
-- [x] Serialization using Encodable/Decodable
-- [x] Automatic Hashable/Equatable conformance
-- [x] Swift concurrency support via Sendable conformance
-- [x] Persisted operations support
-- [x] Optional URLSession support, including support for query operations using GET and subscriptions using server-sent events
-- [ ] TODO: Automatic persisted-operation fallback for subscriptions; currently unsupported
-- [x] Schema can come from SDL, JSON or an introspection endpoint
-- [x] Control over public/internal access level
-- [x] Control over mutable or immutable types
-- [x] Only generates types for scalars, enums, and input objects that are used by operations
-- [x] No dependency added to your app binary
+- Operation and response models built from Swift structs with stored properties
+- GraphQL enums represented as Swift enums
+- Native `Codable` generation, `Sendable` defaults, and configurable model conformances
+- Automatic and registered persisted operations
+- Optional `URLSession` support for POST requests, GET queries, and server-sent event subscriptions
+- SDL, JSON, and introspection schema inputs
+- Configurable access levels and property mutability
+- Schema types generated only when referenced by an operation
+- No runtime package dependency added to the client application
 
----
+Automatic persisted-operation fallback is supported for queries and mutations. Registered persisted operations are supported for
+subscriptions, but automatic fallback is not.
 
 ## Platform Support
 
-The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference implementation.
-Generated source deployment requirements depend on the APIs enabled in your configuration. Subscription support requires version
-26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
+The code generator runs on macOS 26 or newer because it uses JavaScriptCore to execute the bundled GraphQL reference
+implementation. Generated source deployment requirements depend on the enabled APIs. Subscription support requires version 26 or
+newer of macOS, iOS, tvOS, watchOS, or visionOS.
 
 ## GraphQL Compatibility
 
@@ -45,7 +43,7 @@ Swift GraphQL Codegen targets the [September 2025 edition of the GraphQL specifi
 Schemas and introspection endpoints must conform to that edition. Earlier introspection schemas are not supported; in particular,
 an introspection endpoint must expose `__Type.isOneOf`.
 
-## Output directory ownership
+## Output Directory Ownership
 
 Codegen assumes exclusive ownership of the configured schema output directories. Each run may remove and recreate the scalar,
 enum, and input-object directories, including files that are not part of the current generated output. Do not store unrelated or
@@ -55,90 +53,78 @@ When a schema category's `directoryName` is `nil`, that category writes directly
 schema root itself as an owned output directory. Customized scalar files are preserved while their scalar remains part of the
 generated output; if the scalar is no longer used by an operation, its file may be removed on the next run.
 
-## Server-Sent Event limits
+## Subscription Limits
 
 The generated GraphQL subscription API accepts LF, CRLF, and CR line endings and independently bounds SSE lines, complete event
 payloads, and decoded results waiting for the consumer. Configure these limits with `maximumLineByteCount`,
-`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing. This API requires version 26 or newer of macOS, iOS,
-tvOS, watchOS, or visionOS.
-
----
-
-## Table of Contents
-
-1. [Platform Support](#platform-support)
-2. [GraphQL Compatibility](#graphql-compatibility)
-3. [Output directory ownership](#output-directory-ownership)
-4. [Server-Sent Event limits](#server-sent-event-limits)
-5. [Getting Started](#getting-started)
-6. [Example](#example-output)
-7. [Motivation](#motivation)
-8. [Design](#design)
-9. [Contributing](#contributing)
-10. [License](#license)
-
----
+`maximumEventByteCount`, and `maximumBufferedResultCount` when subscribing.
 
 ## Getting Started
 
-Below is a simple example demonstrating how you might integrate this library into your GraphQL project.
+Create a Swift package executable that runs code generation separately from your client application.
 
-### Step 1: Create an SPM executable.
+### 1. Add the Package
 
-In `Package.swift` create an executable target that depends on this library:
+In `Package.swift`, add an executable target that depends on `GraphQLCodegen`:
 
 ```swift
-// swift-tools-version:6.3
+// swift-tools-version: 6.3
 import PackageDescription
 
 let package = Package(
     name: "MyCodegenCLI",
     platforms: [
-        .macOS(.v26)
+        .macOS(.v26),
     ],
     products: [
         .executable(name: "my-codegen-cli", targets: ["MyCodegenCLI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pm-dev/swift-graphql-codegen", from: "0.5.0"),
+        .package(url: "https://github.com/pm-dev/swift-graphql-codegen", from: "0.7.2"),
     ],
     targets: [
         .executableTarget(
             name: "MyCodegenCLI",
             dependencies: [
-                .product(name: "GraphQLCodegen", package: "swift-graphql-codegen")
+                .product(name: "GraphQLCodegen", package: "swift-graphql-codegen"),
             ]
-        )
+        ),
     ]
 )
 ```
 
-### Step 2: Implement your codegen executable
+### 2. Configure Code Generation
 
-In your executable target, create a command that imports the `GraphQLCodegen` module. The library provides a `Configuration` type to specify how you’d like your code generated (e.g., file output paths, usage of let vs. var, etc.). Pass this to the `Codegen.run` function. Explore the `Configuration` type to see all available configuration options. Most options come with a recommended default.
+The following executable reads `schema.sdl` and GraphQL operations from an `Operations` directory next to the source file, then
+writes generated schema and API files to `Generated`:
 
 ```swift
+import Foundation
 import GraphQLCodegen
 
 @main
 struct MyCodegenCLI {
+    private static let sourceDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
     static func main() async throws {
+        let generatedDirectory = sourceDirectory.appending(path: "Generated", directoryHint: .isDirectory)
+
         try await Codegen(
             .configuration(
                 input: .input(
-                    // SDL and JSON files are also supported
-                    schemaSource: .introspectionEndpoint(
-                        url: URL(string: "http://localhost:5173/api/graphql")!,
-                        headers: ["Authorization": "Bearer <token>"]
+                    schemaSource: .SDLSchemaFile(
+                        sourceDirectory.appending(path: "schema.sdl", directoryHint: .notDirectory)
                     ),
-                    documentDirectories: [graphQLDocumentsDirectory]
+                    documentDirectories: [
+                        sourceDirectory.appending(path: "Operations", directoryHint: .isDirectory),
+                    ]
                 ),
                 output: .output(
                     schema: .schema(
-                        directory: graphQLSchemaOutputDirectory
+                        directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory)
                     ),
                     api: .api(
-                        directory: graphQLAPIOutputDirectory
+                        directory: generatedDirectory.appending(path: "API", directoryHint: .isDirectory)
                     )
                 )
             )
@@ -147,355 +133,110 @@ struct MyCodegenCLI {
 }
 ```
 
-### Step 3: Compile and run your executable CLI
+JSON schema files and introspection endpoints are also supported through `Configuration.Input.SchemaSource`.
+
+### 3. Run the Generator
+
+From the package directory, run:
 
 ```bash
 swift run my-codegen-cli
 ```
 
-Your CLI will parse the schema and operations, then produce Swift types in the locations specified by your Configuration.
+## Generated Output
 
-
-## Example
-
-Below is an illustration of what the generated code might look like for an example Star Wars schema. Explore this codegen yourself by pulling the repository and running the standalone package in `Examples/StarwarsExample`.
-
-Suppose you have the following GraphQL schema:
-
-```graphqls
-type Query {
-  hero(episode: Episode): Character!
-}
-
-interface Character {
-  id: ID!
-  name: String!
-}
-
-type Jedi implements Character {
-  id: ID!
-  name: String!
-  lightSaberColor: String!
-}
-
-type Droid implements Character {
-  id: ID!
-  name: String!
-  primaryFunction: String
-}
-
-enum Episode {
-  NEWHOPE
-  EMPIRE
-  JEDI
-}
-```
-
-And an operation:
+Given a GraphQL operation such as:
 
 ```graphql
 query Hero($episode: Episode!) {
   hero(episode: $episode) {
     id
     name
-    ...on Jedi {
-      lightSaberColor
-    }
-    ...on Droid {
-      primaryFunction
-    }
   }
 }
 ```
 
-The output will look like:
+Codegen produces an operation type and nested response models. This abbreviated example shows the generated shape:
 
 ```swift
 struct HeroQuery: GraphQLQuery {
-
     static let operationName: String? = "Hero"
 
-    static let document = """
+    static let document = #"""
     query Hero($episode: Episode!) {
       hero(episode: $episode) {
         id
         name
-        ...on Jedi {
-          lightSaberColor
-        }
-        ...on Droid {
-          primaryFunction
-        }
       }
     }
-    """
+    """#
+
+    static let minifiedDocument = #"""
+    query Hero($episode:Episode!){hero(episode:$episode){id name}}
+    """#
 
     let variables: Variables
-
     let extensions: [String: AnyEncodable]?
 
-    init(
-        episode: Episode,
-        extensions: [String: AnyEncodable]? = nil
-    ) {
-        self.variables = Variables(
-            episode: episode
-        )
-        self.extensions = extensions
-    }
-
     struct Variables: Encodable, Sendable {
-
         let episode: Episode
     }
 
-    struct Data: Decodable, Hashable, Sendable {
-
+    struct Data: Decodable, Sendable, Hashable {
         let hero: Hero
 
-        struct Hero: Decodable, Hashable, Sendable {
-
+        struct Hero: Decodable, Sendable, Hashable {
             let id: ID
-
             let name: String
-
-            let lightSaberColor: String?
-
-            let primaryFunction: String?
         }
     }
-}
-
-enum Episode: String, Encodable, Sendable {
-    case NEWHOPE
-    case EMPIRE
-    case JEDI
 }
 ```
 
-Key features you’ll notice in the generated code:
-
-- Structs: We represent each operation and response type as a Swift struct.
-- Native Codable: Encodable and Decodable conformance using Swift’s built-in protocols.
-- Automatic Equatable and Hashable: For easy comparison and set/dictionary usage.
-- Swift Concurrency: By default, generated types conform to Sendable.
-- Configuration: You can specify whether to use `var` or `let` for property declarations (among other options). By default, `let` is used in operation response types and `var` is used in fragment types, but this is customizable.
-
-Let's take a look at an example using fragments:
-
-```graphql
-query Hero($episode: Episode!) {
-  hero(episode: $episode) {
-    __typename
-    ...jedi
-    ...droid
-  }
-}
-
-fragment jedi on Jedi {
-  ...character
-  lightSaberColor
-}
-
-fragment droid on Droid {
-  ...character
-  primaryFunction
-}
-
-fragment character on Character {
-  id
-  name
-}
-```
-
-Would output:
-
-```swift
-struct HeroQuery: GraphQLQuery {
-
-    static let operationName: String? = "Hero"
-
-    static let document = """
-    query Hero($episode: Episode!) {
-      hero(episode: $episode) {
-        __typename
-        ...jedi
-        ...droid
-      }
-    }
-    \(Jedi.source)
-    \(Droid.source)
-    \(Character.source)
-    """
-
-    let variables: Variables
-
-    let extensions: [String: AnyEncodable]?
-
-    init(
-        episode: Episode,
-        extensions: [String: AnyEncodable]? = nil
-    ) {
-        self.variables = Variables(
-            episode: episode
-        )
-        self.extensions = extensions
-    }
-
-    struct Variables: Encodable, Sendable {
-
-        let episode: Episode
-    }
-
-    struct Data: Decodable, Sendable {
-
-        let hero: Hero
-
-        struct Hero: Decodable, Sendable {
-
-            let __typename: String
-
-            let __jedi: Jedi?
-
-            let __droid: Droid?
-
-            init(from decoder: Decoder) throws {
-                enum CodingKeys: CodingKey {
-                    case __typename
-                }
-                let container = try decoder.container(keyedBy: CodingKeys.self)
-                __typename = try container.decode(String.self, forKey: .__typename)
-                __jedi = __typename == "Jedi" ? try Jedi(from: decoder) : nil
-                __droid = __typename == "Droid" ? try Droid(from: decoder) : nil
-            }
-        }
-    }
-}
-
-struct Jedi: Decodable, Sendable, Hashable {
-
-    static let source = """
-    fragment jedi on Jedi {
-      ...character
-      lightSaberColor
-    }
-    """
-
-    var __character: Character
-
-    var lightSaberColor: String
-
-    init(from decoder: Decoder) throws {
-        enum CodingKeys: CodingKey {
-            case lightSaberColor
-        }
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        lightSaberColor = try container.decode(String.self, forKey: .lightSaberColor)
-        __character = try Character(from: decoder)
-    }
-}
-
-struct Droid: Decodable, Sendable, Hashable {
-
-    static let source = """
-    fragment droid on Droid {
-      ...character
-      primaryFunction
-    }
-    """
-
-    var __character: Character
-
-    var primaryFunction: String?
-
-    init(from decoder: Decoder) throws {
-        enum CodingKeys: CodingKey {
-            case primaryFunction
-        }
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        primaryFunction = try container.decode(String?.self, forKey: .primaryFunction)
-        __character = try Character(from: decoder)
-    }
-}
-
-struct Character: Decodable, Sendable, Hashable {
-
-    static let source = """
-    fragment character on Character {
-      id
-      name
-    }
-    """
-
-    var id: ID
-
-    var name: String
-}
-```
-
+The [Star Wars example](Examples/StarwarsExample) contains a runnable generator and its checked-in output, including the complete
+[generated Hero query](Examples/StarwarsExample/Sources/StarwarsExample/Operations/HeroQuery.graphql.swift).
 
 ## Design
 
-This library focuses on simplicity and ease of use. The generated types use structs, stored properties, Swift’s compiler-generated Encodable/Decodable and Equatable/Hashable where possible to greatly reduce boilerplate. Operation response types mirror your documents, with fields ordered consistently with the GraphQL spec. No underlying types or reflection-based logic. You can also optionally generate networking helpers using URLRequest and URLSession whose API is generated taking into consideration your Configuration options, giving you fine-grained control over how you integrate network requests in your project.
-This library uses a pinned version of the reference implementation [graphql-js](https://github.com/graphql/graphql-js) through Apple’s JavaScriptCore framework to parse and validate GraphQL schemas and documents. The supported target is the September 2025 edition of the GraphQL specification.
+Generated response models use stored properties rather than a backing dictionary or reflection. Operation response types mirror
+the selected fields, with response properties ordered consistently with the GraphQL specification. Custom scalars, protocol
+conformances, imports, access levels, and mutability are configurable.
 
-Key design points:
+The generator uses a pinned version of [graphql-js](https://github.com/graphql/graphql-js) through JavaScriptCore to parse and
+validate GraphQL schemas and documents.
 
-- Extendable: You can add custom scalar definitions and add protocol conformances or module imports if needed.
-- Tailored Networking: The opt-in networking code is generated in the same pass, ensuring an API that is as simple as possible. For example, Persisted Operations and GET queries are supported, but if those configuration options are turned off, the generated Networking APIs will be absent these concepts.
-- Parsing & Validation: We delegate to graphql-js to parse and validate your schema and `.graphql` documents.
+### Generated Type Naming
 
-Simplicity also means this package is small, which keeps SPM resolution times and compile times fast
-- ~70 Swift files
-- ~5k lines of code
-- ~3 second clean build compile time (M1 laptop)
-- 1 dependency (Apple's OrderedCollections package)
+The response key for a field is its alias when one is present, or its schema field name otherwise. When a selected field has a
+selection set, Codegen names its nested response type by capitalizing that response key.
 
-### Generated type naming
-
-GraphQL response keys may use any casing permitted by GraphQL. The response key is the field alias when one is present, or the schema field name otherwise.
-
-When a selected field has a selection set, codegen creates a nested response type named by capitalizing its response key. When two fields in the same selection set would produce the same type name, Codegen reports an error. For example, this valid GraphQL:
+If two fields in the same selection set produce the same Swift type name, Codegen reports an error. For example, this valid
+GraphQL selection would produce `struct Profile` for both fields:
 
 ```graphql
 profile: Viewer { id }
 Profile: Viewer { name }
 ```
 
-would produce `struct Profile` for both keys. An alias or fragment can be used to resolve this conflict.
+Use an alias or fragment to resolve the conflict.
 
-Before writing files, Codegen builds the concrete output plan and validates declarations in their actual Swift lexical scopes. This includes conflicts between response keys, fragments, generated schema types, and fixed operation declarations or references such as `Data`, `Variables`, and `CodingKey`.
+Before writing files, Codegen validates declarations in their actual Swift lexical scopes. This includes conflicts between
+response keys, fragments, generated schema types, and fixed operation declarations or references such as `Data`, `Variables`, and
+`CodingKey`.
 
-Configured conformances are emitted verbatim and are not included in collision validation. Codegen neither qualifies generated system type references nor validates collisions with Swift standard-library or Foundation types. Callers are responsible for avoiding those collisions with GraphQL aliases or fragment names and for qualifying configured types and conformances when necessary.
-
-## Alternatives
-
-Alternative Swift GraphQL client libraries exist. This project was created to solve specific issues and reduce complexity. It has optimized for different tradeoffs than the libraries below. Choosing the right library will depend on your specific use case.
-
-[Apollo iOS](https://github.com/apollographql/apollo-ios)
-
-- A feature-rich library that includes codegen, caching and advanced networking infrastructure.
-- All functionality is compiled into in a single binary regardless of whether you use it or not.
-- Relies on computed properties from a backing dictionary
-    - This can complicate local mutations and make it difficult to use generated types in your domain model.
-    - This can make mocking data difficult.
-- Missing `Sendable` conformances.
-- [Uses unsafe fragment resolution](https://github.com/apollographql/apollo-ios/issues/3516).
-
-[swift-graphql](https://github.com/maticzav/swift-graphql)
-
-- `swift-graphql` is does not provide codegen from .graphql documents. Instead, you build typesafe queries in code. [Why swift-graphql](https://swift-graphql.com/why)
-- This makes it easy to compose selection sets, however, fragments already solve this.
-- [Manual decoding](https://swift-graphql.com/querying#decoding-values).
-
+Configured conformances are emitted verbatim and are not included in collision validation. Codegen neither qualifies generated
+system type references nor validates collisions with Swift standard-library or Foundation types. Callers must avoid those
+collisions with GraphQL aliases or fragment names and qualify configured types and conformances when necessary.
 
 ## Contributing
-Contributions, documentation improvements, bug reports, and feature requests are welcome! Feel free to submit pull requests or open issues in our GitHub repository. We appreciate community involvement, whether it’s clarifying docs, squashing bugs, or proposing new features.
 
-The generator ships a bundled copy of the GraphQL JavaScript reference implementation. After changing `Sources/GraphQLJS` or its dependencies, run `./Scripts/update-graphql-bundle` and commit the updated `Sources/GraphQLCodegen/Resources/graphql.bundle.js`. CI rebuilds the bundle from the frozen pnpm lockfile and verifies that the committed resource is current.
+Contributions, documentation improvements, bug reports, and feature requests are welcome through pull requests and GitHub issues.
 
+The generator ships a bundled copy of the GraphQL JavaScript reference implementation. After changing `Sources/GraphQLJS` or its
+dependencies, run `./Scripts/update-graphql-bundle` and commit the updated
+`Sources/GraphQLCodegen/Resources/graphql.bundle.js`. CI rebuilds the bundle from the frozen pnpm lockfile and verifies that the
+committed resource is current.
 
 ## License
-This project is released under the MIT License.
 
-Thanks for choosing Swift GraphQL Codegen! We hope it helps you deliver type-safe and maintainable GraphQL clients in Swift. If you have any questions or run into issues, please open an issue.
+Swift GraphQL Codegen is available under the [MIT License](LICENSE).

--- a/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
@@ -28,7 +28,7 @@ struct SwiftTypeIdentifier: Hashable {
             guard operationCount == 1 else {
                 throw Codegen.Error(description: """
                 Missing operation name. Operations may only be unnamed if they're the only operation in the document.
-                https://spec.graphql.org/October2021/#sel-FAFPTABABoC6of
+                https://spec.graphql.org/September2025/#sel-DAFRCSBDTAoC6of
                 URL: \(document.url)
                 """)
             }

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -67,7 +67,7 @@ struct DocumentsLoader {
                         This allows reusing fragments declared in other .graphql files.
                         If you think this is the wrong decision, please open an issue on github
                         and explain your use-case.
-                        https://spec.graphql.org/October2021/#sel-IALVDDFDABhCBrE77W
+                        https://spec.graphql.org/September2025/#sel-IALVDDFDABhCBrE77W
                         """)
                     }
                     definitions.append(.fragment(fragment.name.value))

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -68,7 +68,7 @@ struct Schema {
                 throw Codegen.Error(description: """
                 Unexpectedly querying a field \(field.responseKey) directly from a union type \(union.ast.name).
                 Fields may not be queried directly from union types.
-                https://spec.graphql.org/October2021/#sel-EAHdJDBAACCiDzyP
+                https://spec.graphql.org/September2025/#sel-EAHdJCApHCCiDzyP
 
                 Turn on type validation to catch errors like this.
                 """)
@@ -154,7 +154,7 @@ struct Schema {
             throw Codegen.Error(description: """
             Selected a field \(typeRef) whose type is an input object.
             Input objects are not supported as field types
-            https://spec.graphql.org/October2021/#sec-Input-Objects.Result-Coercion
+            https://spec.graphql.org/September2025/#sec-Input-Objects.Result-Coercion
 
             Note: Turning on validation can help find other similar errors
             """)
@@ -219,7 +219,7 @@ struct Schema {
             throw Codegen.Error(description: """
             Fragment was specified on type `\(name)`.
             Fragments must be specified on a valid object, interface or union type.
-            https://spec.graphql.org/October2021/#sel-GAFbdJABeBiC2vU
+            https://spec.graphql.org/September2025/#sel-GAFddJABeBiC2vU
 
             Note: Turning on validation can help find other similar errors
             """)

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -11,7 +11,7 @@ struct LoadedSchema {
 }
 
 // Type names are guaranteed to be unique
-// https://spec.graphql.org/October2021/#sel-FAHTLABDBEmrR
+// https://spec.graphql.org/September2025/#sel-DAHTCKBDLA5BotN
 struct TypeASTCache {
     var scalars: [String: __Schema.__NamedType.Scalar] = [:]
     var objects: [String: __Schema.__NamedType.Object] = [:]

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -36,12 +36,12 @@ struct GraphQLOperationWriter: APIOutput {
         \(accessLevel)protocol GraphQLOperation: Sendable {
 
             /// The optional name of the operation.
-            /// https://spec.graphql.org/October2021/#sel-FAFRDCEAAAAFBBAAD-zM
+            /// https://spec.graphql.org/September2025/#sel-FAFTDCFABAADFCBAAD-zM
             static var operationName: String? { get }
         \(operationSourceRequirements())
 
             /// The parameterized variables to execute the operation with.
-            /// https://spec.graphql.org/October2021/#sec-Language.Variables
+            /// https://spec.graphql.org/September2025/#sec-Language.Variables
             var variables: Variables { get }
 
             /// The operation's variables erased for request encoding.
@@ -92,7 +92,7 @@ struct GraphQLOperationWriter: APIOutput {
 
             /// The executable string operated on by a GraphQL service, containing
             /// an operation definition and zero or more fragment definitions.
-            /// https://spec.graphql.org/October2021/#sec-Document
+            /// https://spec.graphql.org/September2025/#sec-Document
             static var document: String { get }
 
             /// A precomputed, execution-equivalent document with executable descriptions and ignored characters removed.

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -20,7 +20,7 @@ struct SelectionSetResolver {
     let documents: Documents
 
     /// Ensure field ordering matches response ordering by following a similar algorithm to:
-    /// https://spec.graphql.org/October2021/#sec-Field-Collection
+    /// https://spec.graphql.org/September2025/#sec-Field-Collection
     func resolve() throws -> ResolvedSelectionSet {
         try collect(
             selectionSet: selectionSet,


### PR DESCRIPTION
## Summary

- update source documentation and checked-in generated output from the October 2021 GraphQL specification to September 2025
- remap paragraph selection anchors to the equivalent normative text in the September 2025 specification
- streamline the README around current capabilities, platform requirements, setup, and generated output
- fix the license link, installation version, and self-contained codegen example
- remove stale generated examples, manual navigation, volatile competitor comparisons, and outdated size/build metrics

## Why

The package now targets the September 2025 GraphQL specification, but several source and generated documentation links still referenced October 2021. The README had also drifted as generated APIs evolved, leaving broken navigation, an old package version, and examples that no longer matched current output.

## Impact

This is a documentation-only change. It gives users current specification references and a shorter setup path that matches release 0.7.2 and the checked-in Star Wars example.

## Validation

- `swift test` — 57 tests passed
- regenerated the Star Wars example with `swift run StarwarsExample`
- verified every updated GraphQL section and selection anchor against the September 2025 specification
- verified README-local links and the documented release tag
- `git diff --check`
