### PR TITLE
Always validate GraphQL documents during code generation

### DIFF
--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -37,13 +37,11 @@ public struct Codegen: Sendable {
         ).validate()
 
         // Validation
-        if configuration.validation {
-            try DocumentsValidator(
-                schemaJSON: loadedSchema.schemaJSON,
-                documents: documents,
-                graphQLJS: graphQLJS
-            ).validate()
-        }
+        try DocumentsValidator(
+            schemaJSON: loadedSchema.schemaJSON,
+            documents: documents,
+            graphQLJS: graphQLJS
+        ).validate()
 
         // Resolution
         let resolvedDocuments = try DocumentsResolver(

--- a/Sources/GraphQLCodegen/Configuration/Configuration.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.swift
@@ -9,25 +9,19 @@ public struct Configuration: Sendable {
     ///
     /// - Parameters:
     ///   - input: Options controlling how to ingest the GraphQL schema and GraphQL operations.
-    ///   - validation: Pass `true` (recommended) if you'd like to validate your GraphQL operations against your GraphQL schema.
-    ///   Invalid operations are likely to cause errors during codegen, however if you're already sure all operations are valid,
-    ///   you can skip this step by passing `false`.
     ///   - output: Options controlling the code that is output by this codegen.
     /// - Returns: A `Configuration` to be passed to `Codegen.run`
     public static func configuration(
         input: Input,
-        validation: Bool = true,
         output: Output
     ) -> Configuration {
         Configuration(
             input: input,
-            validation: validation,
             output: output
         )
     }
 
     public var input: Input
-    public var validation: Bool
     public var output: Output
 
     func validate() throws {

--- a/Sources/GraphQLCodegen/Input/Documents/Documents.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Documents.swift
@@ -7,11 +7,7 @@ struct Documents {
 
     func fragment(_ name: String) throws -> Document.Fragment {
         guard let fragment = fragmentLookup[name] else {
-            throw Codegen.Error(description: """
-            Unable to find fragment definition for \(name)
-
-            Note: Turning on validation can help find other similar errors
-            """)
+            throw Codegen.Error(description: "Unable to find fragment definition for \(name)")
         }
         return fragment
     }

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -51,11 +51,7 @@ struct Schema {
 
         func field(_ field: GraphQLAST.Field) throws -> __Schema.__Field {
             func error() -> Codegen.Error {
-                Codegen.Error(description: """
-                Selected field '\(field.name.value)' that doesn't exist on \(name).
-
-                Note: Turn on validation for more debuggable error descriptions and to find other similar errors
-                """)
+                Codegen.Error(description: "Selected field '\(field.name.value)' that doesn't exist on \(name).")
             }
             switch self {
             case .OBJECT(let object):
@@ -69,8 +65,6 @@ struct Schema {
                 Unexpectedly querying a field \(field.responseKey) directly from a union type \(union.ast.name).
                 Fields may not be queried directly from union types.
                 https://spec.graphql.org/September2025/#sel-EAHdJCApHCCiDzyP
-
-                Turn on type validation to catch errors like this.
                 """)
             }
         }
@@ -155,8 +149,6 @@ struct Schema {
             Selected a field \(typeRef) whose type is an input object.
             Input objects are not supported as field types
             https://spec.graphql.org/September2025/#sec-Input-Objects.Result-Coercion
-
-            Note: Turning on validation can help find other similar errors
             """)
         }
     }
@@ -220,8 +212,6 @@ struct Schema {
             Fragment was specified on type `\(name)`.
             Fragments must be specified on a valid object, interface or union type.
             https://spec.graphql.org/September2025/#sel-GAFddJABeBiC2vU
-
-            Note: Turning on validation can help find other similar errors
             """)
         }
     }
@@ -334,8 +324,6 @@ struct Schema {
         Codegen.Error(description: """
         Invalid Operation \(operation.ast.name?.value ?? "")
         The GraphQL schema does not support \(operation.ast.operation) operations
-
-        Note: Turning on validation can help find other similar errors
         """)
     }
 }

--- a/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
@@ -58,10 +58,6 @@ struct FieldResolver {
     }
 
     private func missingSelectionSetError() -> Codegen.Error {
-        Codegen.Error(description: """
-        Selected field \(schemaCoordinate), which requires a selection set.
-
-        Note: Turning on validation can help find other similar errors
-        """)
+        Codegen.Error(description: "Selected field \(schemaCoordinate), which requires a selection set.")
     }
 }

--- a/Tests/Tests/DeprecationSupportTests.swift
+++ b/Tests/Tests/DeprecationSupportTests.swift
@@ -115,7 +115,7 @@ struct DeprecationSupportTests {
     }
 
     @Test
-    func rejectsDeprecatedUsageFromJSONSchemaWhenValidationIsDisabled() async throws {
+    func rejectsDeprecatedUsageFromJSONSchema() async throws {
         let fixture = try makeFixture(document: #"query Search { search(old: "value") }"#)
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let graphQLJS = try GraphQLJS()
@@ -290,7 +290,6 @@ struct DeprecationSupportTests {
                 documentDirectories: [fixture.operationsDirectory],
                 deprecationPolicy: deprecationPolicy
             ),
-            validation: false,
             output: .output(
                 schema: .schema(directory: fixture.schemaTypesDirectory),
                 documents: .documents(directory: .directory(fixture.operationsDirectory)),

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -469,20 +469,6 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
-    func reportsSchemaCoordinatesInsteadOfFieldAliases() async {
-        await expectCodegenError(containing: "Selected field Query.search, which requires a selection set") {
-            try await runCodegen(
-                document: "query Viewer { result: search }",
-                schema: """
-                type Query { search: SearchResult! }
-                type SearchResult { value: String! }
-                """,
-                validation: false
-            )
-        }
-    }
-
-    @Test
     func rejectsSchemaTypeNamedAfterGeneratedSupportType() async {
         for typeName in ["GraphQLSingleResponseOperation", "PersistedOperationRetry"] {
             await expectCodegenError(containing: "conflicting top-level Swift type names") {
@@ -742,8 +728,7 @@ struct GraphQLCodeGeneratorTests {
         enumCaseConversion: Configuration.Output.Schema.Enums.CaseConversion? = nil,
         minifyDocument: Bool = true,
         outputRelativePath: String = "Operations/Viewer.graphql.swift",
-        responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"],
-        validation: Bool = true
+        responseDataConformances: [String] = ["Decodable", "Sendable", "Hashable"]
     ) async throws -> String {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
@@ -766,7 +751,6 @@ struct GraphQLCodeGeneratorTests {
                     schemaSource: .SDLSchemaFile(schemaURL),
                     documentDirectories: [operationsDirectory]
                 ),
-                validation: validation,
                 output: .output(
                     schema: .schema(
                         directory: generatedDirectory.appending(path: "SchemaTypes", directoryHint: .isDirectory),


### PR DESCRIPTION
## Summary
- Remove the optional validation setting from code generation configuration.
- Validate GraphQL documents during every code generation run.
- Remove obsolete validation guidance and tests that depended on bypassing validation.

## Validation
- `git diff --check`
- Builds and tests were not run.