### PR TITLE
Migrate pnpm build approval configuration

### DIFF
--- a/Sources/GraphQLJS/package.json
+++ b/Sources/GraphQLJS/package.json
@@ -2,11 +2,6 @@
   "name": "GraphQLJS",
   "version": "1.0.0",
   "packageManager": "pnpm@10.34.5",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
-  },
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/Sources/GraphQLJS/pnpm-workspace.yaml
+++ b/Sources/GraphQLJS/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

- Move the esbuild lifecycle-script approval from package.json to pnpm-workspace.yaml.
- Replace the removed onlyBuiltDependencies setting with allowBuilds.

## Why

pnpm 11 no longer reads the pnpm field in package.json and removes onlyBuiltDependencies. Renovate PR #84 consequently fails during the frozen install with ERR_PNPM_IGNORED_BUILDS for esbuild.

allowBuilds is already supported by the currently pinned pnpm 10.34.5. Landing this migration first keeps the current build working and allows the pnpm 11 upgrade to pass after rebasing.

## Validation

- Ran the GraphQL bundle update with pnpm 10.34.5.
- Ran a forced frozen install and bundle generation with pnpm 11.20.0.
- Confirmed the esbuild postinstall completed under pnpm 11.
- Confirmed graphql.bundle.js remained unchanged.