### PR TITLE
Move document paths into scanner

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -17,12 +17,12 @@ struct DocumentsLoader {
     let graphQLJS: GraphQLJS
 
     func load() throws -> Documents {
-        let documentFileURLs = try DocumentScanner(
+        let documentFiles = try DocumentScanner(
             directories: configuration.input.documentDirectories
         ).scan()
         var fragmentLookup: [String: Document.Fragment] = [:]
         let parsedDocuments = try parse(
-            documentFileURLs,
+            documentFiles,
             fragmentLookup: &fragmentLookup
         )
         var manifestOperations: [PersistedOperationManifest.Operation] = []
@@ -49,12 +49,13 @@ struct DocumentsLoader {
     }
 
     private func parse(
-        _ documentURLs: [URL],
+        _ documentFiles: [DocumentScanner.DocumentFile],
         fragmentLookup: inout [String: Document.Fragment]
     ) throws -> [ParsedDocument] {
         var documents: [ParsedDocument] = []
-        documents.reserveCapacity(documentURLs.count)
-        for documentURL in documentURLs {
+        documents.reserveCapacity(documentFiles.count)
+        for documentFile in documentFiles {
+            let documentURL = documentFile.url
             let documentText = try String(contentsOf: documentURL, encoding: .utf8)
             let ast = try DocumentASTParser(
                 graphQLJS: graphQLJS,
@@ -98,7 +99,7 @@ struct DocumentsLoader {
             documents.append(
                 ParsedDocument(
                     definitions: definitions,
-                    relativePath: try relativePath(for: documentURL),
+                    relativePath: documentFile.relativePath,
                     url: documentURL
                 )
             )
@@ -164,18 +165,6 @@ struct DocumentsLoader {
             )
         }
         return updatedDocuments
-    }
-
-    private func relativePath(for documentURL: URL) throws -> String {
-        let documentComponents = documentURL.standardizedFileURL.pathComponents
-        let sourceRoot = configuration.input.documentDirectories
-            .map(\.standardizedFileURL.pathComponents)
-            .filter { documentComponents.starts(with: $0) }
-            .max { $0.count < $1.count }
-        guard let sourceRoot else {
-            throw Codegen.Error(description: "Document is outside the configured input directories: \(documentURL)")
-        }
-        return documentComponents.dropFirst(sourceRoot.count).joined(separator: "/")
     }
 
     private func hash(_ sourceText: String) -> String {

--- a/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
@@ -1,18 +1,37 @@
 import Foundation
 
 struct DocumentScanner {
+    struct DocumentFile {
+        let relativePath: String
+        let url: URL
+    }
+
     enum DocumentFileFinderError: Error {
         case failedToEnumerateDirectory(URL)
     }
 
     let directories: [URL]
 
-    func scan() throws -> [URL] {
-        let documentFileURLs = try directories
-            .sorted { $0.path < $1.path }
-            .map(scanDirectory)
-            .flatMap { $0 }
-        return Set(documentFileURLs).sorted { $0.path < $1.path }
+    func scan() throws -> [DocumentFile] {
+        var documentByURL: [URL: (document: DocumentFile, sourceRootDepth: Int)] = [:]
+        for directory in directories.sorted(by: { $0.path < $1.path }) {
+            let sourceRoot = directory.standardizedFileURL.pathComponents
+            for url in try scanDirectory(directory) {
+                let standardizedURL = url.standardizedFileURL
+                let document = DocumentFile(
+                    relativePath: standardizedURL.pathComponents
+                        .dropFirst(sourceRoot.count)
+                        .joined(separator: "/"),
+                    url: url
+                )
+                if documentByURL[standardizedURL]?.sourceRootDepth ?? -1 < sourceRoot.count {
+                    documentByURL[standardizedURL] = (document, sourceRoot.count)
+                }
+            }
+        }
+        return documentByURL
+            .sorted { $0.key.path < $1.key.path }
+            .map(\.value.document)
     }
 
     private func scanDirectory(_ directory: URL) throws -> [URL] {

--- a/Tests/GraphQLCodegenTests/Tests/Integration/AnonymousOperationTypeNameTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/AnonymousOperationTypeNameTests.swift
@@ -40,6 +40,34 @@ struct AnonymousOperationTypeNameTests {
         }
     }
 
+    @Test
+    func usesNearestConfiguredDocumentRootForOutputPath() async throws {
+        let fileName = "current-user.graphql"
+        let fixture = try makeFixture(documentFileName: fileName)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var configuration = configuration(for: fixture)
+        configuration.input.documentDirectories = [
+            fixture.operations.deletingLastPathComponent(),
+            fixture.operations,
+        ]
+
+        try await Codegen(configuration).run()
+
+        let outputDirectory = fixture.output.appending(path: "Operations", directoryHint: .isDirectory)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: outputDirectory.appending(path: fileName + ".swift").path(percentEncoded: false)
+            )
+        )
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: outputDirectory
+                    .appending(path: "Operations/" + fileName + ".swift")
+                    .path(percentEncoded: false)
+            )
+        )
+    }
+
     private func configuration(for fixture: AnonymousOperationFixture) -> Configuration {
         .configuration(
             input: .input(


### PR DESCRIPTION
## What changed
- Made DocumentScanner return each document URL with its output-relative path.
- Preserved nearest-root precedence when configured input directories overlap.
- Removed DocumentsLoader second-pass root lookup and unreachable fallback.
- Added integration coverage for overlapping document roots.

## Why
Only the scanner knows the source root that discovered a document. Re-deriving ownership later duplicated work and defended against a state the call path could not produce.

## Impact
Document output paths remain unchanged, including nested-root behavior.

## Validation
- `swift test` (64 tests)
- `swiftlint lint --strict`
