### PR TITLE
Preserve unrelated files in GraphQL document output directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,17 @@ an introspection endpoint must expose `__Type.isOneOf`.
 
 ## Output Directory Ownership
 
-When document output is configured as `.directory(URL)`, Codegen assumes exclusive ownership of that directory and may remove all
-of its existing contents before writing the current generated output. Do not store unrelated or independently maintained files in
-that directory. With `.definition` output, Codegen instead removes obsolete files ending in `.graphql.swift` from the configured
-document directories, so do not use that suffix for independently maintained files there.
+For both `.definition` and `.directory(URL)` document output, Codegen removes obsolete files ending in `.graphql.swift` from the
+corresponding document directories while preserving other files. Do not use that suffix for independently maintained files in
+those directories.
 
 Codegen writes all referenced scalar, enum, and input-object declarations to `Schema.swift` inside `Schema.directory`. Each run
 replaces that file while preserving other files in the same directory. Configure the generated file's header and imports through
 `Schema.header` and `Schema.importedModules`.
 
 Codegen writes shared GraphQL infrastructure and optional HTTP networking support to `Support.swift` inside `Support.directory`.
-Each run replaces that file while preserving other files in the same directory. `Schema.directory` and `Support.directory` may
-refer to the same location.
+Each run replaces that file while preserving other files in the same directory. Schema, support, and document output may share
+the same directory.
 
 Configure custom Swift scalar types with `Scalars.scalarMapping`; scalars without a mapping default to `String`. Each mapping can
 specify a module imported by `Schema.swift` and can optionally prefix the mapped type with the module name.

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.swift
@@ -10,8 +10,8 @@ extension Configuration.Output {
 
         /// Places generated Swift documents in a separate directory.
         ///
-        /// Codegen assumes exclusive ownership of this directory and may remove all of its existing contents
-        /// before writing the current generated output. Do not store unrelated or independently maintained files here.
+        /// On each run, Codegen removes obsolete files ending in `.graphql.swift` while preserving other files.
+        /// Do not use that suffix for independently maintained files in this directory.
         case directory(URL)
     }
 
@@ -22,9 +22,8 @@ extension Configuration.Output {
         /// Call this function to create a new `Documents` instance.
         ///
         /// - Parameters:
-        ///   - directory: Where generated document files will be located. A separately configured directory is
-        ///   exclusively owned by Codegen and may have all of its existing contents removed on each run. When files
-        ///   are placed beside their definitions, obsolete files ending in `.graphql.swift` may be removed instead.
+        ///   - directory: Where generated document files will be located. Obsolete files ending in `.graphql.swift`
+        ///   are removed from document output directories while other files are preserved.
         ///   - header: An optional string to include at the top of generated document files.
         ///   - importedModules: A list of modules to import into generated document files.
         ///   Just include the module name, the "import" keyword will be added automatically.

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -77,10 +77,7 @@ struct DocumentsWriter {
 
     func write(using fileOutput: FileOutput) throws {
         try validateOutputURLs()
-        switch configuration.output.documents.directory {
-        case .definition: break
-        case .directory(let url):
-            fileOutput.remove(at: url)
+        if case .directory(let url) = configuration.output.documents.directory {
             fileOutput.createDirectory(at: url)
         }
         for plannedDocument in documentPlans {
@@ -122,15 +119,20 @@ struct DocumentsWriter {
                 try file.write(to: outputURL, configuration: configuration, using: fileOutput)
             }
         }
-        if case .definition = configuration.output.documents.directory {
-            let generated = documentPlans.map { $0.document.outputURL(configuration) }
-            let removed = try previouslyGeneratedFileURLs().subtracting(generated)
-            fileOutput.remove(at: removed)
-        }
+        let generated = documentPlans.map { $0.document.outputURL(configuration) }
+        let removed = try previouslyGeneratedFileURLs().subtracting(generated)
+        fileOutput.remove(at: removed)
     }
 
     private func previouslyGeneratedFileURLs() throws -> Set<URL> {
-        let generatedFileURLs = try configuration.input.documentDirectories
+        let directories: [URL]
+        switch configuration.output.documents.directory {
+        case .definition:
+            directories = configuration.input.documentDirectories
+        case .directory(let directory):
+            directories = [directory]
+        }
+        let generatedFileURLs = try directories
             .sorted { $0.path < $1.path }
             .map(generatedFileURLs(in:))
             .flatMap { $0 }

--- a/Tests/Tests/Integration/OutputTransactionTests.swift
+++ b/Tests/Tests/Integration/OutputTransactionTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct OutputTransactionTests {
     @Test
-    func replacesSeparateDocumentOutputDirectory() async throws {
+    func removesObsoleteGeneratedDocumentsAndPreservesOtherFiles() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
@@ -34,7 +34,7 @@ struct OutputTransactionTests {
         try await Codegen(configuration).run()
 
         #expect(!FileManager.default.fileExists(atPath: generatedDocument.path(percentEncoded: false)))
-        #expect(!FileManager.default.fileExists(atPath: unrelatedFile.path(percentEncoded: false)))
+        #expect(try String(contentsOf: unrelatedFile, encoding: .utf8) == unrelatedContents)
     }
 
     @Test
@@ -72,6 +72,7 @@ struct OutputTransactionTests {
                     scalarMapping: ["Custom": .scalar(typeName: "UUID", module: .module(name: "Foundation"))]
                 )
             ),
+            documentsDirectory: schemaDirectory,
             supportDirectory: schemaDirectory
         )
         try await Codegen(configuration).run()
@@ -96,7 +97,7 @@ struct OutputTransactionTests {
         let generatedFiles = try FileManager.default.contentsOfDirectory(
             atPath: schemaDirectory.path(percentEncoded: false)
         )
-        #expect(generatedFiles.sorted() == ["README.md", "Schema.swift", "Support.swift"])
+        #expect(generatedFiles.sorted() == ["README.md", "Schema.swift", "Support.swift", "Value.graphql.swift"])
 
         configuration.output.schema.scalars.scalarMapping = [
             "Custom": .scalar(typeName: "URL", module: .module(name: "Foundation", prefix: true)),
@@ -152,6 +153,7 @@ struct OutputTransactionTests {
     private func configuration(
         for fixture: Fixture,
         schema: Configuration.Output.Schema? = nil,
+        documentsDirectory: URL? = nil,
         supportDirectory: URL? = nil
     ) -> Configuration {
         .configuration(
@@ -165,7 +167,7 @@ struct OutputTransactionTests {
                 ),
                 documents: .documents(
                     directory: .directory(
-                        fixture.output.appending(path: "Operations", directoryHint: .isDirectory)
+                        documentsDirectory ?? fixture.output.appending(path: "Operations", directoryHint: .isDirectory)
                     )
                 ),
                 support: .support(


### PR DESCRIPTION
## Summary
- Remove only obsolete `.graphql.swift` files from configured document output directories.
- Preserve unrelated files and allow schema, support, and documents to share one output directory.
- Update the documented ownership contract and existing integration coverage.

## Verification
- `git diff --check`
- Builds and tests were not run.