### PR TITLE
Centralize API source metadata

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/APIOutput.swift
+++ b/Sources/GraphQLCodegen/Output/API/APIOutput.swift
@@ -16,6 +16,18 @@ protocol APIOutput: Sendable {
 }
 
 extension APIOutput {
+    var accessLevel: String {
+        configuration.output.api.accessLevel == .public ? "public " : ""
+    }
+
+    var header: String {
+        configuration.output.api.header.map { "\($0)\n\n" } ?? ""
+    }
+
+    var headerBeforeImports: String {
+        configuration.output.api.header.map { "\($0)\n" } ?? ""
+    }
+
     func write(using fileOutput: FileOutput) throws {
         try source.write(
             to: configuration.output.api.directory.appending(

--- a/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/AnyEncodableWriter.swift
@@ -4,15 +4,6 @@ struct AnyEncodableWriter: APIOutput {
     let relativePath = "AnyEncodable.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "AnyEncodable")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)\(accessLevel)struct AnyEncodable: Encodable, Sendable {

--- a/Sources/GraphQLCodegen/Output/API/GraphQLEnumWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLEnumWriter.swift
@@ -4,15 +4,6 @@ struct GraphQLEnumWriter: APIOutput {
     let relativePath = "GraphQLEnum.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLEnum")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)\(accessLevel)enum GraphQLEnum<T>: Decodable, Hashable, Sendable where T: Hashable & RawRepresentable & Sendable, T.RawValue == String {

--- a/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLErrorWriter.swift
@@ -4,15 +4,6 @@ struct GraphQLErrorWriter: APIOutput {
     let relativePath = "GraphQLError.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLError")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)/// https://spec.graphql.org/September2025/#sec-Errors

--- a/Sources/GraphQLCodegen/Output/API/GraphQLHasDefaultWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLHasDefaultWriter.swift
@@ -4,15 +4,6 @@ struct GraphQLHasDefaultWriter: APIOutput {
     let relativePath = "GraphQLHasDefault.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLHasDefault")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)\(accessLevel)enum GraphQLHasDefault<T>: Encodable, Hashable, Sendable where T: Encodable & Hashable & Sendable {

--- a/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLNullableWriter.swift
@@ -5,15 +5,6 @@ struct GraphQLNullableWriter: APIOutput {
     let relativePath = "GraphQLNullable.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLNullable")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         let indirectCase = requiresIndirectNullable ? "indirect " : ""
         return """

--- a/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/GraphQLResponseWriter.swift
@@ -4,15 +4,6 @@ struct GraphQLResponseWriter: APIOutput {
     let relativePath = "GraphQLResponse.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLResponse")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)\(accessLevel)enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/DefaultEncodersWriter.swift
@@ -13,10 +13,6 @@ struct DefaultEncodersWriter: APIOutput {
         return typeNames
     }
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
     private var automaticPersistedOperationHashSource: String {
         """
         private func persistedOperationHash(_ document: String) -> String {
@@ -33,11 +29,6 @@ struct DefaultEncodersWriter: APIOutput {
             }
         }
         """
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n"
     }
 
     private var includeSubscriptionSupport: Bool {
@@ -57,7 +48,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func getWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
+        \(headerBeforeImports)import CryptoKit
         import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
@@ -101,7 +92,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func getWithRegisteredPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -135,7 +126,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func getWithNoPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -176,7 +167,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func postWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import CryptoKit
+        \(headerBeforeImports)import CryptoKit
         import Foundation
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
@@ -185,7 +176,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func postWithRegisteredPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
@@ -193,7 +184,7 @@ struct DefaultEncodersWriter: APIOutput {
 
     private func postWithNoPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithNoPersistedOperations())
         """

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/EncodersWriter.swift
@@ -16,15 +16,6 @@ struct EncodersWriter: APIOutput {
         return typeNames
     }
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n"
-    }
-
     private var includeSubscriptionSupport: Bool {
         plan.includesSubscriptions
     }
@@ -42,7 +33,7 @@ struct EncodersWriter: APIOutput {
 
     private func getWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
         \(accessLevel)protocol URLQueryEncoder {
@@ -68,7 +59,7 @@ struct EncodersWriter: APIOutput {
 
     private func getWithRegisteredPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
         /// is being used.
@@ -87,7 +78,7 @@ struct EncodersWriter: APIOutput {
 
     private func getWithNoPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
         /// is being used.
@@ -110,7 +101,7 @@ struct EncodersWriter: APIOutput {
 
     private func postWithAutomaticPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
@@ -118,7 +109,7 @@ struct EncodersWriter: APIOutput {
 
     private func postWithRegisteredPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
@@ -126,7 +117,7 @@ struct EncodersWriter: APIOutput {
 
     private func postWithNoPersistedOperations() -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithNoPersistedOperations())
         """

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLOperationWriter.swift
@@ -21,15 +21,6 @@ struct GraphQLOperationWriter: APIOutput {
         return typeNames
     }
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)/// A `GraphQLOperation` represents a GraphQL document containing a single operation.

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/GraphQLRequestWriter.swift
@@ -13,15 +13,6 @@ struct GraphQLRequestWriter: APIOutput {
         return typeNames
     }
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n"
-    }
-
     private var includeSubscriptionSupport: Bool {
         plan.includesSubscriptions
     }
@@ -521,7 +512,7 @@ struct GraphQLRequestWriter: APIOutput {
         subscriptionSupport: String
     ) -> String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         \(persistedOperationRetryDeclaration())
         \(requestDeclaration())

--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -7,22 +7,13 @@ struct URLSessionWriter: APIOutput {
 
     let topLevelTypeNames: [SwiftTypeIdentifier] = []
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n"
-    }
-
     private var includeSubscriptionSupport: Bool {
         hasSubscription && configuration.output.api.HTTPSupport?.subscriptionSupport == true
     }
 
     var source: String {
         """
-        \(header)import Foundation
+        \(headerBeforeImports)import Foundation
 
         /// Defaults conform to https://graphql.github.io/graphql-over-http/draft/
         extension URLSession {

--- a/Sources/GraphQLCodegen/Output/API/JSONValueWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/JSONValueWriter.swift
@@ -4,15 +4,6 @@ struct JSONValueWriter: APIOutput {
     let relativePath = "JSONValue.swift"
     let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "JSONValue")]
 
-    private var accessLevel: String {
-        configuration.output.api.accessLevel == .public ? "public " : ""
-    }
-
-    private var header: String {
-        guard let header = configuration.output.api.header else { return "" }
-        return "\(header)\n\n"
-    }
-
     var source: String {
         """
         \(header)\(accessLevel)enum JSONValue: Decodable, Sendable {


### PR DESCRIPTION
## What changed
- Added shared access-level and header formatting to APIOutput.
- Removed duplicated metadata derivation from all twelve API writers.
- Preserved the distinct spacing used before declarations and imports.

## Why
Every writer interpreted the same API configuration independently, creating a broad consistency surface for a single semantic rule.

## Impact
Generated source is byte-for-byte unchanged, while the writer implementations contain substantially less repeated code.

## Validation
- `swift test` (63 tests, including full generated-output comparison)
- `swiftlint lint --strict`
