### PR TITLE
Reduce mise CI cache size

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,6 +16,8 @@ jobs:
   build-lint-test:
     runs-on: macos-26
     timeout-minutes: 30
+    env:
+      MISE_ENABLE_TOOLS: periphery,swiftlint
 
     steps:
       - uses: actions/checkout@v7
@@ -42,6 +44,9 @@ jobs:
           fi
 
       - uses: jdx/mise-action@v4
+        with:
+          add_shims_to_path: false
+          cache_key_prefix: mise-ci-v1
 
       - uses: actions/cache@v6
         with:


### PR DESCRIPTION
## Summary

- limit CI-managed mise tools to Periphery and SwiftLint
- keep Swift on the Xcode toolchain already provided by the macOS 26 runner
- use a new CI-specific mise cache prefix and avoid adding mise shims to `PATH`

## Why

The mise action was caching the standalone Swift 6.3.3 toolchain, producing a roughly 1.3 GB cache. Restoring and unpacking that cache took substantially longer than installing or activating the lint tools.

The macOS 26 runner already provides Swift 6.3.3 through Xcode 26.6, so caching a second Swift toolchain adds CI time and cache storage without changing the compiler used by the project.

## Impact

CI should restore a much smaller mise cache containing only Periphery and SwiftLint. Local development remains unchanged because `mise.toml` still pins Swift 6.3.3 outside CI.

## Validation

- `git diff --check`
- parsed `.github/workflows/CI.yml` with Ruby YAML
- verified `MISE_ENABLE_TOOLS=periphery,swiftlint mise ls` resolves only Periphery 3.8.0 and SwiftLint 0.65.0
- verified the resulting mise environment does not add a managed Swift toolchain to `PATH`
