### PR TITLE
Avoid deprecated backing storage collisions

### DIFF
--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -14,6 +14,7 @@ extension SwiftStructBuilder {
         configuration: Configuration
     ) throws {
         let typePlan = SelectionSetTypePlan(selectionSet: selectionSet, conformances: conformances)
+        reservePropertyNames(selectionSet.map { responseKey, _ in responseKey })
 
         var hasNonnilTypenameField = false
         for (responseKey, selection) in selectionSet {

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
@@ -37,6 +37,7 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
     }
 
     private var builder: SwiftTypeBuilder
+    private var reservedPropertyNames: Set<String> = []
     private var storedProperties: [StoredProperty] = []
     private let usesCodingKeys: Bool
 
@@ -56,6 +57,10 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
         usesCodingKeys = conformances.contains { conformance in
             SwiftConformanceName(source: conformance).usesCodingKeys
         }
+    }
+
+    mutating func reservePropertyNames(_ names: [String]) {
+        reservedPropertyNames.formUnion(names)
     }
 
     func build(configuration: Configuration) -> [String] {
@@ -90,11 +95,11 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
             case .assigned, .unassigned: immutable ? "let" : "var"
             }
         let safeName = identifier(name)
-        let backingName = "__\(name)"
         let usesBackingStorage = switch value {
         case .unassigned: deprecation != nil
         case .assigned, .computed: false
         }
+        let backingName = usesBackingStorage ? backingStorageName(for: name) : safeName
         if isStatic == false {
             switch value {
             case .assigned, .unassigned:
@@ -180,6 +185,15 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
 
     func storageName(forProperty name: String) -> String {
         storedProperties.first { $0.name == name }?.storageName ?? identifier(name)
+    }
+
+    private func backingStorageName(for propertyName: String) -> String {
+        var name = "__\(propertyName)"
+        let storedPropertyNames = Set(storedProperties.map(\.storageName))
+        while reservedPropertyNames.contains(name) || storedPropertyNames.contains(name) {
+            name = "_\(name)"
+        }
+        return name
     }
 
     mutating func addNestedType(_ type: SwiftTypeBuildable) {

--- a/Tests/GraphQLCodegenTests/Tests/DeprecationSupportTests.swift
+++ b/Tests/GraphQLCodegenTests/Tests/DeprecationSupportTests.swift
@@ -205,6 +205,46 @@ struct DeprecationSupportTests {
         #expect(generated.contains("__oldField = try container.decode(String?.self, forKey: .oldField)"))
     }
 
+    @Test
+    func avoidsDeprecatedBackingStorageCollisionsWithResponseKeys() async throws {
+        let fixture = try makeFixture(
+            document: """
+            query Search {
+              foo: oldField
+              __foo: search
+              ...SearchFragment
+            }
+
+            fragment SearchFragment on Query {
+              search
+            }
+            """
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+
+        try await Codegen(
+            makeConfiguration(
+                schemaSource: .SDLSchemaFile(fixture.schemaURL),
+                deprecationPolicy: .include,
+                fixture: fixture
+            )
+        ).run()
+
+        let generated = try String(
+            contentsOf: fixture.operationsDirectory.appending(
+                path: "Search.graphql.swift",
+                directoryHint: .notDirectory
+            ),
+            encoding: .utf8
+        )
+        #expect(generated.contains("private let ___foo: String?"))
+        #expect(generated.contains("var foo: String? { ___foo }"))
+        #expect(generated.contains("let __foo: String"))
+        #expect(generated.contains("case ___foo = \"foo\""))
+        #expect(generated.contains("case __foo"))
+        #expect(generated.contains("___foo = try container.decode(String?.self, forKey: .foo)"))
+    }
+
     private func diagnostics(
         in fixture: Fixture,
         policy: Configuration.Input.DeprecationPolicy


### PR DESCRIPTION
## Summary

- reserve GraphQL response keys before allocating backing storage for deprecated response properties
- add leading underscores until the private storage name is unique in its generated Swift struct
- add regression coverage for a deprecated `foo` response alongside a valid `__foo` alias, including custom decoding

## Why

Deprecated response properties use private backing storage so generated custom decoders do not trigger deprecation warnings. The previous fixed `__<responseKey>` name could collide with another valid GraphQL response alias, producing duplicate Swift properties and duplicate `CodingKeys` cases.

## Impact

Valid operations with these aliases now generate compilable, collision-free Swift. Existing generated names remain unchanged when there is no collision.

## Validation

- `swift test` — 72 tests in 15 suites
- `mise run lint` — zero violations
- `mise run periphery` — no unused code
- `git diff --check`
