### PR TITLE
Add configurable GraphQL scalar mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ enum, and input-object directories, including files that are not part of the cur
 independently maintained files in these directories.
 
 When a schema category's `directoryName` is `nil`, that category writes directly into `Schema.directory`, and Codegen treats the
-schema root itself as an owned output directory. Customized scalar files are preserved while their scalar remains part of the
-generated output; if the scalar is no longer used by an operation, its file may be removed on the next run.
+schema root itself as an owned output directory. Scalar files are regenerated on every run. Configure custom Swift types with
+`Scalars.scalarMapping`; scalars without a mapping default to `String`. Each mapping can specify a module imported only by its
+generated scalar file and can optionally prefix the mapped type with the module name.
 
 ## Subscription Limits
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.swift
@@ -1,13 +1,39 @@
 extension Configuration.Output.Schema {
     /// Options controlling the code generated to represent scalar types.
     ///
-    /// Codegen only creates a file for scalars if there's not already an existing file for the scalar.
-    /// This differs from Enum and Input Object files which will always override existing code.
-    /// This behavior allows you to customize scalar types. By default, scalars are simple String typealiases
-    /// but you are free to change that and create full types for scalars, or use a typealias to an already existing
-    /// type (i.e. `Foundation.URL` or `Foundation.UUID`). A customized scalar file is preserved while its scalar
-    /// remains part of the generated output; if the scalar is no longer used, its file may be removed on the next run.
+    /// Scalar files are regenerated on every run. Configure custom Swift types with `scalarMapping`;
+    /// scalars without a mapping are generated as `String` typealiases.
     public struct Scalars: Sendable {
+        /// The Swift type and optional module used to represent a GraphQL scalar.
+        public struct Scalar: Sendable {
+            /// A module imported by a generated scalar file.
+            public struct Module: Sendable {
+                public var name: String
+                public var prefix: Bool
+
+                /// Creates a module configuration for a generated scalar file.
+                ///
+                /// - Parameters:
+                ///   - name: The name of the module to import.
+                ///   - prefix: Whether the generated typealias prefixes the type name with the module name.
+                public static func module(name: String, prefix: Bool = false) -> Module {
+                    Module(name: name, prefix: prefix)
+                }
+            }
+
+            public var typeName: String
+            public var module: Module?
+
+            /// Creates a Swift type mapping for a GraphQL scalar.
+            ///
+            /// - Parameters:
+            ///   - typeName: The Swift type used by this scalar's generated typealias.
+            ///   - module: The module to import into this scalar's generated file.
+            public static func scalar(typeName: String, module: Module? = nil) -> Scalar {
+                Scalar(typeName: typeName, module: module)
+            }
+        }
+
         /// Call this function to create a new `Scalars` instance.
         ///
         /// - Parameters:
@@ -16,24 +42,25 @@ extension Configuration.Output.Schema {
         ///   - header: An optional string to include at the top of generated scalar files.
         ///   - importedModules: A list of modules to import into the generated scalar file.
         ///   Just include the module name, the "import" keyword will be added automatically.
+        ///   - scalarMapping: Swift scalar mappings keyed by GraphQL scalar name. Unmapped scalars default to `String`.
         /// - Returns: A new `Scalars` instance to be passed to the `Schema.schema` factory function.
         public static func scalars(
             directoryName: String? = "Scalars",
-            header: String? = """
-            // @generated
-            // Any changes to this file will not be overwritten by future code generation execution.
-            """,
-            importedModules: [String] = []
+            header: String? = "// @generated",
+            importedModules: [String] = [],
+            scalarMapping: [String: Scalar] = [:]
         ) -> Scalars {
             Scalars(
                 directoryName: directoryName,
                 header: header,
-                importedModules: importedModules
+                importedModules: importedModules,
+                scalarMapping: scalarMapping
             )
         }
 
         public var directoryName: String?
         public var header: String?
         public var importedModules: [String]
+        public var scalarMapping: [String: Scalar]
     }
 }

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -5,15 +5,9 @@ final class FileOutput {
         let description: String
     }
 
-    private enum StagedFileKind {
-        case generated
-        case preserved
-    }
-
     private struct StagedFile {
         let temporaryURL: URL
         let finalURL: URL
-        let kind: StagedFileKind
     }
 
     private struct Backup {
@@ -30,7 +24,6 @@ final class FileOutput {
     private let temporaryDirectory = FileManager.default.temporaryDirectory
     private var directoriesToCreate: Set<URL> = []
     private var urlsToRemove: Set<URL> = []
-    private var urlsToSave: Set<URL> = []
     private var stagedFiles: [StagedFile] = []
 
     func createDirectory(at destination: URL) {
@@ -45,10 +38,6 @@ final class FileOutput {
         urlsToRemove.formUnion(urls)
     }
 
-    func save(at url: URL) {
-        urlsToSave.insert(url)
-    }
-
     func write(_ lines: [String], to url: URL) throws {
         let contents = lines.joined(separator: "\n") + "\n"
         try write(Data(contents.utf8), to: url)
@@ -57,19 +46,12 @@ final class FileOutput {
     func write(_ data: Data, to url: URL) throws {
         let tempURL = temporaryURL()
         try data.write(to: tempURL)
-        stagedFiles.append(StagedFile(temporaryURL: tempURL, finalURL: url, kind: .generated))
+        stagedFiles.append(StagedFile(temporaryURL: tempURL, finalURL: url))
     }
 
     func execute() throws {
         var commitState = CommitState()
         do {
-            try urlsToSave.sorted(by: pathOrder).forEach { url in
-                let tempURL = temporaryURL()
-                try FileManager.default.moveItem(at: url, to: tempURL)
-                stagedFiles.append(StagedFile(temporaryURL: tempURL, finalURL: url, kind: .preserved))
-            }
-            urlsToSave.removeAll()
-
             let removalRoots = minimalRemovalRoots()
             for url in removalRoots where fileExists(at: url) {
                 let backup = Backup(temporaryURL: temporaryURL(), originalURL: url)
@@ -137,25 +119,10 @@ final class FileOutput {
     private func rollback(_ commitState: CommitState) -> [String] {
         var failures: [String] = []
         for stagedFile in commitState.published.reversed() where fileExists(at: stagedFile.finalURL) {
-            let failure = switch stagedFile.kind {
-            case .generated:
-                recoveryFailure(
-                    "Failed to remove published file \(stagedFile.finalURL.path)",
-                    operation: { try FileManager.default.removeItem(at: stagedFile.finalURL) }
-                )
-            case .preserved:
-                recoveryFailure(
-                    "Failed to stage preserved file \(stagedFile.finalURL.path) for restoration at " +
-                        stagedFile.temporaryURL.path,
-                    operation: {
-                        try FileManager.default.moveItem(
-                            at: stagedFile.finalURL,
-                            to: stagedFile.temporaryURL
-                        )
-                    }
-                )
-            }
-            if let failure {
+            if let failure = recoveryFailure(
+                "Failed to remove published file \(stagedFile.finalURL.path)",
+                operation: { try FileManager.default.removeItem(at: stagedFile.finalURL) }
+            ) {
                 failures.append(failure)
             }
         }
@@ -205,29 +172,10 @@ final class FileOutput {
         }
 
         for stagedFile in stagedFiles where fileExists(at: stagedFile.temporaryURL) {
-            let failure = switch stagedFile.kind {
-            case .generated:
-                recoveryFailure(
-                    "Failed to remove staged file \(stagedFile.temporaryURL.path)",
-                    operation: { try FileManager.default.removeItem(at: stagedFile.temporaryURL) }
-                )
-            case .preserved:
-                recoveryFailure(
-                    "Failed to restore preserved file \(stagedFile.finalURL.path) from " +
-                        stagedFile.temporaryURL.path,
-                    operation: {
-                        try FileManager.default.createDirectory(
-                            at: stagedFile.finalURL.deletingLastPathComponent(),
-                            withIntermediateDirectories: true
-                        )
-                        try FileManager.default.moveItem(
-                            at: stagedFile.temporaryURL,
-                            to: stagedFile.finalURL
-                        )
-                    }
-                )
-            }
-            if let failure {
+            if let failure = recoveryFailure(
+                "Failed to remove staged file \(stagedFile.temporaryURL.path)",
+                operation: { try FileManager.default.removeItem(at: stagedFile.temporaryURL) }
+            ) {
                 failures.append(failure)
             }
         }

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -64,14 +64,13 @@ struct SchemaWriter {
             guard case .scalar(let scalar) = type else { continue }
             let filename = "\(scalar.ast.name).graphqls.swift"
             let url = scalarsDir.appending(path: filename, directoryHint: .notDirectory)
-            guard !FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else {
-                // Will not overwrite existing scalar file
-                fileOutput.save(at: url)
-                continue
-            }
             var file = SwiftFileWriter()
             file.setHeader(configuration.output.schema.scalars.header)
-            file.setImports(configuration.output.schema.scalars.importedModules)
+            var importedModules = configuration.output.schema.scalars.importedModules
+            if let module = configuration.output.schema.scalars.scalarMapping[scalar.ast.name]?.module {
+                importedModules.append(module.name)
+            }
+            file.setImports(importedModules)
             file.addType(SchemaScalarBuilder(scalar: scalar))
             try file.write(to: url, configuration: configuration, using: fileOutput)
         }

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
@@ -13,7 +13,12 @@ struct SchemaScalarBuilder: SwiftTypeBuildable {
         }
         let isPublic = configuration.output.schema.accessLevel == .public
         let typeName = SwiftTypeIdentifier(swiftName: scalar.ast.name).source
-        lines.append("\(isPublic ? "public " : "")typealias \(typeName) = String")
+        let scalarMapping = configuration.output.schema.scalars.scalarMapping[scalar.ast.name]
+        var mappedType = scalarMapping?.typeName ?? "String"
+        if let module = scalarMapping?.module, module.prefix {
+            mappedType = "\(module.name).\(mappedType)"
+        }
+        lines.append("\(isPublic ? "public " : "")typealias \(typeName) = \(mappedType)")
         return lines
     }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
@@ -16,6 +16,9 @@ struct SwiftFileWriter {
             lines.append(contentsOf: type.build(configuration: configuration))
             lines.append("")
         }
+        if let lastLine = lines.last, lastLine.isEmpty {
+            lines.removeLast()
+        }
         try fileOutput.write(lines, to: file)
     }
 

--- a/StarwarsExample/client/Codegen/Sources/Codegen.swift
+++ b/StarwarsExample/client/Codegen/Sources/Codegen.swift
@@ -25,6 +25,11 @@ enum StarwarsCodegen {
                 output: .output(
                     schema: .schema(
                         directory: sourceDirectory.appending(path: "Schema", directoryHint: .isDirectory),
+                        scalars: .scalars(
+                            scalarMapping: [
+                                "ID": .scalar(typeName: "String", module: .module(name: "Swift", prefix: true)),
+                            ]
+                        ),
                         enums: .enums(caseConversion: .conversion(from: .macro, to: .lowerCamel)),
                         accessLevel: .public
                     ),

--- a/StarwarsExample/client/Packages/GraphQL/Operations/FavoriteEpisodeChangedSubscription.graphql.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Operations/FavoriteEpisodeChangedSubscription.graphql.swift
@@ -21,4 +21,3 @@ public struct FavoriteEpisodeChangedSubscription: GraphQLSubscription {
         public let favoriteEpisodeChanged: GraphQLEnum<Episode>
     }
 }
-

--- a/StarwarsExample/client/Packages/GraphQL/Operations/HeroQuery.graphql.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Operations/HeroQuery.graphql.swift
@@ -94,4 +94,3 @@ public struct Character: Decodable, Sendable, Hashable {
 
     public var name: String
 }
-

--- a/StarwarsExample/client/Packages/GraphQL/Operations/SetFavoriteEpisodeMutation.graphql.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Operations/SetFavoriteEpisodeMutation.graphql.swift
@@ -32,4 +32,3 @@ public struct SetFavoriteEpisodeMutation: GraphQLMutation {
         public let setFavoriteEpisode: GraphQLEnum<Episode>
     }
 }
-

--- a/StarwarsExample/client/Packages/GraphQL/Schema/Enums/Episode.graphqls.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Schema/Enums/Episode.graphqls.swift
@@ -5,4 +5,3 @@ public enum Episode: String, Encodable, Sendable {
     case empire = "EMPIRE"
     case jedi = "JEDI"
 }
-

--- a/StarwarsExample/client/Packages/GraphQL/Schema/Scalars/ID.graphqls.swift
+++ b/StarwarsExample/client/Packages/GraphQL/Schema/Scalars/ID.graphqls.swift
@@ -1,5 +1,5 @@
 // @generated
-// Any changes to this file will not be overwritten by future code generation execution.
+import Swift
 
 /// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-public typealias ID = String
+public typealias ID = Swift.String

--- a/Tests/Fixtures/Generated/Operations/NodeQuery.graphql.swift
+++ b/Tests/Fixtures/Generated/Operations/NodeQuery.graphql.swift
@@ -94,4 +94,3 @@ struct EntityFields: Decodable, Sendable, Hashable {
 
     var name: String
 }
-

--- a/Tests/Fixtures/Generated/Operations/SetStateMutation.graphql.swift
+++ b/Tests/Fixtures/Generated/Operations/SetStateMutation.graphql.swift
@@ -32,4 +32,3 @@ struct SetStateMutation: GraphQLMutation {
         let setState: GraphQLEnum<State>
     }
 }
-

--- a/Tests/Fixtures/Generated/Operations/StateChangedSubscription.graphql.swift
+++ b/Tests/Fixtures/Generated/Operations/StateChangedSubscription.graphql.swift
@@ -21,4 +21,3 @@ struct StateChangedSubscription: GraphQLSubscription {
         let stateChanged: GraphQLEnum<State>
     }
 }
-

--- a/Tests/Fixtures/Generated/SchemaTypes/Enums/State.graphqls.swift
+++ b/Tests/Fixtures/Generated/SchemaTypes/Enums/State.graphqls.swift
@@ -5,4 +5,3 @@ enum State: String, Encodable, Sendable {
     case running = "RUNNING"
     case stopped = "STOPPED"
 }
-

--- a/Tests/Fixtures/Generated/SchemaTypes/Scalars/ID.graphqls.swift
+++ b/Tests/Fixtures/Generated/SchemaTypes/Scalars/ID.graphqls.swift
@@ -1,5 +1,4 @@
 // @generated
-// Any changes to this file will not be overwritten by future code generation execution.
 
 /// The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
 typealias ID = String

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -138,18 +138,6 @@ struct GraphQLCodeGeneratorTests {
                 to: operationsDirectory.appending(path: operationFile, directoryHint: .notDirectory)
             )
         }
-        let scalarsDirectory = generatedDirectory.appending(
-            path: "SchemaTypes/Scalars",
-            directoryHint: .isDirectory
-        )
-        try FileManager.default.createDirectory(at: scalarsDirectory, withIntermediateDirectories: true)
-        try FileManager.default.copyItem(
-            at: expectedDirectory.appending(
-                path: "SchemaTypes/Scalars/ID.graphqls.swift",
-                directoryHint: .notDirectory
-            ),
-            to: scalarsDirectory.appending(path: "ID.graphqls.swift", directoryHint: .notDirectory)
-        )
         try await Codegen(
             .configuration(
                 input: .input(

--- a/Tests/Tests/Integration/OutputTransactionTests.swift
+++ b/Tests/Tests/Integration/OutputTransactionTests.swift
@@ -38,7 +38,7 @@ struct OutputTransactionTests {
     }
 
     @Test
-    func preservesCustomScalarSourcesIncludingBuiltInID() async throws {
+    func regeneratesScalarSourcesUsingConfiguredMappings() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
@@ -63,10 +63,36 @@ struct OutputTransactionTests {
         let idSource = "struct ID: Codable, Sendable { let rawValue: String }\n"
         try Data(idSource.utf8).write(to: idScalarURL)
 
-        try await Codegen(configuration(for: fixture)).run()
+        var configuration = configuration(
+            for: fixture,
+            schema: .schema(
+                directory: fixture.output.appending(path: "Schema", directoryHint: .isDirectory),
+                scalars: .scalars(
+                    scalarMapping: ["Custom": .scalar(typeName: "UUID", module: .module(name: "Foundation"))]
+                )
+            )
+        )
+        try await Codegen(configuration).run()
 
-        #expect(try String(contentsOf: customScalarURL, encoding: .utf8) == customSource)
-        #expect(try String(contentsOf: idScalarURL, encoding: .utf8) == idSource)
+        let generatedCustomSource = try String(contentsOf: customScalarURL, encoding: .utf8)
+        let generatedIDSource = try String(contentsOf: idScalarURL, encoding: .utf8)
+        #expect(generatedCustomSource.contains("import Foundation\n"))
+        #expect(generatedCustomSource.contains("typealias Custom = UUID"))
+        #expect(generatedIDSource.contains("typealias ID = String"))
+        #expect(!generatedIDSource.contains("import Foundation\n"))
+
+        configuration.output.schema.scalars.scalarMapping = [
+            "Custom": .scalar(typeName: "URL", module: .module(name: "Foundation", prefix: true)),
+            "ID": .scalar(typeName: "Int"),
+        ]
+        try await Codegen(configuration).run()
+
+        let updatedCustomSource = try String(contentsOf: customScalarURL, encoding: .utf8)
+        let updatedIDSource = try String(contentsOf: idScalarURL, encoding: .utf8)
+        #expect(updatedCustomSource.contains("import Foundation\n"))
+        #expect(updatedCustomSource.contains("typealias Custom = Foundation.URL"))
+        #expect(updatedIDSource.contains("typealias ID = Int"))
+        #expect(!updatedIDSource.contains("import Foundation\n"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Configure generated GraphQL scalar aliases through Scalars.scalarMapping, including per-scalar imports and optional module-qualified type names.
- Regenerate scalar files on every run, remove obsolete preservation transaction paths, and keep Star Wars IDs compatible with existing string-valued responses.
- End generated Swift files with a single newline and update generated fixtures and integration coverage.

## Validation
- swiftlint lint --strict --no-cache --quiet
- git diff --check
- Verified all 14 checked-in generated GraphQL files end with exactly one newline.
- Builds and tests were not run.