### PR TITLE
Reject duplicate GraphQL document filenames in shared output directories

### DIFF
--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.DocumentOutputLocation.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.DocumentOutputLocation.swift
@@ -10,6 +10,7 @@ extension Configuration.Output {
 
         /// Places generated Swift documents in a separate directory.
         ///
+        /// GraphQL document filenames must be unique across all configured document directories.
         /// On each run, Codegen removes obsolete files ending in `.graphql.swift` while preserving other files.
         /// Do not use that suffix for independently maintained files in this directory.
         case directory(URL)

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -17,15 +17,19 @@ struct DocumentsLoader {
     let graphQLJS: GraphQLJS
 
     func load() throws -> Documents {
-        var documentFiles = try DocumentScanner(
-            directories: configuration.input.documentDirectories
-        ).scan()
+        let excludedSchemaURL: URL?
         if case .SDLSchemaFile(let schemaFileURL) = configuration.input.schemaSource {
-            let standardizedSchemaFileURL = schemaFileURL.standardizedFileURL
-            documentFiles.removeAll { documentFile in
-                documentFile.url.standardizedFileURL == standardizedSchemaFileURL
-            }
+            excludedSchemaURL = schemaFileURL
+        } else {
+            excludedSchemaURL = nil
         }
+        let requiringUniqueFilenames = switch configuration.output.documents.directory {
+        case .definition: false
+        case .directory: true
+        }
+        let documentFiles = try DocumentScanner(
+            directories: configuration.input.documentDirectories
+        ).scan(excluding: excludedSchemaURL, requiringUniqueFilenames: requiringUniqueFilenames)
         var fragmentLookup: [String: Document.Fragment] = [:]
         let parsedDocuments = try parse(
             documentFiles,

--- a/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/Scan/DocumentScanner.swift
@@ -6,18 +6,41 @@ struct DocumentScanner {
         let url: URL
     }
 
-    enum DocumentFileFinderError: Error {
+    enum DocumentFileFinderError: Error, CustomStringConvertible {
+        case duplicateFilename(String, URL, URL)
         case failedToEnumerateDirectory(URL)
+
+        var description: String {
+            switch self {
+            case .duplicateFilename(let filename, let first, let second):
+                """
+                GraphQL document filenames must be unique when using a shared output directory:
+                Filename: \(filename)
+                Sources:
+                \(first.path)
+                \(second.path)
+                """
+            case .failedToEnumerateDirectory(let directory):
+                "Failed to enumerate GraphQL document directory: \(directory.path)"
+            }
+        }
     }
 
     let directories: [URL]
 
-    func scan() throws -> [DocumentFile] {
+    func scan(
+        excluding excludedURL: URL?,
+        requiringUniqueFilenames: Bool
+    ) throws -> [DocumentFile] {
+        let excludedURL = excludedURL?.standardizedFileURL
         var documentByURL: [URL: (document: DocumentFile, sourceRootDepth: Int)] = [:]
         for directory in directories.sorted(by: { $0.path < $1.path }) {
             let sourceRoot = directory.standardizedFileURL.pathComponents
             for url in try scanDirectory(directory) {
                 let standardizedURL = url.standardizedFileURL
+                if let excludedURL, standardizedURL == excludedURL {
+                    continue
+                }
                 let document = DocumentFile(
                     relativePath: standardizedURL.pathComponents
                         .dropFirst(sourceRoot.count)
@@ -29,9 +52,21 @@ struct DocumentScanner {
                 }
             }
         }
-        return documentByURL
+        let documents = documentByURL
             .sorted { $0.key.path < $1.key.path }
             .map(\.value.document)
+        guard requiringUniqueFilenames else {
+            return documents
+        }
+        var documentByFilename: [String: URL] = [:]
+        for document in documents {
+            let filename = document.url.lastPathComponent
+            if let existingDocument = documentByFilename[filename] {
+                throw DocumentFileFinderError.duplicateFilename(filename, existingDocument, document.url)
+            }
+            documentByFilename[filename] = document.url
+        }
+        return documents
     }
 
     private func scanDirectory(_ directory: URL) throws -> [URL] {

--- a/Tests/Tests/Integration/AnonymousOperationTypeNameTests.swift
+++ b/Tests/Tests/Integration/AnonymousOperationTypeNameTests.swift
@@ -68,6 +68,43 @@ struct AnonymousOperationTypeNameTests {
         )
     }
 
+    @Test(arguments: [false, true])
+    func validatesDuplicateDocumentFilenamesOnlyForSharedOutputDirectories(
+        generateBesideDefinitions: Bool
+    ) async throws {
+        let filename = "Value.graphql"
+        let fixture = try makeFixture(documentFileName: filename)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let firstDocument = fixture.operations.appending(path: filename, directoryHint: .notDirectory)
+        try Data("query FirstValue { currentUser }".utf8).write(to: firstDocument)
+        let otherOperations = fixture.root.appending(path: "OtherOperations", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: otherOperations, withIntermediateDirectories: true)
+        let secondDocument = otherOperations.appending(path: filename, directoryHint: .notDirectory)
+        try Data("query SecondValue { currentUser }".utf8).write(to: secondDocument)
+
+        var configuration = configuration(for: fixture)
+        configuration.input.documentDirectories = [fixture.operations, otherOperations]
+        if generateBesideDefinitions {
+            configuration.output.documents.directory = .definition
+            try await Codegen(configuration).run()
+
+            #expect(FileManager.default.fileExists(atPath: firstDocument.appendingPathExtension("swift").path))
+            #expect(FileManager.default.fileExists(atPath: secondDocument.appendingPathExtension("swift").path))
+        } else {
+            do {
+                try await Codegen(configuration).run()
+                Issue.record("Expected duplicate GraphQL document filenames to be rejected")
+            } catch {
+                let description = String(describing: error)
+                #expect(description.contains("GraphQL document filenames must be unique"))
+                #expect(description.contains(filename))
+                #expect(description.contains(firstDocument.path))
+                #expect(description.contains(secondDocument.path))
+            }
+        }
+    }
+
     private func configuration(for fixture: AnonymousOperationFixture) -> Configuration {
         .configuration(
             input: .input(


### PR DESCRIPTION
## Summary

- reject duplicate GraphQL document filenames when generated documents share one output directory
- allow duplicate filenames when generated files remain beside their definitions
- exclude the schema during document scanning and report both conflicting source paths
- cover both document-output modes with an integration test

## Validation

- Strict SwiftLint passed.
- The staged diff passed git diff --check.
- Builds and tests were not run.