### PR TITLE
Hash registered persisted operations at request time

### DIFF
--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Operations.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Operations.swift
@@ -14,8 +14,6 @@ extension Configuration.Output.Documents {
         ///   edits change different lines of the document.
         ///   - conformances: A list of protocols each generated operation will conform to.
         ///   - variables: Options controlling generated code for the variables struct.
-        ///   - persistedOperations: Controls whether operations support persisted operations. Pass nil to remove
-        ///   support for persisted operations.
         ///   - responseData: Options controlling generated code for the response "Data" struct.
         /// - Returns: A new `Operations` instance to be passed to the `Documents.documents` factory function.
         public static func operations(
@@ -24,7 +22,6 @@ extension Configuration.Output.Documents {
             minifyDocument: Bool = true,
             conformances: [String] = [],
             variables: Variables = .variables(),
-            persistedOperations: PersistedOperations? = .automatic,
             responseData: ResponseData = .responseData()
         ) -> Operations {
             Operations(
@@ -33,7 +30,6 @@ extension Configuration.Output.Documents {
                 minifyDocument: minifyDocument,
                 conformances: conformances,
                 variables: variables,
-                persistedOperations: persistedOperations,
                 responseData: responseData
             )
         }
@@ -43,7 +39,6 @@ extension Configuration.Output.Documents {
         public var minifyDocument: Bool
         public var conformances: [String]
         public var variables: Variables
-        public var persistedOperations: PersistedOperations?
         public var responseData: ResponseData
     }
 }

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.PersistedOperations.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.PersistedOperations.swift
@@ -21,8 +21,13 @@ extension Configuration.Output.Support.HTTPSupport {
         /// This manifest file should be merged into the mapping of hashes to documents stored on the server.
         /// This adds a layer of security by preventing unknown operations from being executed by the server. It also
         /// can improve performance because servers no longer need to validate operations at request time.
+        /// Set `allowUnregisteredOperations` to `true` to expose a runtime option for sending the full document
+        /// instead of its registered hash, which is useful when developing against an unregistered server.
         /// To learn more about automatic persisted operations:
         /// https://the-guild.dev/graphql/yoga-server/docs/features/persisted-operations
-        case registered(manifestJSONFileOutput: URL)
+        case registered(
+            manifestJSONFileOutput: URL,
+            allowUnregisteredOperations: Bool = false
+        )
     }
 }

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.PersistedOperations.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.PersistedOperations.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Configuration.Output.Documents.Operations {
+extension Configuration.Output.Support.HTTPSupport {
     /// Defines the different types of persisted operations.
     public enum PersistedOperations: Sendable {
         /// When `automatic` persisted operations is enabled, a hash of the GraphQL document

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.swift
@@ -5,7 +5,7 @@ extension Configuration.Output.Support {
     /// https://graphql.github.io/graphql-over-http/draft/#sec-GraphQL-over-HTTP
     ///
     /// Codegen will use options from `Configuration` to craft Networking APIs specifically to your
-    /// use case. For example, if `Operations.persistedOperations` is `nil` the generated
+    /// use case. For example, if `persistedOperations` is `nil` the generated
     /// APIs for creating a GraphQL request will not include those options.
     public struct HTTPSupport: Sendable {
         /// Call this function to create a new `HTTPSupport` instance.
@@ -13,6 +13,8 @@ extension Configuration.Output.Support {
         /// - Parameters:
         ///   - enableGETQueries: Pass `true` to enable making `query` operation requests using the HTTP GET
         ///   method. Passing `false` will ensure all operation requests are made using the HTTP POST method
+        ///   - persistedOperations: Controls whether generated HTTP requests use automatic or registered persisted
+        ///   operations. Pass `nil` to include the full operation document in every request.
         ///   - subscriptionSupport: Pass `true` to enable support for subscription operations via GraphQL over Server-Sent Events:
         ///   https://github.com/enisdenjo/graphql-sse/blob/master/PROTOCOL.md#distinct-connections-mode. If your
         ///   graphql documents include one or more subscription operations, this will add a `subscribe` function to the generated URLSession
@@ -21,15 +23,18 @@ extension Configuration.Output.Support {
         /// - Returns: A new `HTTPSupport` instance to be passed to the `Support.support` factory function.
         public static func httpSupport(
             enableGETQueries: Bool = false,
+            persistedOperations: PersistedOperations? = .automatic,
             subscriptionSupport: Bool = false
         ) -> HTTPSupport {
             HTTPSupport(
                 enableGETQueries: enableGETQueries,
+                persistedOperations: persistedOperations,
                 subscriptionSupport: subscriptionSupport
             )
         }
 
         public var enableGETQueries: Bool
+        public var persistedOperations: PersistedOperations?
         public var subscriptionSupport: Bool
     }
 }

--- a/Sources/GraphQLCodegen/Configuration/Configuration.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.swift
@@ -35,7 +35,7 @@ public struct Configuration: Sendable {
             throw Codegen.Error(description: "The indentation space count must not be negative.")
         }
         switch output.support.HTTPSupport?.persistedOperations {
-        case .registered(let manifestJSONFileOutput):
+        case .registered(let manifestJSONFileOutput, _):
             try verifyLocalURL(
                 manifestJSONFileOutput,
                 expectedExtension: ["json"],

--- a/Sources/GraphQLCodegen/Configuration/Configuration.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.swift
@@ -34,7 +34,7 @@ public struct Configuration: Sendable {
         if case .spaces(let count) = output.indentation, count < 0 {
             throw Codegen.Error(description: "The indentation space count must not be negative.")
         }
-        switch output.documents.operations.persistedOperations {
+        switch output.support.HTTPSupport?.persistedOperations {
         case .registered(let manifestJSONFileOutput):
             try verifyLocalURL(
                 manifestJSONFileOutput,

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -29,15 +29,9 @@ struct Document: Sendable {
     }
 
     struct Operation: Sendable {
-        enum Persistence: Sendable {
-            case registered(hash: String)
-            case standard
-        }
-
         let ast: GraphQLAST.OperationDefinition
         let canonicalText: String
         let documentText: String
-        let persistence: Persistence
     }
 
     struct Fragment {

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -40,7 +40,7 @@ struct DocumentsLoader {
         )
         let persistedOperationManifest: PersistedOperationManifestOutput? =
             switch configuration.output.support.HTTPSupport?.persistedOperations {
-            case .registered(let manifestURL):
+            case .registered(let manifestURL, _):
                 PersistedOperationManifestOutput(
                     operations: manifestOperations,
                     url: manifestURL

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -39,7 +39,7 @@ struct DocumentsLoader {
             manifestOperations: &manifestOperations
         )
         let persistedOperationManifest: PersistedOperationManifestOutput? =
-            switch configuration.output.documents.operations.persistedOperations {
+            switch configuration.output.support.HTTPSupport?.persistedOperations {
             case .registered(let manifestURL):
                 PersistedOperationManifestOutput(
                     operations: manifestOperations,
@@ -134,29 +134,25 @@ struct DocumentsLoader {
                         operationSourceText: operationSourceText
                     ).expandSourceText { $0.sourceText }
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
-                    let persistence: Document.Operation.Persistence
-                    switch configuration.output.documents.operations.persistedOperations {
-                    case .registered:
-                        let hash = hash(canonicalText)
+                    if case .registered = configuration.output.support.HTTPSupport?.persistedOperations {
+                        let documentText = configuration.output.documents.operations.minifyDocument
+                            ? canonicalText
+                            : expandedText
                         manifestOperations.append(
                             PersistedOperationManifest.Operation(
-                                id: hash,
-                                body: canonicalText,
+                                id: hash(documentText),
+                                body: documentText,
                                 name: operationAST.name?.value,
                                 type: operationAST.operation.rawValue
                             )
                         )
-                        persistence = .registered(hash: hash)
-                    case .automatic, .none:
-                        persistence = .standard
                     }
                     updatedDefinitions.append(
                         .operation(
                             Document.Operation(
                                 ast: operationAST,
                                 canonicalText: canonicalText,
-                                documentText: expandedText,
-                                persistence: persistence
+                                documentText: expandedText
                             )
                         )
                     )

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -22,7 +22,6 @@ struct OperationBuilder {
         var operationStruct = makeOperationStruct()
         addOperationNameProperty(to: &operationStruct)
         addDocumentProperty(to: &operationStruct)
-        addHashProperty(to: &operationStruct)
         addVariablesProperty(to: &operationStruct)
         addExtensionsProperty(to: &operationStruct)
         addVariablesStruct(to: &operationStruct)
@@ -69,44 +68,24 @@ struct OperationBuilder {
     }
 
     private func addDocumentProperty(to operationStruct: inout SwiftStructBuilder) {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered: break
-        case .automatic, .none:
-            let documentText =
-                if configuration.output.documents.operations.minifyDocument {
-                    operation.canonicalText
-                } else {
-                    operation.documentText
-                }
-            operationStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "document",
-                value: .assigned(
-                    SwiftSource(value: documentText).multilineStringLiteral,
-                    type: nil
-                )
+        let documentText =
+            if configuration.output.documents.operations.minifyDocument {
+                operation.canonicalText
+            } else {
+                operation.documentText
+            }
+        operationStruct.addProperty(
+            description: nil,
+            deprecation: nil,
+            isPublic: isPublic,
+            isStatic: true,
+            immutable: true,
+            name: "document",
+            value: .assigned(
+                SwiftSource(value: documentText).multilineStringLiteral,
+                type: nil
             )
-        }
-    }
-
-    private func addHashProperty(to operationStruct: inout SwiftStructBuilder) {
-        switch operation.persistence {
-        case .registered(let hash):
-            operationStruct.addProperty(
-                description: nil,
-                deprecation: nil,
-                isPublic: isPublic,
-                isStatic: true,
-                immutable: true,
-                name: "hash",
-                value: .assigned("\"\(hash)\"", type: nil)
-            )
-        case .standard: break
-        }
+        )
     }
 
     private func addExtensionsProperty(to operationStruct: inout SwiftStructBuilder) {

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -35,6 +35,21 @@ struct DefaultEncodersWriter: SupportOutput {
         plan.includesSubscriptions
     }
 
+    private var registeredOperationParameter: String {
+        guard plan.allowsUnregisteredOperations else { return "" }
+        return ",\n        useRegisteredOperation: Bool"
+    }
+
+    private var registeredOperationArgument: String {
+        guard plan.allowsUnregisteredOperations else { return "" }
+        return ", useRegisteredOperation: useRegisteredOperation"
+    }
+
+    private var registeredOperationQueryItem: String {
+        guard plan.allowsUnregisteredOperations else { return "" }
+        return "\n            body.query.map { URLQueryItem(name: \"query\", value: $0) },"
+    }
+
     var source: String {
         switch plan.mode {
         case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
@@ -98,11 +113,13 @@ struct DefaultEncodersWriter: SupportOutput {
         /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
             \(accessLevel)init() {}
-            \(accessLevel)func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem] {
-                let body = Body(operation: query)
+            \(accessLevel)func encode<Query: GraphQLQuery>(
+                query: Query\(registeredOperationParameter)
+            ) throws -> [URLQueryItem] {
+                let body = Body(operation: query\(registeredOperationArgument))
                 let encoder = JSONEncoder()
                 return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
                     try body.variables.map { variables in
                         URLQueryItem(
                             name: "variables",
@@ -243,29 +260,68 @@ struct DefaultEncodersWriter: SupportOutput {
         \(accessLevel)struct JSONBodyEncoder: HTTPBodyEncoder {
             \(accessLevel)init() {}
             \(accessLevel)let contentType = "application/json"
-            \(accessLevel)func encode<Operation: GraphQLOperation>(operation: Operation) throws -> Data {
-                try JSONEncoder().encode(Body(operation: operation))
+            \(accessLevel)func encode<Operation: GraphQLOperation>(
+                operation: Operation\(registeredOperationParameter)
+            ) throws -> Data {
+                try JSONEncoder().encode(
+                    Body(operation: operation\(registeredOperationArgument))
+                )
             }
         }
 
+        \(registeredOperationBody())
+
+        \(persistedOperationHashSource)
+        """
+    }
+
+    private func registeredOperationBody() -> String {
+        guard plan.allowsUnregisteredOperations else {
+            return """
+            private struct Body: Encodable {
+                let operationName: String?
+                let variables: AnyEncodable?
+                let extensions: [String: AnyEncodable]?
+
+                init<Operation: GraphQLOperation>(operation: Operation) {
+                    var extensions = operation.extensions ?? [:]
+                    extensions["persistedQuery"] = AnyEncodable([
+                        "version": AnyEncodable(1),
+                        "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
+                    ])
+                    self.operationName = Operation.operationName
+                    self.variables = operation.requestVariables
+                    self.extensions = extensions
+                }
+            }
+            """
+        }
+        return """
         private struct Body: Encodable {
             let operationName: String?
+            let query: String?
             let variables: AnyEncodable?
             let extensions: [String: AnyEncodable]?
 
-            init<Operation: GraphQLOperation>(operation: Operation) {
-                var extensions = operation.extensions ?? [:]
-                extensions["persistedQuery"] = AnyEncodable([
-                    "version": AnyEncodable(1),
-                    "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
-                ])
+            init<Operation: GraphQLOperation>(
+                operation: Operation,
+                useRegisteredOperation: Bool
+            ) {
+                var extensions = operation.extensions
+                if useRegisteredOperation {
+                    var registeredExtensions = extensions ?? [:]
+                    registeredExtensions["persistedQuery"] = AnyEncodable([
+                        "version": AnyEncodable(1),
+                        "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
+                    ])
+                    extensions = registeredExtensions
+                }
                 self.operationName = Operation.operationName
+                self.query = useRegisteredOperation ? nil : Operation.document
                 self.variables = operation.requestVariables
                 self.extensions = extensions
             }
         }
-
-        \(persistedOperationHashSource)
         """
     }
 
@@ -304,11 +360,13 @@ struct DefaultEncodersWriter: SupportOutput {
         return """
 
 
-            \(accessLevel)func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLQueryItem] {
-                let body = Body(operation: subscription)
+            \(accessLevel)func encode<Subscription: GraphQLSubscription>(
+                subscription: Subscription\(registeredOperationParameter)
+            ) throws -> [URLQueryItem] {
+                let body = Body(operation: subscription\(registeredOperationArgument))
                 let encoder = JSONEncoder()
                 return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
+                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
                     try body.variables.map { variables in
                         URLQueryItem(
                             name: "variables",

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -31,6 +31,25 @@ struct DefaultEncodersWriter: SupportOutput {
         """
     }
 
+    private var urlQueryItemExtensionSource: String {
+        """
+        private extension URLQueryItem {
+            init?<Value: Encodable>(
+                name: String,
+                encoding value: Value?,
+                using encoder: JSONEncoder
+            ) throws {
+                guard let value else { return nil }
+
+                self.init(
+                    name: name,
+                    value: String(decoding: try encoder.encode(value), as: UTF8.self)
+                )
+            }
+        }
+        """
+    }
+
     private var includeSubscriptionSupport: Bool {
         plan.includesSubscriptions
     }
@@ -83,21 +102,13 @@ struct DefaultEncodersWriter: SupportOutput {
                 return [
                     body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try body.variables.map { variables in
-                        URLQueryItem(
-                            name: "variables",
-                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                        )
-                    },
-                    try body.extensions.map { extensions in
-                        URLQueryItem(
-                            name: "extensions",
-                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                        )
-                    }
+                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
                 ].compactMap { $0 }
             }
         }
+
+        \(urlQueryItemExtensionSource)
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
@@ -120,21 +131,13 @@ struct DefaultEncodersWriter: SupportOutput {
                 let encoder = JSONEncoder()
                 return [
                     body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
-                    try body.variables.map { variables in
-                        URLQueryItem(
-                            name: "variables",
-                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                        )
-                    },
-                    try body.extensions.map { extensions in
-                        URLQueryItem(
-                            name: "extensions",
-                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                        )
-                    }
+                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
                 ].compactMap { $0 }
             }\(subscriptionSupportWithRegisteredPersistedOperations())
         }
+
+        \(urlQueryItemExtensionSource)
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
@@ -155,21 +158,13 @@ struct DefaultEncodersWriter: SupportOutput {
                 return [
                     body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try body.variables.map { variables in
-                        URLQueryItem(
-                            name: "variables",
-                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                        )
-                    },
-                    try body.extensions.map { extensions in
-                        URLQueryItem(
-                            name: "extensions",
-                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                        )
-                    }
+                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
                 ].compactMap { $0 }
             }\(subscriptionSupportWithNoPersistedOperations())
         }
+
+        \(urlQueryItemExtensionSource)
 
         \(httpBodyEncoderWithNoPersistedOperations())
         """
@@ -367,18 +362,8 @@ struct DefaultEncodersWriter: SupportOutput {
                 let encoder = JSONEncoder()
                 return [
                     body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
-                    try body.variables.map { variables in
-                        URLQueryItem(
-                            name: "variables",
-                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                        )
-                    },
-                    try body.extensions.map { extensions in
-                        URLQueryItem(
-                            name: "extensions",
-                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                        )
-                    }
+                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
                 ].compactMap { $0 }
             }
         """
@@ -395,18 +380,8 @@ struct DefaultEncodersWriter: SupportOutput {
                 return [
                     body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
                     body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try body.variables.map { variables in
-                        URLQueryItem(
-                            name: "variables",
-                            value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                        )
-                    },
-                    try body.extensions.map { extensions in
-                        URLQueryItem(
-                            name: "extensions",
-                            value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                        )
-                    }
+                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
                 ].compactMap { $0 }
             }
         """

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -13,7 +13,7 @@ struct DefaultEncodersWriter: SupportOutput {
         return typeNames
     }
 
-    private var automaticPersistedOperationHashSource: String {
+    private var persistedOperationHashSource: String {
         """
         private func persistedOperationHash(_ document: String) -> String {
             let digits = Array("0123456789abcdef".utf8)
@@ -90,7 +90,8 @@ struct DefaultEncodersWriter: SupportOutput {
 
     private func getWithRegisteredPersistedOperations() -> String {
         """
-        \(headerBeforeImports)import Foundation
+        \(headerBeforeImports)import CryptoKit
+        import Foundation
 
         /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
         /// using the spec described at:
@@ -168,7 +169,8 @@ struct DefaultEncodersWriter: SupportOutput {
 
     private func postWithRegisteredPersistedOperations() -> String {
         """
-        \(headerBeforeImports)import Foundation
+        \(headerBeforeImports)import CryptoKit
+        import Foundation
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
@@ -229,7 +231,7 @@ struct DefaultEncodersWriter: SupportOutput {
             }
         }
 
-        \(automaticPersistedOperationHashSource)
+        \(persistedOperationHashSource)
         """
     }
 
@@ -255,13 +257,15 @@ struct DefaultEncodersWriter: SupportOutput {
                 var extensions = operation.extensions ?? [:]
                 extensions["persistedQuery"] = AnyEncodable([
                     "version": AnyEncodable(1),
-                    "sha256Hash": AnyEncodable(Operation.hash)
+                    "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
                 ])
                 self.operationName = Operation.operationName
                 self.variables = operation.requestVariables
                 self.extensions = extensions
             }
         }
+
+        \(persistedOperationHashSource)
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -31,20 +31,47 @@ struct DefaultEncodersWriter: SupportOutput {
         """
     }
 
-    private var urlQueryItemExtensionSource: String {
-        """
-        private extension URLQueryItem {
-            init?<Value: Encodable>(
-                name: String,
-                encoding value: Value?,
-                using encoder: JSONEncoder
-            ) throws {
-                guard let value else { return nil }
+    private var urlQueryItemsExtensionSource: String {
+        let optionalQueryItem = """
 
-                self.init(
-                    name: name,
-                    value: String(decoding: try encoder.encode(value), as: UTF8.self)
-                )
+                if let query = body.query {
+                    items.append(URLQueryItem(name: "query", value: query))
+                }
+        """
+        let queryItem: String
+        switch plan.persistence {
+        case .automatic:
+            queryItem = optionalQueryItem
+        case .registered(let allowsUnregisteredOperations):
+            queryItem = allowsUnregisteredOperations ? optionalQueryItem : ""
+        case .none:
+            queryItem = "\n        items.append(URLQueryItem(name: \"query\", value: body.query))"
+        }
+
+        return """
+        private extension [URLQueryItem] {
+            static func from(_ body: Body) throws -> Self {
+                var items = [URLQueryItem]()
+                if let operationName = body.operationName {
+                    items.append(URLQueryItem(name: "operationName", value: operationName))
+                }\(queryItem)
+                if let variables = body.variables {
+                    items.append(
+                        URLQueryItem(
+                            name: "variables",
+                            value: String(decoding: try JSONEncoder().encode(variables), as: UTF8.self)
+                        )
+                    )
+                }
+                if let extensions = body.extensions {
+                    items.append(
+                        URLQueryItem(
+                            name: "extensions",
+                            value: String(decoding: try JSONEncoder().encode(extensions), as: UTF8.self)
+                        )
+                    )
+                }
+                return items
             }
         }
         """
@@ -62,11 +89,6 @@ struct DefaultEncodersWriter: SupportOutput {
     private var registeredOperationArgument: String {
         guard plan.allowsUnregisteredOperations else { return "" }
         return ", useRegisteredOperation: useRegisteredOperation"
-    }
-
-    private var registeredOperationQueryItem: String {
-        guard plan.allowsUnregisteredOperations else { return "" }
-        return "\n            body.query.map { URLQueryItem(name: \"query\", value: $0) },"
     }
 
     var source: String {
@@ -94,21 +116,16 @@ struct DefaultEncodersWriter: SupportOutput {
                 operation: Operation,
                 automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
             ) throws -> [URLQueryItem] {
-                let body = Body(
-                    operation: operation,
-                    automaticPersistedOperationPhase: automaticPersistedOperationPhase
+                try .from(
+                    Body(
+                        operation: operation,
+                        automaticPersistedOperationPhase: automaticPersistedOperationPhase
+                    )
                 )
-                let encoder = JSONEncoder()
-                return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-                    body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-                ].compactMap { $0 }
             }
         }
 
-        \(urlQueryItemExtensionSource)
+        \(urlQueryItemsExtensionSource)
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
         """
@@ -127,17 +144,11 @@ struct DefaultEncodersWriter: SupportOutput {
             \(accessLevel)func encode<Query: GraphQLQuery>(
                 query: Query\(registeredOperationParameter)
             ) throws -> [URLQueryItem] {
-                let body = Body(operation: query\(registeredOperationArgument))
-                let encoder = JSONEncoder()
-                return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
-                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-                ].compactMap { $0 }
+                try .from(Body(operation: query\(registeredOperationArgument)))
             }\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
-        \(urlQueryItemExtensionSource)
+        \(urlQueryItemsExtensionSource)
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
         """
@@ -153,18 +164,11 @@ struct DefaultEncodersWriter: SupportOutput {
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
             \(accessLevel)init() {}
             \(accessLevel)func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem] {
-                let body = Body(operation: query)
-                let encoder = JSONEncoder()
-                return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-                    body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-                ].compactMap { $0 }
+                try .from(Body(operation: query))
             }\(subscriptionSupportWithNoPersistedOperations())
         }
 
-        \(urlQueryItemExtensionSource)
+        \(urlQueryItemsExtensionSource)
 
         \(httpBodyEncoderWithNoPersistedOperations())
         """
@@ -358,13 +362,7 @@ struct DefaultEncodersWriter: SupportOutput {
             \(accessLevel)func encode<Subscription: GraphQLSubscription>(
                 subscription: Subscription\(registeredOperationParameter)
             ) throws -> [URLQueryItem] {
-                let body = Body(operation: subscription\(registeredOperationArgument))
-                let encoder = JSONEncoder()
-                return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },\(registeredOperationQueryItem)
-                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-                ].compactMap { $0 }
+                try .from(Body(operation: subscription\(registeredOperationArgument)))
             }
         """
     }
@@ -375,14 +373,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
 
             \(accessLevel)func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLQueryItem] {
-                let body = Body(operation: subscription)
-                let encoder = JSONEncoder()
-                return [
-                    body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-                    body.query.map { URLQueryItem(name: "query", value: $0) },
-                    try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-                    try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-                ].compactMap { $0 }
+                try .from(Body(operation: subscription))
             }
         """
     }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
@@ -56,7 +56,8 @@ struct EncodersWriter: SupportOutput {
     }
 
     private func getWithRegisteredPersistedOperations() -> String {
-        """
+        guard plan.allowsUnregisteredOperations else { return getWithNoPersistedOperations() }
+        return """
         \(headerBeforeImports)import Foundation
 
         /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
@@ -66,8 +67,12 @@ struct EncodersWriter: SupportOutput {
             /// Encodes a query operation for a GET request.
             /// - Parameters:
             ///   query: The query operation to encode.
+            ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
+            func encode<Query: GraphQLQuery>(
+                query: Query,
+                useRegisteredOperation: Bool
+            ) throws -> [URLQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
@@ -102,7 +107,8 @@ struct EncodersWriter: SupportOutput {
     }
 
     private func postWithRegisteredPersistedOperations() -> String {
-        """
+        guard plan.allowsUnregisteredOperations else { return postWithNoPersistedOperations() }
+        return """
         \(headerBeforeImports)import Foundation
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
@@ -165,8 +171,12 @@ struct EncodersWriter: SupportOutput {
             /// Encodes an operation into body data for a POST request.
             /// - Parameters:
             ///   operation: The GraphQL operation to encode.
+            ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             /// - Returns: The encoded data to be set as the HTTP body of the POST request.
-            func encode<Operation: GraphQLOperation>(operation: Operation) throws -> Data
+            func encode<Operation: GraphQLOperation>(
+                operation: Operation,
+                useRegisteredOperation: Bool
+            ) throws -> Data
         }
         """
     }
@@ -197,8 +207,12 @@ struct EncodersWriter: SupportOutput {
             /// Encodes a subscription operation for a GET request.
             /// - Parameters:
             ///   subscription: The subscription operation to encode.
+            ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLQueryItem]
+            func encode<Subscription: GraphQLSubscription>(
+                subscription: Subscription,
+                useRegisteredOperation: Bool
+            ) throws -> [URLQueryItem]
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
@@ -29,7 +29,7 @@ struct GraphQLOperationWriter: SupportOutput {
             /// The optional name of the operation.
             /// https://spec.graphql.org/September2025/#sel-FAFTDCFABAADFCBAAD-zM
             static var operationName: String? { get }
-        \(operationSourceRequirements())
+        \(operationDocumentRequirements())
 
             /// The parameterized variables to execute the operation with.
             /// https://spec.graphql.org/September2025/#sec-Language.Variables
@@ -63,19 +63,6 @@ struct GraphQLOperationWriter: SupportOutput {
 
         \(accessLevel)protocol GraphQLQuery: GraphQLSingleResponseOperation {}\(mutationProtocol())\(subscriptionProtocol())
         """
-    }
-
-    private func operationSourceRequirements() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
-        case .registered:
-            """
-
-                /// The SHA-256 hash of the registered executable operation document.
-                static var hash: String { get }
-            """
-        case .automatic, .none:
-            operationDocumentRequirements()
-        }
     }
 
     private func operationDocumentRequirements() -> String {

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -191,19 +191,24 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func registeredOperationInitializer() -> String {
-        """
+        guard plan.allowsUnregisteredOperations else { return operationInitializerWithoutPersistence() }
+        return """
 
 
             /// Initializes a POST request for a registered single-response GraphQL operation.
             \(accessLevel)init(
                 operation: Operation,
                 endpoint: URL,
+                useRegisteredOperation: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
                 accept: String = "application/graphql-response+json"
             ) throws where Operation: GraphQLSingleResponseOperation {
                 self.urlRequest = URLRequest(url: endpoint)
                 self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: operation)
+                self.urlRequest.httpBody = try bodyEncoder.encode(
+                    operation: operation,
+                    useRegisteredOperation: useRegisteredOperation
+                )
                 self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
                 self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
                 self.endpoint = endpoint
@@ -361,7 +366,8 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func registeredQuerySupport() -> String {
-        """
+        guard plan.allowsUnregisteredOperations else { return querySupportWithoutPersistence() }
+        return """
 
 
             /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.
@@ -378,6 +384,7 @@ struct GraphQLRequestWriter: SupportOutput {
             /// - Parameters:
             ///   - query: The GraphQLQuery operation the request is for.
             ///   - endpoint: The GraphQL server endpoint.
+            ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
             ///   - accept: The value to use in the "accept" header field. By default this is
             ///   "application/graphql-response+json". This field is required by the spec:
@@ -385,18 +392,27 @@ struct GraphQLRequestWriter: SupportOutput {
             \(accessLevel)init(
                 query: Operation,
                 endpoint: URL,
+                useRegisteredOperation: Bool = true,
                 strategy: QueryStrategy = .GET(),
                 accept: String = "application/graphql-response+json"
             ) throws where Operation: GraphQLQuery {
                 switch strategy {
                 case .GET(let queryEncoder):
-                    let url = endpoint.appending(queryItems: try queryEncoder.encode(query: query))
+                    let url = endpoint.appending(
+                        queryItems: try queryEncoder.encode(
+                            query: query,
+                            useRegisteredOperation: useRegisteredOperation
+                        )
+                    )
                     self.urlRequest = URLRequest(url: url)
                     self.urlRequest.httpMethod = "GET"
                 case .POST(let bodyEncoder):
                     self.urlRequest = URLRequest(url: endpoint)
                     self.urlRequest.httpMethod = "POST"
-                    self.urlRequest.httpBody = try bodyEncoder.encode(operation: query)
+                    self.urlRequest.httpBody = try bodyEncoder.encode(
+                        operation: query,
+                        useRegisteredOperation: useRegisteredOperation
+                    )
                     self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
                 }
                 self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
@@ -548,6 +564,9 @@ struct GraphQLRequestWriter: SupportOutput {
 
     private func subscriptionSupportGetWithRegisteredPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
+        guard plan.allowsUnregisteredOperations else {
+            return subscriptionSupportGetWithNoPersistedOperations()
+        }
         return """
 
 
@@ -557,21 +576,31 @@ struct GraphQLRequestWriter: SupportOutput {
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
             ///   - endpoint: The GraphQL server endpoint.
+            ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: URL,
+                useRegisteredOperation: Bool = true,
                 strategy: SubscriptionStrategy = .GET()
             ) throws where Operation: GraphQLSubscription {
                 switch strategy {
                 case .GET(let queryEncoder):
-                    let url = endpoint.appending(queryItems: try queryEncoder.encode(subscription: subscription))
+                    let url = endpoint.appending(
+                        queryItems: try queryEncoder.encode(
+                            subscription: subscription,
+                            useRegisteredOperation: useRegisteredOperation
+                        )
+                    )
                     self.urlRequest = URLRequest(url: url)
                     self.urlRequest.httpMethod = "GET"
                 case .POST(let bodyEncoder):
                     self.urlRequest = URLRequest(url: endpoint)
                     self.urlRequest.httpMethod = "POST"
-                    self.urlRequest.httpBody = try bodyEncoder.encode(operation: subscription)
+                    self.urlRequest.httpBody = try bodyEncoder.encode(
+                        operation: subscription,
+                        useRegisteredOperation: useRegisteredOperation
+                    )
                     self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
                 }
                 self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
@@ -652,6 +681,9 @@ struct GraphQLRequestWriter: SupportOutput {
 
     private func subscriptionSupportPostWithRegisteredPersistedOperations() -> String {
         guard includeSubscriptionSupport else { return "" }
+        guard plan.allowsUnregisteredOperations else {
+            return subscriptionSupportPostWithNoPersistedOperations()
+        }
         return """
 
 
@@ -659,15 +691,20 @@ struct GraphQLRequestWriter: SupportOutput {
             /// - Parameters:
             ///   - subscription: The GraphQLSubscription operation the request is for.
             ///   - endpoint: The GraphQL server endpoint.
+            ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
             ///   - bodyEncoder: The encoder used to serialize the operation into HTTP body data.
             \(accessLevel)init(
                 subscription: Operation,
                 endpoint: URL,
+                useRegisteredOperation: Bool = true,
                 bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder()
             ) throws where Operation: GraphQLSubscription {
                 self.urlRequest = URLRequest(url: endpoint)
                 self.urlRequest.httpMethod = "POST"
-                self.urlRequest.httpBody = try bodyEncoder.encode(operation: subscription)
+                self.urlRequest.httpBody = try bodyEncoder.encode(
+                    operation: subscription,
+                    useRegisteredOperation: useRegisteredOperation
+                )
                 self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
                 self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
                 self.endpoint = endpoint

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/HTTPGenerationPlan.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/HTTPGenerationPlan.swift
@@ -32,7 +32,7 @@ struct HTTPGenerationPlan {
     init(configuration: Configuration, hasSubscription: Bool) {
         let enablesGETQueries = configuration.output.support.HTTPSupport?.enableGETQueries == true
         let persistence: Persistence
-        switch configuration.output.documents.operations.persistedOperations {
+        switch configuration.output.support.HTTPSupport?.persistedOperations {
         case .automatic: persistence = .automatic
         case .registered: persistence = .registered
         case .none: persistence = .none

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/HTTPGenerationPlan.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/HTTPGenerationPlan.swift
@@ -10,13 +10,18 @@ struct HTTPGenerationPlan {
 
     enum Persistence {
         case automatic
-        case registered
+        case registered(allowsUnregisteredOperations: Bool)
         case none
     }
 
     let enablesGETQueries: Bool
     let includesSubscriptions: Bool
     let persistence: Persistence
+
+    var allowsUnregisteredOperations: Bool {
+        guard case .registered(let allowsUnregisteredOperations) = persistence else { return false }
+        return allowsUnregisteredOperations
+    }
 
     var mode: Mode {
         switch (enablesGETQueries, persistence) {
@@ -34,7 +39,8 @@ struct HTTPGenerationPlan {
         let persistence: Persistence
         switch configuration.output.support.HTTPSupport?.persistedOperations {
         case .automatic: persistence = .automatic
-        case .registered: persistence = .registered
+        case .registered(_, let allowUnregisteredOperations):
+            persistence = .registered(allowsUnregisteredOperations: allowUnregisteredOperations)
         case .none: persistence = .none
         }
         self.enablesGETQueries = enablesGETQueries

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
@@ -52,7 +52,7 @@ struct URLSessionWriter: SupportOutput {
     }
 
     private func requestErrorHandling() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
+        switch configuration.output.support.HTTPSupport?.persistedOperations {
         case .automatic:
             """
             case .requestError(let requestError):
@@ -330,7 +330,7 @@ struct URLSessionWriter: SupportOutput {
     }
 
     private func automaticPersistedOperationSubscriptionDocumentation() -> String {
-        guard case .automatic = configuration.output.documents.operations.persistedOperations else { return "" }
+        guard case .automatic = configuration.output.support.HTTPSupport?.persistedOperations else { return "" }
         return """
 
             /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
@@ -339,7 +339,7 @@ struct URLSessionWriter: SupportOutput {
     }
 
     private func subscriptionRequestErrorHandling() -> String {
-        switch configuration.output.documents.operations.persistedOperations {
+        switch configuration.output.support.HTTPSupport?.persistedOperations {
         case .automatic:
             """
             case .requestError(let requestError):

--- a/StarwarsExample/client/Codegen/Sources/Codegen.swift
+++ b/StarwarsExample/client/Codegen/Sources/Codegen.swift
@@ -34,6 +34,12 @@ enum StarwarsCodegen {
                         accessLevel: .public,
                         HTTPSupport: .httpSupport(
                             enableGETQueries: true,
+                            persistedOperations: .registered(
+                                manifestJSONFileOutput: exampleDirectory.appending(
+                                    path: "server/src/registered-operations.generated.json",
+                                    directoryHint: .notDirectory
+                                )
+                            ),
                             subscriptionSupport: true
                         )
                     )

--- a/StarwarsExample/client/Codegen/Sources/Codegen.swift
+++ b/StarwarsExample/client/Codegen/Sources/Codegen.swift
@@ -34,13 +34,7 @@ enum StarwarsCodegen {
                         accessLevel: .public,
                         HTTPSupport: .httpSupport(
                             enableGETQueries: true,
-                            persistedOperations: .registered(
-                                manifestJSONFileOutput: exampleDirectory.appending(
-                                    path: "server/src/registered-operations.generated.json",
-                                    directoryHint: .notDirectory
-                                ),
-                                allowUnregisteredOperations: true
-                            ),
+                            persistedOperations: .automatic,
                             subscriptionSupport: true
                         )
                     )

--- a/StarwarsExample/client/Codegen/Sources/Codegen.swift
+++ b/StarwarsExample/client/Codegen/Sources/Codegen.swift
@@ -38,7 +38,8 @@ enum StarwarsCodegen {
                                 manifestJSONFileOutput: exampleDirectory.appending(
                                     path: "server/src/registered-operations.generated.json",
                                     directoryHint: .notDirectory
-                                )
+                                ),
+                                allowUnregisteredOperations: true
                             ),
                             subscriptionSupport: true
                         )

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
@@ -7,14 +7,35 @@ import Foundation
 /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
 public struct DefaultURLQueryEncoder: URLQueryEncoder {
     public init() {}
-    public func encode<Operation: GraphQLOperation>(
-        operation: Operation,
-        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
+    public func encode<Query: GraphQLQuery>(
+        query: Query,
+        useRegisteredOperation: Bool
     ) throws -> [URLQueryItem] {
-        let body = Body(
-            operation: operation,
-            automaticPersistedOperationPhase: automaticPersistedOperationPhase
-        )
+        let body = Body(operation: query, useRegisteredOperation: useRegisteredOperation)
+        let encoder = JSONEncoder()
+        return [
+            body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
+            body.query.map { URLQueryItem(name: "query", value: $0) },
+            try body.variables.map { variables in
+                URLQueryItem(
+                    name: "variables",
+                    value: String(decoding: try encoder.encode(variables), as: UTF8.self)
+                )
+            },
+            try body.extensions.map { extensions in
+                URLQueryItem(
+                    name: "extensions",
+                    value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
+                )
+            }
+        ].compactMap { $0 }
+    }
+
+    public func encode<Subscription: GraphQLSubscription>(
+        subscription: Subscription,
+        useRegisteredOperation: Bool
+    ) throws -> [URLQueryItem] {
+        let body = Body(operation: subscription, useRegisteredOperation: useRegisteredOperation)
         let encoder = JSONEncoder()
         return [
             body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
@@ -43,13 +64,10 @@ public struct JSONBodyEncoder: HTTPBodyEncoder {
     public let contentType = "application/json"
     public func encode<Operation: GraphQLOperation>(
         operation: Operation,
-        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
+        useRegisteredOperation: Bool
     ) throws -> Data {
         try JSONEncoder().encode(
-            Body(
-                operation: operation,
-                automaticPersistedOperationPhase: automaticPersistedOperationPhase
-            )
+            Body(operation: operation, useRegisteredOperation: useRegisteredOperation)
         )
     }
 }
@@ -62,19 +80,19 @@ private struct Body: Encodable {
 
     init<Operation: GraphQLOperation>(
         operation: Operation,
-        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
+        useRegisteredOperation: Bool
     ) {
         var extensions = operation.extensions
-        if automaticPersistedOperationPhase != nil {
-            var persistedExtensions = extensions ?? [:]
-            persistedExtensions["persistedQuery"] = AnyEncodable([
+        if useRegisteredOperation {
+            var registeredExtensions = extensions ?? [:]
+            registeredExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
                 "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
             ])
-            extensions = persistedExtensions
+            extensions = registeredExtensions
         }
         self.operationName = Operation.operationName
-        self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : Operation.document
+        self.query = useRegisteredOperation ? nil : Operation.document
         self.variables = operation.requestVariables
         self.extensions = extensions
     }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
@@ -16,18 +16,8 @@ public struct DefaultURLQueryEncoder: URLQueryEncoder {
         return [
             body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
             body.query.map { URLQueryItem(name: "query", value: $0) },
-            try body.variables.map { variables in
-                URLQueryItem(
-                    name: "variables",
-                    value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                )
-            },
-            try body.extensions.map { extensions in
-                URLQueryItem(
-                    name: "extensions",
-                    value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                )
-            }
+            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
         ].compactMap { $0 }
     }
 
@@ -40,19 +30,24 @@ public struct DefaultURLQueryEncoder: URLQueryEncoder {
         return [
             body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
             body.query.map { URLQueryItem(name: "query", value: $0) },
-            try body.variables.map { variables in
-                URLQueryItem(
-                    name: "variables",
-                    value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                )
-            },
-            try body.extensions.map { extensions in
-                URLQueryItem(
-                    name: "extensions",
-                    value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                )
-            }
+            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
         ].compactMap { $0 }
+    }
+}
+
+private extension URLQueryItem {
+    init?<Value: Encodable>(
+        name: String,
+        encoding value: Value?,
+        using encoder: JSONEncoder
+    ) throws {
+        guard let value else { return nil }
+
+        self.init(
+            name: name,
+            value: String(decoding: try encoder.encode(value), as: UTF8.self)
+        )
     }
 }
 

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/DefaultEncoders.swift
@@ -7,47 +7,45 @@ import Foundation
 /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
 public struct DefaultURLQueryEncoder: URLQueryEncoder {
     public init() {}
-    public func encode<Query: GraphQLQuery>(
-        query: Query,
-        useRegisteredOperation: Bool
+    public func encode<Operation: GraphQLOperation>(
+        operation: Operation,
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) throws -> [URLQueryItem] {
-        let body = Body(operation: query, useRegisteredOperation: useRegisteredOperation)
-        let encoder = JSONEncoder()
-        return [
-            body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-            body.query.map { URLQueryItem(name: "query", value: $0) },
-            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-        ].compactMap { $0 }
-    }
-
-    public func encode<Subscription: GraphQLSubscription>(
-        subscription: Subscription,
-        useRegisteredOperation: Bool
-    ) throws -> [URLQueryItem] {
-        let body = Body(operation: subscription, useRegisteredOperation: useRegisteredOperation)
-        let encoder = JSONEncoder()
-        return [
-            body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-            body.query.map { URLQueryItem(name: "query", value: $0) },
-            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-        ].compactMap { $0 }
+        try .from(
+            Body(
+                operation: operation,
+                automaticPersistedOperationPhase: automaticPersistedOperationPhase
+            )
+        )
     }
 }
 
-private extension URLQueryItem {
-    init?<Value: Encodable>(
-        name: String,
-        encoding value: Value?,
-        using encoder: JSONEncoder
-    ) throws {
-        guard let value else { return nil }
-
-        self.init(
-            name: name,
-            value: String(decoding: try encoder.encode(value), as: UTF8.self)
-        )
+private extension [URLQueryItem] {
+    static func from(_ body: Body) throws -> Self {
+        var items = [URLQueryItem]()
+        if let operationName = body.operationName {
+            items.append(URLQueryItem(name: "operationName", value: operationName))
+        }
+        if let query = body.query {
+            items.append(URLQueryItem(name: "query", value: query))
+        }
+        if let variables = body.variables {
+            items.append(
+                URLQueryItem(
+                    name: "variables",
+                    value: String(decoding: try JSONEncoder().encode(variables), as: UTF8.self)
+                )
+            )
+        }
+        if let extensions = body.extensions {
+            items.append(
+                URLQueryItem(
+                    name: "extensions",
+                    value: String(decoding: try JSONEncoder().encode(extensions), as: UTF8.self)
+                )
+            )
+        }
+        return items
     }
 }
 
@@ -59,10 +57,13 @@ public struct JSONBodyEncoder: HTTPBodyEncoder {
     public let contentType = "application/json"
     public func encode<Operation: GraphQLOperation>(
         operation: Operation,
-        useRegisteredOperation: Bool
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) throws -> Data {
         try JSONEncoder().encode(
-            Body(operation: operation, useRegisteredOperation: useRegisteredOperation)
+            Body(
+                operation: operation,
+                automaticPersistedOperationPhase: automaticPersistedOperationPhase
+            )
         )
     }
 }
@@ -75,19 +76,19 @@ private struct Body: Encodable {
 
     init<Operation: GraphQLOperation>(
         operation: Operation,
-        useRegisteredOperation: Bool
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) {
         var extensions = operation.extensions
-        if useRegisteredOperation {
-            var registeredExtensions = extensions ?? [:]
-            registeredExtensions["persistedQuery"] = AnyEncodable([
+        if automaticPersistedOperationPhase != nil {
+            var persistedExtensions = extensions ?? [:]
+            persistedExtensions["persistedQuery"] = AnyEncodable([
                 "version": AnyEncodable(1),
                 "sha256Hash": AnyEncodable(persistedOperationHash(Operation.document))
             ])
-            extensions = registeredExtensions
+            extensions = persistedExtensions
         }
         self.operationName = Operation.operationName
-        self.query = useRegisteredOperation ? nil : Operation.document
+        self.query = automaticPersistedOperationPhase == .initialRequestWithHash ? nil : Operation.document
         self.variables = operation.requestVariables
         self.extensions = extensions
     }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/Encoders.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/Encoders.swift
@@ -1,19 +1,28 @@
 // @generated
 import Foundation
 
-/// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
+/// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
+/// is being used.
 public protocol URLQueryEncoder {
 
-    /// Encodes an operation for a GET request.
+    /// Encodes a query operation for a GET request.
     /// - Parameters:
-    ///   operation: The operation to encode.
-    ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
-    ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
-    ///   should always be sent.
+    ///   query: The query operation to encode.
+    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
     /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-    func encode<Operation: GraphQLOperation>(
-        operation: Operation,
-        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
+    func encode<Query: GraphQLQuery>(
+        query: Query,
+        useRegisteredOperation: Bool
+    ) throws -> [URLQueryItem]
+
+    /// Encodes a subscription operation for a GET request.
+    /// - Parameters:
+    ///   subscription: The subscription operation to encode.
+    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
+    /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
+    func encode<Subscription: GraphQLSubscription>(
+        subscription: Subscription,
+        useRegisteredOperation: Bool
     ) throws -> [URLQueryItem]
 }
 
@@ -27,24 +36,10 @@ public protocol HTTPBodyEncoder {
     /// Encodes an operation into body data for a POST request.
     /// - Parameters:
     ///   operation: The GraphQL operation to encode.
-    ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
-    ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
-    ///   should always be sent.
+    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
     /// - Returns: The encoded data to be set as the HTTP body of the POST request.
     func encode<Operation: GraphQLOperation>(
         operation: Operation,
-        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
+        useRegisteredOperation: Bool
     ) throws -> Data
-}
-
-/// Indicates which phase of Automatic Persisted Operations the request is for.
-public enum AutomaticPersistedOperationPhase {
-
-    /// This phase indicates encoders should encode an operation's hash instead of the document
-    /// text.
-    case initialRequestWithHash
-
-    /// This phase indicates encoders should encode an operation's document text as well as its hash, because
-    /// the document's hash was not previously found by the server.
-    case persistRequestWithDocument
 }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/Encoders.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/Encoders.swift
@@ -1,28 +1,19 @@
 // @generated
 import Foundation
 
-/// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
-/// is being used.
+/// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
 public protocol URLQueryEncoder {
 
-    /// Encodes a query operation for a GET request.
+    /// Encodes an operation for a GET request.
     /// - Parameters:
-    ///   query: The query operation to encode.
-    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
+    ///   operation: The operation to encode.
+    ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
+    ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
+    ///   should always be sent.
     /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-    func encode<Query: GraphQLQuery>(
-        query: Query,
-        useRegisteredOperation: Bool
-    ) throws -> [URLQueryItem]
-
-    /// Encodes a subscription operation for a GET request.
-    /// - Parameters:
-    ///   subscription: The subscription operation to encode.
-    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
-    /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-    func encode<Subscription: GraphQLSubscription>(
-        subscription: Subscription,
-        useRegisteredOperation: Bool
+    func encode<Operation: GraphQLOperation>(
+        operation: Operation,
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) throws -> [URLQueryItem]
 }
 
@@ -36,10 +27,24 @@ public protocol HTTPBodyEncoder {
     /// Encodes an operation into body data for a POST request.
     /// - Parameters:
     ///   operation: The GraphQL operation to encode.
-    ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
+    ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
+    ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
+    ///   should always be sent.
     /// - Returns: The encoded data to be set as the HTTP body of the POST request.
     func encode<Operation: GraphQLOperation>(
         operation: Operation,
-        useRegisteredOperation: Bool
+        automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) throws -> Data
+}
+
+/// Indicates which phase of Automatic Persisted Operations the request is for.
+public enum AutomaticPersistedOperationPhase {
+
+    /// This phase indicates encoders should encode an operation's hash instead of the document
+    /// text.
+    case initialRequestWithHash
+
+    /// This phase indicates encoders should encode an operation's document text as well as its hash, because
+    /// the document's hash was not previously found by the server.
+    case persistRequestWithDocument
 }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/GraphQLRequest.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/GraphQLRequest.swift
@@ -1,6 +1,10 @@
 // @generated
 import Foundation
 
+enum PersistedOperationRetry {
+    case GET(queryEncoder: URLQueryEncoder)
+    case POST(bodyEncoder: HTTPBodyEncoder)
+}
 
 /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
 public struct GraphQLRequest<Operation: GraphQLOperation> {
@@ -14,6 +18,20 @@ public struct GraphQLRequest<Operation: GraphQLOperation> {
 
     /// The GraphQL operation executed in the request.
     public let operation: Operation
+    /// The retry configuration for an unknown persisted operation.
+    let persistedOperationRetry: PersistedOperationRetry?
+
+    private init(
+        urlRequest: URLRequest,
+        endpoint: URL,
+        operation: Operation,
+        persistedOperationRetry: PersistedOperationRetry?
+    ) {
+        self.urlRequest = urlRequest
+        self.endpoint = endpoint
+        self.operation = operation
+        self.persistedOperationRetry = persistedOperationRetry
+    }
 }
 
 extension GraphQLRequest {
@@ -22,61 +40,150 @@ extension GraphQLRequest {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
-    /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.
+    /// Returns a request updated to retry an unknown persisted operation with its full document.
+    func updated(
+        for retry: PersistedOperationRetry
+    ) throws -> Self where Operation: GraphQLSingleResponseOperation {
+        var urlRequest = urlRequest
+        switch retry {
+        case .GET(let queryEncoder):
+            urlRequest.url = endpoint.appending(
+                queryItems: try queryEncoder.encode(
+                    operation: operation,
+                    automaticPersistedOperationPhase: .persistRequestWithDocument
+                )
+            )
+            urlRequest.httpMethod = "GET"
+            urlRequest.httpBody = nil
+            urlRequest.setValue(nil, forHTTPHeaderField: "content-type")
+        case .POST(let bodyEncoder):
+            urlRequest.url = endpoint
+            urlRequest.httpMethod = "POST"
+            urlRequest.httpBody = try bodyEncoder.encode(
+                operation: operation,
+                automaticPersistedOperationPhase: .persistRequestWithDocument
+            )
+            urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+        }
+        return Self(
+            urlRequest: urlRequest,
+            endpoint: endpoint,
+            operation: operation,
+            persistedOperationRetry: nil
+        )
+    }
+
+    /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`
     public enum QueryStrategy {
 
-        /// Instructs the request to be a GET request, encoding the operation into the url query component.
+        /// Describes how to retry an automatic persisted operation when its hash is not recognized.
+        public enum AutomaticPersistedOperationRetryPolicy {
+
+            /// Retries with the full document encoded in the URL query component.
+            case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
+
+            /// Retries with the full document encoded in the HTTP body.
+            case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+
+            var retry: PersistedOperationRetry {
+                switch self {
+                case .GET(let queryEncoder):
+                    return .GET(queryEncoder: queryEncoder)
+                case .POST(let bodyEncoder):
+                    return .POST(bodyEncoder: bodyEncoder)
+                }
+            }
+        }
+
+        /// Instructs the request to be a GET request without support for automatic persisted queries
         case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
 
-        /// Instructs the request to be a POST request, encoding the operation into the http body.
+        /// Instructs the request to be a POST request without support for automatic persisted queries
         case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
+
+        /// Instructs the request to be a GET request, enabling automatic persisted queries
+        case GETWithAutomaticPersistedOperations(
+            queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder(),
+            retryPolicy: AutomaticPersistedOperationRetryPolicy = .POST()
+        )
+
+        /// Instructs the request to be a POST request, enabling automatic persisted queries.
+        /// The retry policy must be selected explicitly.
+        case POSTWithAutomaticPersistedOperations(
+            bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
+            retryPolicy: AutomaticPersistedOperationRetryPolicy
+        )
     }
 
     /// Initializes a new `GraphQLRequest` with a query operation
     /// - Parameters:
     ///   - query: The GraphQLQuery operation the request is for.
     ///   - endpoint: The GraphQL server endpoint.
-    ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
-    ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
+    ///   - strategy: The option describing whether the request should be a GET or POST and whether
+    ///   automatic persisted operations is enabled. By default `GET` is used
+    ///   and automatic persisted operations is enabled. If the initial request results in a
+    ///   "PersistedQueryNotFound" error, the configured retry policy sends the full query document.
     ///   - accept: The value to use in the "accept" header field. By default this is
     ///   "application/graphql-response+json". This field is required by the spec:
     ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
     public init(
         query: Operation,
         endpoint: URL,
-        useRegisteredOperation: Bool = true,
-        strategy: QueryStrategy = .GET(),
+        strategy: QueryStrategy = .GETWithAutomaticPersistedOperations(),
         accept: String = "application/graphql-response+json"
     ) throws where Operation: GraphQLQuery {
+        let persistedOperationRetry: PersistedOperationRetry?
         switch strategy {
         case .GET(let queryEncoder):
+            persistedOperationRetry = nil
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    query: query,
-                    useRegisteredOperation: useRegisteredOperation
+                    operation: query,
+                    automaticPersistedOperationPhase: nil
                 )
             )
             self.urlRequest = URLRequest(url: url)
             self.urlRequest.httpMethod = "GET"
         case .POST(let bodyEncoder):
+            persistedOperationRetry = nil
             self.urlRequest = URLRequest(url: endpoint)
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
                 operation: query,
-                useRegisteredOperation: useRegisteredOperation
+                automaticPersistedOperationPhase: nil
+            )
+            self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
+        case .GETWithAutomaticPersistedOperations(let queryEncoder, let retryPolicy):
+            persistedOperationRetry = retryPolicy.retry
+            let url = endpoint.appending(
+                queryItems: try queryEncoder.encode(
+                    operation: query,
+                    automaticPersistedOperationPhase: .initialRequestWithHash
+                )
+            )
+            self.urlRequest = URLRequest(url: url)
+            self.urlRequest.httpMethod = "GET"
+        case .POSTWithAutomaticPersistedOperations(let bodyEncoder, let retryPolicy):
+            persistedOperationRetry = retryPolicy.retry
+            self.urlRequest = URLRequest(url: endpoint)
+            self.urlRequest.httpMethod = "POST"
+            self.urlRequest.httpBody = try bodyEncoder.encode(
+                operation: query,
+                automaticPersistedOperationPhase: .initialRequestWithHash
             )
             self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         }
         self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = query
+        self.persistedOperationRetry = persistedOperationRetry
     }
 
-    /// Initializes a POST request for a registered single-response GraphQL operation.
+    /// Initializes a POST request for a single-response GraphQL operation.
     public init(
         operation: Operation,
         endpoint: URL,
-        useRegisteredOperation: Bool = true,
+        automaticPersistedOperations: Bool = true,
         bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
         accept: String = "application/graphql-response+json"
     ) throws where Operation: GraphQLSingleResponseOperation {
@@ -84,12 +191,13 @@ extension GraphQLRequest {
         self.urlRequest.httpMethod = "POST"
         self.urlRequest.httpBody = try bodyEncoder.encode(
             operation: operation,
-            useRegisteredOperation: useRegisteredOperation
+            automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil
         )
         self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = operation
+        self.persistedOperationRetry = automaticPersistedOperations ? .POST(bodyEncoder: bodyEncoder) : nil
     }
 
     /// Describes how the `GraphQLRequest` should encode a `GraphQLSubscription` operation into its
@@ -106,21 +214,20 @@ extension GraphQLRequest {
     /// Initializes a new `GraphQLRequest` with a subscription operation
     /// - Parameters:
     ///   - subscription: The GraphQLSubscription operation the request is for.
-    ///   - endpoint: The GraphQL server endpoint.
-    ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
+    ///   - endpoint: The GraphQL server endpoint supporting GraphQL over Server-Sent Events.
     ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
+    ///   Automatic persisted operations are unavailable because subscription fallback is not supported.
     public init(
         subscription: Operation,
         endpoint: URL,
-        useRegisteredOperation: Bool = true,
         strategy: SubscriptionStrategy = .GET()
     ) throws where Operation: GraphQLSubscription {
         switch strategy {
         case .GET(let queryEncoder):
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    subscription: subscription,
-                    useRegisteredOperation: useRegisteredOperation
+                    operation: subscription,
+                    automaticPersistedOperationPhase: nil
                 )
             )
             self.urlRequest = URLRequest(url: url)
@@ -130,12 +237,13 @@ extension GraphQLRequest {
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
                 operation: subscription,
-                useRegisteredOperation: useRegisteredOperation
+                automaticPersistedOperationPhase: nil
             )
             self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         }
         self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = subscription
+        self.persistedOperationRetry = nil
     }
 }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/GraphQLRequest.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/GraphQLRequest.swift
@@ -1,10 +1,6 @@
 // @generated
 import Foundation
 
-enum PersistedOperationRetry {
-    case GET(queryEncoder: URLQueryEncoder)
-    case POST(bodyEncoder: HTTPBodyEncoder)
-}
 
 /// A `GraphQLRequest` represents a `URLRequest` for a GraphQL operation.
 public struct GraphQLRequest<Operation: GraphQLOperation> {
@@ -18,20 +14,6 @@ public struct GraphQLRequest<Operation: GraphQLOperation> {
 
     /// The GraphQL operation executed in the request.
     public let operation: Operation
-    /// The retry configuration for an unknown persisted operation.
-    let persistedOperationRetry: PersistedOperationRetry?
-
-    private init(
-        urlRequest: URLRequest,
-        endpoint: URL,
-        operation: Operation,
-        persistedOperationRetry: PersistedOperationRetry?
-    ) {
-        self.urlRequest = urlRequest
-        self.endpoint = endpoint
-        self.operation = operation
-        self.persistedOperationRetry = persistedOperationRetry
-    }
 }
 
 extension GraphQLRequest {
@@ -40,150 +22,61 @@ extension GraphQLRequest {
         { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
-    /// Returns a request updated to retry an unknown persisted operation with its full document.
-    func updated(
-        for retry: PersistedOperationRetry
-    ) throws -> Self where Operation: GraphQLSingleResponseOperation {
-        var urlRequest = urlRequest
-        switch retry {
-        case .GET(let queryEncoder):
-            urlRequest.url = endpoint.appending(
-                queryItems: try queryEncoder.encode(
-                    operation: operation,
-                    automaticPersistedOperationPhase: .persistRequestWithDocument
-                )
-            )
-            urlRequest.httpMethod = "GET"
-            urlRequest.httpBody = nil
-            urlRequest.setValue(nil, forHTTPHeaderField: "content-type")
-        case .POST(let bodyEncoder):
-            urlRequest.url = endpoint
-            urlRequest.httpMethod = "POST"
-            urlRequest.httpBody = try bodyEncoder.encode(
-                operation: operation,
-                automaticPersistedOperationPhase: .persistRequestWithDocument
-            )
-            urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-        }
-        return Self(
-            urlRequest: urlRequest,
-            endpoint: endpoint,
-            operation: operation,
-            persistedOperationRetry: nil
-        )
-    }
-
-    /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`
+    /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.
     public enum QueryStrategy {
 
-        /// Describes how to retry an automatic persisted operation when its hash is not recognized.
-        public enum AutomaticPersistedOperationRetryPolicy {
-
-            /// Retries with the full document encoded in the URL query component.
-            case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
-
-            /// Retries with the full document encoded in the HTTP body.
-            case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
-
-            var retry: PersistedOperationRetry {
-                switch self {
-                case .GET(let queryEncoder):
-                    return .GET(queryEncoder: queryEncoder)
-                case .POST(let bodyEncoder):
-                    return .POST(bodyEncoder: bodyEncoder)
-                }
-            }
-        }
-
-        /// Instructs the request to be a GET request without support for automatic persisted queries
+        /// Instructs the request to be a GET request, encoding the operation into the url query component.
         case GET(queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder())
 
-        /// Instructs the request to be a POST request without support for automatic persisted queries
+        /// Instructs the request to be a POST request, encoding the operation into the http body.
         case POST(bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder())
-
-        /// Instructs the request to be a GET request, enabling automatic persisted queries
-        case GETWithAutomaticPersistedOperations(
-            queryEncoder: URLQueryEncoder = DefaultURLQueryEncoder(),
-            retryPolicy: AutomaticPersistedOperationRetryPolicy = .POST()
-        )
-
-        /// Instructs the request to be a POST request, enabling automatic persisted queries.
-        /// The retry policy must be selected explicitly.
-        case POSTWithAutomaticPersistedOperations(
-            bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
-            retryPolicy: AutomaticPersistedOperationRetryPolicy
-        )
     }
 
     /// Initializes a new `GraphQLRequest` with a query operation
     /// - Parameters:
     ///   - query: The GraphQLQuery operation the request is for.
     ///   - endpoint: The GraphQL server endpoint.
-    ///   - strategy: The option describing whether the request should be a GET or POST and whether
-    ///   automatic persisted operations is enabled. By default `GET` is used
-    ///   and automatic persisted operations is enabled. If the initial request results in a
-    ///   "PersistedQueryNotFound" error, the configured retry policy sends the full query document.
+    ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
+    ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
     ///   - accept: The value to use in the "accept" header field. By default this is
     ///   "application/graphql-response+json". This field is required by the spec:
     ///   https://graphql.github.io/graphql-over-http/draft/#sec-Accept
     public init(
         query: Operation,
         endpoint: URL,
-        strategy: QueryStrategy = .GETWithAutomaticPersistedOperations(),
+        useRegisteredOperation: Bool = true,
+        strategy: QueryStrategy = .GET(),
         accept: String = "application/graphql-response+json"
     ) throws where Operation: GraphQLQuery {
-        let persistedOperationRetry: PersistedOperationRetry?
         switch strategy {
         case .GET(let queryEncoder):
-            persistedOperationRetry = nil
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    operation: query,
-                    automaticPersistedOperationPhase: nil
+                    query: query,
+                    useRegisteredOperation: useRegisteredOperation
                 )
             )
             self.urlRequest = URLRequest(url: url)
             self.urlRequest.httpMethod = "GET"
         case .POST(let bodyEncoder):
-            persistedOperationRetry = nil
             self.urlRequest = URLRequest(url: endpoint)
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
                 operation: query,
-                automaticPersistedOperationPhase: nil
-            )
-            self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
-        case .GETWithAutomaticPersistedOperations(let queryEncoder, let retryPolicy):
-            persistedOperationRetry = retryPolicy.retry
-            let url = endpoint.appending(
-                queryItems: try queryEncoder.encode(
-                    operation: query,
-                    automaticPersistedOperationPhase: .initialRequestWithHash
-                )
-            )
-            self.urlRequest = URLRequest(url: url)
-            self.urlRequest.httpMethod = "GET"
-        case .POSTWithAutomaticPersistedOperations(let bodyEncoder, let retryPolicy):
-            persistedOperationRetry = retryPolicy.retry
-            self.urlRequest = URLRequest(url: endpoint)
-            self.urlRequest.httpMethod = "POST"
-            self.urlRequest.httpBody = try bodyEncoder.encode(
-                operation: query,
-                automaticPersistedOperationPhase: .initialRequestWithHash
+                useRegisteredOperation: useRegisteredOperation
             )
             self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         }
         self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = query
-        self.persistedOperationRetry = persistedOperationRetry
     }
 
-    /// Initializes a POST request for a single-response GraphQL operation.
+    /// Initializes a POST request for a registered single-response GraphQL operation.
     public init(
         operation: Operation,
         endpoint: URL,
-        automaticPersistedOperations: Bool = true,
+        useRegisteredOperation: Bool = true,
         bodyEncoder: HTTPBodyEncoder = JSONBodyEncoder(),
         accept: String = "application/graphql-response+json"
     ) throws where Operation: GraphQLSingleResponseOperation {
@@ -191,13 +84,12 @@ extension GraphQLRequest {
         self.urlRequest.httpMethod = "POST"
         self.urlRequest.httpBody = try bodyEncoder.encode(
             operation: operation,
-            automaticPersistedOperationPhase: automaticPersistedOperations ? .initialRequestWithHash : nil
+            useRegisteredOperation: useRegisteredOperation
         )
         self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         self.urlRequest.setValue(accept, forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = operation
-        self.persistedOperationRetry = automaticPersistedOperations ? .POST(bodyEncoder: bodyEncoder) : nil
     }
 
     /// Describes how the `GraphQLRequest` should encode a `GraphQLSubscription` operation into its
@@ -214,20 +106,21 @@ extension GraphQLRequest {
     /// Initializes a new `GraphQLRequest` with a subscription operation
     /// - Parameters:
     ///   - subscription: The GraphQLSubscription operation the request is for.
-    ///   - endpoint: The GraphQL server endpoint supporting GraphQL over Server-Sent Events.
+    ///   - endpoint: The GraphQL server endpoint.
+    ///   - useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
     ///   - strategy: The option describing whether the request should be a GET or POST. `GET` by default.
-    ///   Automatic persisted operations are unavailable because subscription fallback is not supported.
     public init(
         subscription: Operation,
         endpoint: URL,
+        useRegisteredOperation: Bool = true,
         strategy: SubscriptionStrategy = .GET()
     ) throws where Operation: GraphQLSubscription {
         switch strategy {
         case .GET(let queryEncoder):
             let url = endpoint.appending(
                 queryItems: try queryEncoder.encode(
-                    operation: subscription,
-                    automaticPersistedOperationPhase: nil
+                    subscription: subscription,
+                    useRegisteredOperation: useRegisteredOperation
                 )
             )
             self.urlRequest = URLRequest(url: url)
@@ -237,13 +130,12 @@ extension GraphQLRequest {
             self.urlRequest.httpMethod = "POST"
             self.urlRequest.httpBody = try bodyEncoder.encode(
                 operation: subscription,
-                automaticPersistedOperationPhase: nil
+                useRegisteredOperation: useRegisteredOperation
             )
             self.urlRequest.setValue(bodyEncoder.contentType, forHTTPHeaderField: "content-type")
         }
         self.urlRequest.setValue("text/event-stream", forHTTPHeaderField: "accept")
         self.endpoint = endpoint
         self.operation = subscription
-        self.persistedOperationRetry = nil
     }
 }

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/URLSession+GraphQL.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/URLSession+GraphQL.swift
@@ -21,18 +21,7 @@ extension URLSession {
         }
         switch try decoder(data) {
         case .executionResult(let executionResult): return executionResult
-        case .requestError(let requestError):
-            let containsPersistedQueryNotFound = requestError.errors.contains { error in
-                error.message == "PersistedQueryNotFound"
-            }
-            if containsPersistedQueryNotFound,
-               let retry = request.persistedOperationRetry {
-                return try await self.request(
-                    try request.updated(for: retry),
-                    decoder: decoder
-                )
-            }
-            throw requestError
+        case .requestError(let requestError): throw requestError
         }
     }
 
@@ -51,8 +40,6 @@ extension URLSession {
     /// Initiates an event stream using a GraphQL subscription.
     /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
     /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode
-    /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
-    /// requests always include the full operation document.
     ///
     /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
     /// - Important: This API requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
@@ -118,9 +105,7 @@ extension URLSession {
                                 case .terminated: return
                                 @unknown default: return
                                 }
-                            case .requestError(let requestError):
-                                // TODO: Support automatic persisted operation fallback for subscriptions.
-                                throw requestError
+                            case .requestError(let requestError): throw requestError
                         }
                         case .complete:
                             continuation.finish()

--- a/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/URLSession+GraphQL.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Support/HTTPSupport/URLSession+GraphQL.swift
@@ -3,8 +3,9 @@ import Foundation
 
 /// Defaults conform to https://graphql.github.io/graphql-over-http/draft/
 extension URLSession {
-    public struct HTTPError: Error {
-        public let response: HTTPURLResponse
+    public enum HTTPError: Error {
+        case invalidType(URLResponse)
+        case badResponse(HTTPURLResponse, Data?)
     }
 
     /// Executes a single-response GraphQL operation.
@@ -16,12 +17,31 @@ extension URLSession {
         decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
-        if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-            throw HTTPError(response: httpResponse)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPError.invalidType(response)
+        }
+        guard
+            (200..<300).contains(httpResponse.statusCode) ||
+            httpResponse.mimeType?.caseInsensitiveCompare(
+                "application/graphql-response+json"
+            ) == .orderedSame
+        else {
+            throw HTTPError.badResponse(httpResponse, data)
         }
         switch try decoder(data) {
         case .executionResult(let executionResult): return executionResult
-        case .requestError(let requestError): throw requestError
+        case .requestError(let requestError):
+            let containsPersistedQueryNotFound = requestError.errors.contains { error in
+                error.message == "PersistedQueryNotFound"
+            }
+            if containsPersistedQueryNotFound,
+               let retry = request.persistedOperationRetry {
+                return try await self.request(
+                    try request.updated(for: retry),
+                    decoder: decoder
+                )
+            }
+            throw requestError
         }
     }
 
@@ -40,6 +60,8 @@ extension URLSession {
     /// Initiates an event stream using a GraphQL subscription.
     /// This implementation assumes your server uses the "GraphQL over Server-Sent Events" spec:
     /// https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverSSE.md#distinct-connections-mode
+    /// - Important: Automatic persisted operations are not supported for subscriptions. Subscription
+    /// requests always include the full operation document.
     ///
     /// Lines, complete event payloads, and decoded results waiting for the consumer are bounded independently.
     /// - Important: This API requires version 26 or newer of macOS, iOS, tvOS, watchOS, or visionOS.
@@ -68,8 +90,11 @@ extension URLSession {
             throw SubscriptionError.invalidMaximumBufferedResultCount(maximumBufferedResultCount)
         }
         let (asyncBytes, response) = try await bytes(for: request.urlRequest)
-        if let httpResponse = response as? HTTPURLResponse, !(200..<300).contains(httpResponse.statusCode) {
-            throw HTTPError(response: httpResponse)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HTTPError.invalidType(response)
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw HTTPError.badResponse(httpResponse, nil)
         }
         guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
             throw SubscriptionError.invalidContentType(response.mimeType)
@@ -105,7 +130,9 @@ extension URLSession {
                                 case .terminated: return
                                 @unknown default: return
                                 }
-                            case .requestError(let requestError): throw requestError
+                            case .requestError(let requestError):
+                                // TODO: Support automatic persisted operation fallback for subscriptions.
+                                throw requestError
                         }
                         case .complete:
                             continuation.finish()

--- a/StarwarsExample/server/src/registered-operations.generated.json
+++ b/StarwarsExample/server/src/registered-operations.generated.json
@@ -1,0 +1,24 @@
+{
+  "format" : "apollo-persisted-query-manifest",
+  "operations" : [
+    {
+      "body" : "subscription FavoriteEpisodeChanged{favoriteEpisodeChanged}",
+      "id" : "e98d3cfa8b0da80fc9ace0621e3c3cd3dac83f4759f388e4a4de338e86148394",
+      "name" : "FavoriteEpisodeChanged",
+      "type" : "subscription"
+    },
+    {
+      "body" : "query Hero($episode:Episode!){hero(episode:$episode){__typename ...jedi ...droid}}fragment jedi on Jedi{...character lightSaberColor}fragment droid on Droid{...character primaryFunction operator}fragment character on Character{id name}",
+      "id" : "4e3cbd0a2b22a963217d4ed95e43cbc301eb0b46c36bfa1fdfd9cecfbda148b5",
+      "name" : "Hero",
+      "type" : "query"
+    },
+    {
+      "body" : "mutation SetFavoriteEpisode($episode:Episode!){setFavoriteEpisode(episode:$episode)}",
+      "id" : "59bacbd434335dd3208e38939272356daa7a665ec5425fa5bb4b714b3e13e94d",
+      "name" : "SetFavoriteEpisode",
+      "type" : "mutation"
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Fixtures/Generated/Support/HTTPSupport/DefaultEncoders.swift
+++ b/Tests/Fixtures/Generated/Support/HTTPSupport/DefaultEncoders.swift
@@ -19,19 +19,24 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
         return [
             body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
             body.query.map { URLQueryItem(name: "query", value: $0) },
-            try body.variables.map { variables in
-                URLQueryItem(
-                    name: "variables",
-                    value: String(decoding: try encoder.encode(variables), as: UTF8.self)
-                )
-            },
-            try body.extensions.map { extensions in
-                URLQueryItem(
-                    name: "extensions",
-                    value: String(decoding: try encoder.encode(extensions), as: UTF8.self)
-                )
-            }
+            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
+            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
         ].compactMap { $0 }
+    }
+}
+
+private extension URLQueryItem {
+    init?<Value: Encodable>(
+        name: String,
+        encoding value: Value?,
+        using encoder: JSONEncoder
+    ) throws {
+        guard let value else { return nil }
+
+        self.init(
+            name: name,
+            value: String(decoding: try encoder.encode(value), as: UTF8.self)
+        )
     }
 }
 

--- a/Tests/Fixtures/Generated/Support/HTTPSupport/DefaultEncoders.swift
+++ b/Tests/Fixtures/Generated/Support/HTTPSupport/DefaultEncoders.swift
@@ -11,32 +11,41 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
         operation: Operation,
         automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
     ) throws -> [URLQueryItem] {
-        let body = Body(
-            operation: operation,
-            automaticPersistedOperationPhase: automaticPersistedOperationPhase
+        try .from(
+            Body(
+                operation: operation,
+                automaticPersistedOperationPhase: automaticPersistedOperationPhase
+            )
         )
-        let encoder = JSONEncoder()
-        return [
-            body.operationName.map { URLQueryItem(name: "operationName", value: $0) },
-            body.query.map { URLQueryItem(name: "query", value: $0) },
-            try URLQueryItem(name: "variables", encoding: body.variables, using: encoder),
-            try URLQueryItem(name: "extensions", encoding: body.extensions, using: encoder)
-        ].compactMap { $0 }
     }
 }
 
-private extension URLQueryItem {
-    init?<Value: Encodable>(
-        name: String,
-        encoding value: Value?,
-        using encoder: JSONEncoder
-    ) throws {
-        guard let value else { return nil }
-
-        self.init(
-            name: name,
-            value: String(decoding: try encoder.encode(value), as: UTF8.self)
-        )
+private extension [URLQueryItem] {
+    static func from(_ body: Body) throws -> Self {
+        var items = [URLQueryItem]()
+        if let operationName = body.operationName {
+            items.append(URLQueryItem(name: "operationName", value: operationName))
+        }
+        if let query = body.query {
+            items.append(URLQueryItem(name: "query", value: query))
+        }
+        if let variables = body.variables {
+            items.append(
+                URLQueryItem(
+                    name: "variables",
+                    value: String(decoding: try JSONEncoder().encode(variables), as: UTF8.self)
+                )
+            )
+        }
+        if let extensions = body.extensions {
+            items.append(
+                URLQueryItem(
+                    name: "extensions",
+                    value: String(decoding: try JSONEncoder().encode(extensions), as: UTF8.self)
+                )
+            )
+        }
+        return items
     }
 }
 

--- a/Tests/Tests/GraphQLDefaultValuesGeneratorTests.swift
+++ b/Tests/Tests/GraphQLDefaultValuesGeneratorTests.swift
@@ -56,10 +56,7 @@ struct GraphQLDefaultValuesGeneratorTests {
                             directoryHint: .isDirectory
                         )
                     ),
-                    documents: .documents(
-                        directory: .definition,
-                        operations: .operations(persistedOperations: nil)
-                    ),
+                    documents: .documents(directory: .definition),
                     support: .support(
                         directory: generatedDirectory.appending(path: "Support", directoryHint: .isDirectory),
                         HTTPSupport: nil

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -621,6 +621,10 @@ struct GraphQLCodeGeneratorTests {
             Configuration.Output.Support.HTTPSupport.PersistedOperations.registered(
                 manifestJSONFileOutput: generatedDirectory.appending(path: "manifest.json")
             ),
+            Configuration.Output.Support.HTTPSupport.PersistedOperations.registered(
+                manifestJSONFileOutput: generatedDirectory.appending(path: "manifest.json"),
+                allowUnregisteredOperations: true
+            ),
             nil,
         ] {
             let variantDirectory = generatedDirectory.appending(
@@ -667,7 +671,7 @@ struct GraphQLCodeGeneratorTests {
             )
             #expect(!postRequest[postInitializer.lowerBound...].contains("try self.init("))
 
-            if case .registered(let manifestURL) = persistedOperations {
+            if case .registered(let manifestURL, let allowUnregisteredOperations) = persistedOperations {
                 let generatedOperations = try String(
                     contentsOf: operationsDirectory.appending(path: "Ticks.graphql.swift"),
                     encoding: .utf8
@@ -681,6 +685,12 @@ struct GraphQLCodeGeneratorTests {
                 )
                 #expect(operationProtocols.contains("static var document: String { get }"))
                 #expect(!operationProtocols.contains("static var hash: String { get }"))
+                #expect(
+                    getRequest.contains("useRegisteredOperation: Bool = true") == allowUnregisteredOperations
+                )
+                #expect(
+                    postRequest.contains("useRegisteredOperation: Bool = true") == allowUnregisteredOperations
+                )
 
                 for supportDirectory in [getVariantSupport, postVariantSupport] {
                     let encoders = try String(
@@ -689,7 +699,20 @@ struct GraphQLCodeGeneratorTests {
                     )
                     #expect(encoders.contains("import CryptoKit"))
                     #expect(encoders.contains("persistedOperationHash(Operation.document)"))
+                    #expect(encoders.contains("if useRegisteredOperation") == allowUnregisteredOperations)
+                    #expect(
+                        encoders.contains("self.query = useRegisteredOperation ? nil : Operation.document") ==
+                            allowUnregisteredOperations
+                    )
                     #expect(!encoders.contains("Operation.hash"))
+
+                    let encoderProtocols = try String(
+                        contentsOf: supportDirectory.appending(path: "HTTPSupport/Encoders.swift"),
+                        encoding: .utf8
+                    )
+                    #expect(
+                        encoderProtocols.contains("useRegisteredOperation: Bool") == allowUnregisteredOperations
+                    )
                 }
 
                 let manifest = try JSONDecoder().decode(

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import GraphQLCodegen
 import Testing
@@ -617,7 +618,7 @@ struct GraphQLCodeGeneratorTests {
         #expect(subscriptionRequest.contains("self.persistedOperationRetry = nil"))
 
         for persistedOperations in [
-            Configuration.Output.Documents.Operations.PersistedOperations.registered(
+            Configuration.Output.Support.HTTPSupport.PersistedOperations.registered(
                 manifestJSONFileOutput: generatedDirectory.appending(path: "manifest.json")
             ),
             nil,
@@ -633,7 +634,8 @@ struct GraphQLCodeGeneratorTests {
                 operationsDirectory: operationsDirectory,
                 supportDirectory: getVariantSupport,
                 enableGETQueries: true,
-                persistedOperations: persistedOperations
+                persistedOperations: persistedOperations,
+                minifyDocument: false
             )
             let getRequest = try String(
                 contentsOf: getVariantSupport.appending(path: "HTTPSupport/GraphQLRequest.swift"),
@@ -653,7 +655,8 @@ struct GraphQLCodeGeneratorTests {
                 operationsDirectory: operationsDirectory,
                 supportDirectory: postVariantSupport,
                 enableGETQueries: false,
-                persistedOperations: persistedOperations
+                persistedOperations: persistedOperations,
+                minifyDocument: false
             )
             let postRequest = try String(
                 contentsOf: postVariantSupport.appending(path: "HTTPSupport/GraphQLRequest.swift"),
@@ -663,6 +666,49 @@ struct GraphQLCodeGeneratorTests {
                 postRequest.range(of: "/// Initializes a new `GraphQLRequest` with a subscription operation")
             )
             #expect(!postRequest[postInitializer.lowerBound...].contains("try self.init("))
+
+            if case .registered(let manifestURL) = persistedOperations {
+                let generatedOperations = try String(
+                    contentsOf: operationsDirectory.appending(path: "Ticks.graphql.swift"),
+                    encoding: .utf8
+                )
+                #expect(generatedOperations.contains("static let document"))
+                #expect(!generatedOperations.contains("static let hash"))
+
+                let operationProtocols = try String(
+                    contentsOf: getVariantSupport.appending(path: "HTTPSupport/GraphQLOperation.swift"),
+                    encoding: .utf8
+                )
+                #expect(operationProtocols.contains("static var document: String { get }"))
+                #expect(!operationProtocols.contains("static var hash: String { get }"))
+
+                for supportDirectory in [getVariantSupport, postVariantSupport] {
+                    let encoders = try String(
+                        contentsOf: supportDirectory.appending(path: "HTTPSupport/DefaultEncoders.swift"),
+                        encoding: .utf8
+                    )
+                    #expect(encoders.contains("import CryptoKit"))
+                    #expect(encoders.contains("persistedOperationHash(Operation.document)"))
+                    #expect(!encoders.contains("Operation.hash"))
+                }
+
+                let manifest = try JSONDecoder().decode(
+                    PersistedOperationManifest.self,
+                    from: Data(contentsOf: manifestURL)
+                )
+                #expect(manifest.operations.contains {
+                    $0.body == "mutation SetVersion { setVersion(version: \"2\") }"
+                })
+                #expect(manifest.operations.contains {
+                    $0.body == "subscription Ticks { ticks }"
+                })
+                for operation in manifest.operations {
+                    let documentHash = SHA256.hash(data: Data(operation.body.utf8))
+                        .map { String(format: "%02x", $0) }
+                        .joined()
+                    #expect(operation.id == documentHash)
+                }
+            }
         }
     }
 
@@ -749,7 +795,8 @@ struct GraphQLCodeGeneratorTests {
         operationsDirectory: URL,
         supportDirectory: URL,
         enableGETQueries: Bool,
-        persistedOperations: Configuration.Output.Documents.Operations.PersistedOperations? = .automatic
+        persistedOperations: Configuration.Output.Support.HTTPSupport.PersistedOperations? = .automatic,
+        minifyDocument: Bool = true
     ) async throws {
         try await Codegen(
             .configuration(
@@ -764,12 +811,13 @@ struct GraphQLCodeGeneratorTests {
                             .appending(path: "SchemaTypes", directoryHint: .isDirectory)
                     ),
                     documents: .documents(
-                        operations: .operations(persistedOperations: persistedOperations)
+                        operations: .operations(minifyDocument: minifyDocument)
                     ),
                     support: .support(
                         directory: supportDirectory,
                         HTTPSupport: .httpSupport(
                             enableGETQueries: enableGETQueries,
+                            persistedOperations: persistedOperations,
                             subscriptionSupport: true
                         )
                     )


### PR DESCRIPTION
## Summary
- Move persisted-operation configuration from document generation into HTTP support.
- Keep generated operation documents unchanged and hash registered persisted operations when encoding requests.
- Generate matching manifests for minified and unminified documents, update the Star Wars example, and extend integration coverage.
- Base the changes directly on main without including the SwiftPM build-tool plugin.

## Validation
- git diff --check
- Verified all three Star Wars manifest document hashes.
- Builds and tests were not run.