### PR TITLE
Model persisted manifest output

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -3,6 +3,7 @@ import Foundation
 struct Documents {
     let documents: [Document]
     let fragmentLookup: [String: Document.Fragment]
+    let persistedOperationManifest: PersistedOperationManifestOutput?
 
     func fragment(_ name: String) throws -> Document.Fragment {
         guard let fragment = fragmentLookup[name] else {
@@ -14,6 +15,11 @@ struct Documents {
         }
         return fragment
     }
+}
+
+struct PersistedOperationManifestOutput {
+    let operations: [PersistedOperationManifest.Operation]
+    let url: URL
 }
 
 struct Document: Sendable {

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -25,9 +25,26 @@ struct DocumentsLoader {
             documentFileURLs,
             fragmentLookup: &fragmentLookup
         )
+        var manifestOperations: [PersistedOperationManifest.Operation] = []
+        let preparedDocuments = try prepare(
+            parsedDocuments,
+            fragmentLookup: fragmentLookup,
+            manifestOperations: &manifestOperations
+        )
+        let persistedOperationManifest: PersistedOperationManifestOutput? =
+            switch configuration.output.documents.operations.persistedOperations {
+            case .registered(let manifestURL):
+                PersistedOperationManifestOutput(
+                    operations: manifestOperations,
+                    url: manifestURL
+                )
+            case .automatic, .none:
+                nil
+            }
         return Documents(
-            documents: try prepare(parsedDocuments, fragmentLookup: fragmentLookup),
-            fragmentLookup: fragmentLookup
+            documents: preparedDocuments,
+            fragmentLookup: fragmentLookup,
+            persistedOperationManifest: persistedOperationManifest
         )
     }
 
@@ -91,7 +108,8 @@ struct DocumentsLoader {
 
     private func prepare(
         _ documents: [ParsedDocument],
-        fragmentLookup: [String: Document.Fragment]
+        fragmentLookup: [String: Document.Fragment],
+        manifestOperations: inout [PersistedOperationManifest.Operation]
     ) throws -> [Document] {
         var updatedDocuments: [Document] = []
         updatedDocuments.reserveCapacity(documents.count)
@@ -107,13 +125,22 @@ struct DocumentsLoader {
                         operationSourceText: operationSourceText
                     ).expandSourceText { $0.sourceText }
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
-                    let persistence: Document.Operation.Persistence =
-                        switch configuration.output.documents.operations.persistedOperations {
-                        case .registered:
-                            .registered(hash: hash(canonicalText))
-                        case .automatic, .none:
-                            .standard
-                        }
+                    let persistence: Document.Operation.Persistence
+                    switch configuration.output.documents.operations.persistedOperations {
+                    case .registered:
+                        let hash = hash(canonicalText)
+                        manifestOperations.append(
+                            PersistedOperationManifest.Operation(
+                                id: hash,
+                                body: canonicalText,
+                                name: operationAST.name?.value,
+                                type: operationAST.operation.rawValue
+                            )
+                        )
+                        persistence = .registered(hash: hash)
+                    case .automatic, .none:
+                        persistence = .standard
+                    }
                     updatedDefinitions.append(
                         .operation(
                             Document.Operation(

--- a/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
+++ b/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
@@ -28,12 +28,11 @@ struct CodegenOutputPlan {
             schema: schema,
             resolvedDocuments: resolvedDocuments
         )
-        let manifestWriter: PersistedOperationManifestWriter? =
-            switch configuration.output.documents.operations.persistedOperations {
-        case .registered(let manifestURL):
-            PersistedOperationManifestWriter(manifestURL: manifestURL, documents: documents)
-        case .automatic, .none:
-            nil
+        let manifestWriter = documents.persistedOperationManifest.map { output in
+            PersistedOperationManifestWriter(
+                manifestURL: output.url,
+                operations: output.operations
+            )
         }
         let topLevelDeclarations = apiWriter.topLevelDeclarations +
             documentsWriter.topLevelDeclarations + schemaWriter.topLevelDeclarations

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifestWriter.swift
@@ -2,31 +2,9 @@ import Foundation
 
 struct PersistedOperationManifestWriter {
     let manifestURL: URL
-    let documents: Documents
+    let operations: [PersistedOperationManifest.Operation]
 
     func write(using fileOutput: FileOutput) throws {
-        var operations: [PersistedOperationManifest.Operation] = []
-        for document in documents.documents {
-            for definition in document.definitions {
-                switch definition {
-                case .operation(let operation):
-                    switch operation.persistence {
-                    case .registered(let hash):
-                        operations.append(
-                            PersistedOperationManifest.Operation(
-                                id: hash,
-                                body: operation.canonicalText,
-                                name: operation.ast.name?.value,
-                                type: operation.ast.operation.rawValue
-                            )
-                        )
-                    case .standard:
-                        preconditionFailure("A registered operation manifest requires registered operations")
-                    }
-                case .fragment: break
-                }
-            }
-        }
         let manifest = PersistedOperationManifest(operations: operations)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]


### PR DESCRIPTION
## What changed
- Build registered manifest entries while documents are prepared.
- Carry an optional, concrete manifest output in `Documents`.
- Give `PersistedOperationManifestWriter` only the URL and operations it needs.

## Why
The writer previously rediscovered registered operations by traversing every document and defended against standard operations with an unreachable `preconditionFailure`. Modeling the manifest output at the point persistence is resolved removes both the repeated traversal and the impossible fallback.

## Validation
- `swift test` (63 tests passed)
- `mise run lint` (0 violations)
