### PR TITLE
Treat Swift warnings as errors

### DIFF
--- a/Examples/StarwarsExample/Package.swift
+++ b/Examples/StarwarsExample/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version: 6.3
 import PackageDescription
 
+let warningsAsErrors: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+]
+
 let package = Package(
     name: "StarwarsExample",
     platforms: [
@@ -20,7 +24,8 @@ let package = Package(
                 "Operations/HeroQuery.graphql",
                 "Operations/SetFavoriteEpisodeMutation.graphql",
                 "schema.sdl",
-            ]
+            ],
+            swiftSettings: warningsAsErrors
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,10 @@
 // swift-tools-version: 6.3
 import PackageDescription
 
+let warningsAsErrors: [SwiftSetting] = [
+    .treatAllWarnings(as: .error),
+]
+
 let package = Package(
     name: "swift-graphql-codegen",
     platforms: [
@@ -20,7 +24,8 @@ let package = Package(
             ],
             resources: [
                 .copy("Resources/graphql.bundle.js"),
-            ]
+            ],
+            swiftSettings: warningsAsErrors
         ),
         .target(
             name: "StarwarsExample",
@@ -31,7 +36,8 @@ let package = Package(
                 "Operations/HeroQuery.graphql",
                 "Operations/SetFavoriteEpisodeMutation.graphql",
                 "schema.sdl",
-            ]
+            ],
+            swiftSettings: warningsAsErrors
         ),
         .testTarget(
             name: "GraphQLCodegenTests",
@@ -43,7 +49,8 @@ let package = Package(
                 "Fixtures/Defaults/Definitions",
                 "Fixtures/OneOf/Definitions",
                 "GraphQLCodegen.xctestplan",
-            ]
+            ],
+            swiftSettings: warningsAsErrors
         ),
     ]
 )

--- a/Tests/GraphQLCodegenTests/Tests/Integration/OutputTransactionTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/Integration/OutputTransactionTests.swift
@@ -8,7 +8,7 @@ struct OutputTransactionTests {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
-        let configuration = try configuration(for: fixture)
+        let configuration = configuration(for: fixture)
         try await Codegen(configuration).run()
 
         let documentsDirectory = fixture.output.appending(
@@ -63,7 +63,7 @@ struct OutputTransactionTests {
         let idSource = "struct ID: Codable, Sendable { let rawValue: String }\n"
         try Data(idSource.utf8).write(to: idScalarURL)
 
-        try await Codegen(try configuration(for: fixture)).run()
+        try await Codegen(configuration(for: fixture)).run()
 
         #expect(try String(contentsOf: customScalarURL, encoding: .utf8) == customSource)
         #expect(try String(contentsOf: idScalarURL, encoding: .utf8) == idSource)
@@ -85,7 +85,7 @@ struct OutputTransactionTests {
 
         let blockingFile = fixture.root.appending(path: "0-blocker", directoryHint: .notDirectory)
         try Data().write(to: blockingFile)
-        let configuration = try configuration(
+        let configuration = configuration(
             for: fixture,
             schema: .schema(
                 directory: fixture.output.appending(path: "Schema", directoryHint: .isDirectory),
@@ -118,8 +118,8 @@ struct OutputTransactionTests {
         for fixture: Fixture,
         schema: Configuration.Output.Schema? = nil,
         apiDirectory: URL? = nil
-    ) throws -> Configuration {
-        try .configuration(
+    ) -> Configuration {
+        .configuration(
             input: .input(
                 schemaSource: .SDLSchemaFile(fixture.schema),
                 documentDirectories: [fixture.operations]


### PR DESCRIPTION
## Summary

- Treat Swift compiler warnings as errors for the library, tests, and root Starwars target.
- Apply the same policy to the standalone Starwars example package.
- Remove unnecessary `try` expressions exposed by the stricter build.

## Why

Warnings in library code, generated fixtures, and the example application should fail CI while they are introduced instead of accumulating unnoticed.

## Validation

- `swift build --build-tests`
- `swift test --skip-build` — 64 tests passed
- `swift build --package-path Examples/StarwarsExample`
- `mise run lint`
- `mise run periphery`
- `git diff --check`
