### PR TITLE
Handle GraphQL HTTP error responses correctly

### DIFF
--- a/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/API/HTTPSupport/URLSessionWriter.swift
@@ -17,8 +17,9 @@ struct URLSessionWriter: APIOutput {
 
         /// Defaults conform to https://graphql.github.io/graphql-over-http/draft/
         extension URLSession {
-            \(accessLevel)struct HTTPError: Error {
-                \(accessLevel)let response: HTTPURLResponse
+            \(accessLevel)enum HTTPError: Error {
+                case invalidType(URLResponse)
+                case badResponse(HTTPURLResponse, Data?)
             }
 
             /// Executes a single-response GraphQL operation.
@@ -30,8 +31,16 @@ struct URLSessionWriter: APIOutput {
                 decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
                 let (data, response) = try await data(for: request.urlRequest)
-                if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-                    throw HTTPError(response: httpResponse)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw HTTPError.invalidType(response)
+                }
+                guard
+                    (200..<300).contains(httpResponse.statusCode) ||
+                    httpResponse.mimeType?.caseInsensitiveCompare(
+                        \"application/graphql-response+json\"
+                    ) == .orderedSame
+                else {
+                    throw HTTPError.badResponse(httpResponse, data)
                 }
                 switch try decoder(data) {
                 case .executionResult(let executionResult): return executionResult
@@ -112,8 +121,11 @@ struct URLSessionWriter: APIOutput {
                     throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
                 }
                 let (asyncBytes, response) = try await bytes(for: request.urlRequest)
-                if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-                    throw HTTPError(response: httpResponse)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw HTTPError.invalidType(response)
+                }
+                guard (200..<300).contains(httpResponse.statusCode) else {
+                    throw HTTPError.badResponse(httpResponse, nil)
                 }
                 guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
                     throw SubscriptionError.invalidContentType(response.mimeType)

--- a/Tests/Fixtures/Generated/API/HTTPSupport/URLSession+GraphQL.swift
+++ b/Tests/Fixtures/Generated/API/HTTPSupport/URLSession+GraphQL.swift
@@ -3,8 +3,9 @@ import Foundation
 
 /// Defaults conform to https://graphql.github.io/graphql-over-http/draft/
 extension URLSession {
-    struct HTTPError: Error {
-        let response: HTTPURLResponse
+    enum HTTPError: Error {
+        case invalidType(URLResponse)
+        case badResponse(HTTPURLResponse, Data?)
     }
 
     /// Executes a single-response GraphQL operation.
@@ -16,8 +17,16 @@ extension URLSession {
         decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
-        if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-            throw HTTPError(response: httpResponse)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPError.invalidType(response)
+        }
+        guard
+            (200..<300).contains(httpResponse.statusCode) ||
+            httpResponse.mimeType?.caseInsensitiveCompare(
+                "application/graphql-response+json"
+            ) == .orderedSame
+        else {
+            throw HTTPError.badResponse(httpResponse, data)
         }
         switch try decoder(data) {
         case .executionResult(let executionResult): return executionResult
@@ -81,8 +90,11 @@ extension URLSession {
             throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
         }
         let (asyncBytes, response) = try await bytes(for: request.urlRequest)
-        if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-            throw HTTPError(response: httpResponse)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPError.invalidType(response)
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw HTTPError.badResponse(httpResponse, nil)
         }
         guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
             throw SubscriptionError.invalidContentType(response.mimeType)


### PR DESCRIPTION
## Summary
- Decode `application/graphql-response+json` bodies even when the HTTP status is outside `200..<300`.
- Share `HTTPError` cases between single-response requests and subscriptions while retaining buffered response data when available.
- Update the generated `URLSession` fixture to match the writer output.

## Validation
- `git diff --check`
- Builds and tests not run.