### PR TITLE
Add SwiftFormat setup, pre-commit hook, and CI check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 30
     env:
-      MISE_ENABLE_TOOLS: periphery,swiftlint
+      MISE_ENABLE_TOOLS: periphery,swiftformat,swiftlint
 
     steps:
       - uses: actions/checkout@v7
@@ -62,6 +62,11 @@ jobs:
 
       - name: Periphery
         run: mise run periphery -- --format github-actions --relative-results --color never --quiet
+
+      - name: Format
+        run: |
+          mise run format
+          git diff --exit-code
 
       - name: Lint
         run: mise run lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: swiftformat
+        name: Format Swift
+        entry: mise exec -- swiftformat --cache ignore
+        language: system
+        types: [swift]
+        exclude: ^(StarwarsExample/[^/]+/(iOS/GraphQL|Packages/GraphQL)/|Tests/Fixtures/Generated/)

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,37 +1,100 @@
---disable hoistAwait
---disable hoistPatternLet
---disable redundantRawValues
---disable redundantSelf
---disable wrapMultilineStatementBraces
+--exclude .build
+--exclude StarwarsExample/*/iOS/GraphQL
+--exclude StarwarsExample/*/Packages/GraphQL
+--exclude Tests/Fixtures/Generated
+--exclude node_modules
 
---exclude .build,node_modules,StarwarsExample/*/iOS/GraphQL,StarwarsExample/*/Packages/GraphQL,Tests/Fixtures/Generated
-
---enable blankLineAfterImports
---enable isEmpty
---enable noExplicitOwnership
---enable organizeDeclarations
---enable redundantVariable
---enable sortSwitchCases
---enable unusedPrivateDeclarations
---enable wrapEnumCases
---enable wrapLoopBodies
---enable wrapMultilineConditionalAssignment
-
---commas always
---extensionacl on-declarations
---funcattributes prev-line
---guardelse next-line
---header strip
---organizationmode type
---redundanttype inferred
---stripunusedargs closure-only
---typeattributes prev-line
 --markcategories false
+
+--self init-only # redundantSelf
+--import-grouping testable-bottom # sortedImports
+--trailing-commas always # trailingCommas
+--indent 4 #indent
+--ifdef no-indent #indent
+--indent-strings false #indent
+--wrap-arguments before-first # wrapArguments
+--wrap-parameters before-first # wrapArguments
+--wrap-collections before-first # wrapArguments
+--wrap-conditions after-first # wrapArguments
+--wrap-return-type never #wrapArguments
+--wrap-effects never #wrapArguments
+--call-site-paren balanced # wrapArguments
+--wrap-type-aliases before-first # wrapArguments
+--allow-partial-wrapping false # wrapArguments
+--func-attributes prev-line # wrapAttributes
+--computed-var-attributes prev-line # wrapAttributes
+--stored-var-attributes same-line # wrapAttributes
+--complex-attributes prev-line # wrapAttributes
+--type-attributes prev-line # wrapAttributes
+# --wrap-ternary before-operators # wrap
+--wrap-string-interpolation preserve # wrap
+--mark-struct-threshold 20 # organizeDeclarations
+--mark-enum-threshold 20 # organizeDeclarations
+--organize-types class,struct,enum,extension,actor,protocol # organizeDeclarations
+--organizationmode type
 --typeorder beforeMarks,nestedType,staticProperty,staticPropertyWithBody,staticMethod,classPropertyWithBody,classMethod,overriddenProperty,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,instanceLifecycle,overriddenMethod,instanceMethod,swiftUIProperty,swiftUIMethod
---xcodeindentation enabled
---storedvarattrs same-line
---computedvarattrs same-line
---ranges no-space
---wraparguments before-first
---wrapcollections before-first
---wrapparameters before-first
+# --type-body-marks remove #organizeDeclarations (Intentionally disabled)
+--extension-acl on-declarations # extensionAccessControl
+--pattern-let inline # hoistPatternLet
+--property-types inferred # redundantType, propertyTypes
+# --type-blank-lines preserve # blankLinesAtStartOfScope, blankLinesAtEndOfScope (Intentionally disabled)
+--ranges preserve # spaceAroundOperators
+--operator-func no-space # spaceAroundOperators
+--short-optionals always # typeSugar
+--doc-comments preserve # docComments
+# We recommend a max width of 100 but _strictly enforce_ a max width of 130
+--max-width 130 # wrap
+# Rules from airbnb/swift
+--rules anyObjectProtocol
+--rules blankLinesBetweenScopes
+--rules consecutiveSpaces
+--rules consecutiveBlankLines
+--rules duplicateImports
+--rules extensionAccessControl
+--rules environmentEntry
+--rules hoistPatternLet
+--rules indent
+--rules organizeDeclarations
+--rules redundantParens
+--rules redundantReturn
+--rules redundantSelf
+--rules redundantType
+--rules redundantPattern
+--rules redundantGet
+--rules redundantFileprivate
+--rules redundantRawValues
+--rules redundantEquatable
+--rules sortImports
+--rules sortDeclarations
+--rules strongifiedSelf
+--rules trailingCommas
+--rules trailingSpace
+--rules linebreakAtEndOfFile
+--rules typeSugar
+--rules wrap
+# --rules wrapMultilineStatementBraces
+--rules wrapArguments
+--rules wrapAttributes
+--rules wrapEnumCases
+# --rules wrapSwitchCases (Intentionally disabled)
+--rules singlePropertyPerLine
+--rules braces
+--rules redundantClosure
+--rules redundantInit
+--rules redundantVoidReturnType
+--rules redundantOptionalBinding
+--rules redundantInternal
+--rules redundantPublic
+--rules redundantVariable
+--rules unusedArguments
+--rules spaceInsideBrackets
+--rules spaceInsideBraces
+--rules spaceAroundBraces
+--rules spaceInsideParens
+--rules spaceAroundParens
+--rules spaceAroundOperators
+--rules enumNamespaces
+--rules blockComments
+--rules docComments
+--rules blankLinesAtStartOfScope
+--rules blankLinesAtEndOfScope

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,12 +2,15 @@
 --disable hoistPatternLet
 --disable redundantRawValues
 --disable redundantSelf
+--disable wrapMultilineStatementBraces
+
+--exclude .build,node_modules,StarwarsExample/*/iOS/GraphQL,StarwarsExample/*/Packages/GraphQL,Tests/Fixtures/Generated
 
 --enable blankLineAfterImports
 --enable isEmpty
 --enable noExplicitOwnership
 --enable organizeDeclarations
---enable redundantProperty
+--enable redundantVariable
 --enable sortSwitchCases
 --enable unusedPrivateDeclarations
 --enable wrapEnumCases
@@ -26,8 +29,8 @@
 --markcategories false
 --typeorder beforeMarks,nestedType,staticProperty,staticPropertyWithBody,staticMethod,classPropertyWithBody,classMethod,overriddenProperty,swiftUIPropertyWrapper,instanceProperty,instancePropertyWithBody,instanceLifecycle,overriddenMethod,instanceMethod,swiftUIProperty,swiftUIMethod
 --xcodeindentation enabled
---storedvarattrs prev-line
---computedvarattrs prev-line
+--storedvarattrs same-line
+--computedvarattrs same-line
 --ranges no-space
 --wraparguments before-first
 --wrapcollections before-first

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -70,7 +70,6 @@ opt_in_rules:
   - redundant_type_annotation
   - self_binding
   - sorted_first_last
-  - sorted_imports
   - toggle_bool
   - type_contents_order
   - unneeded_parentheses_in_closure_argument

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             ],
             resources: [
                 .copy("Resources/graphql.bundle.js"),
-            ],
+            ]
         ),
         .executableTarget(
             name: "graphql-codegen",

--- a/Plugins/GraphQLCodegenPlugin/GraphQLCodegenPlugin.swift
+++ b/Plugins/GraphQLCodegenPlugin/GraphQLCodegenPlugin.swift
@@ -16,10 +16,10 @@ struct GraphQLCodegenPlugin: BuildToolPlugin {
             excluding: schemaURL,
             requiringUniqueFilenames: true
         )
-        return [
+        return try [
             .buildCommand(
                 displayName: "Generate GraphQL sources for \(target.name)",
-                executable: try context.tool(named: "graphql-codegen").url,
+                executable: context.tool(named: "graphql-codegen").url,
                 arguments: [
                     "--file-configuration",
                     configurationURL.path,

--- a/Sources/GraphQLCodegen/Codegen.swift
+++ b/Sources/GraphQLCodegen/Codegen.swift
@@ -23,8 +23,8 @@ public struct Codegen: Sendable {
     ///
     /// Operation bodies use the document formatting configured for generated operations.
     public func generatePersistedOperationManifestFile(at manifestURL: URL) async throws {
-        let manifest = PersistedOperationManifest(
-            documents: try await prepareInput().documents,
+        let manifest = try PersistedOperationManifest(
+            documents: await prepareInput().documents,
             minifyDocument: configuration.output.documents.operations.minifyDocument
         )
         let encoder = JSONEncoder()

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Enums.CaseConversion.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Enums.CaseConversion.swift
@@ -4,14 +4,15 @@ extension Configuration.Output.Schema.Enums {
     /// If a CaseConversion is used, it must specify `from: .macro` and `to` may be any case.
     /// If `lowerCamel` is used, this codegen would create `case northWest`
     public struct CaseConversion: Sendable {
-        public var from: Case
-        public var to: Case
         public static func conversion(from: Case, to: Case) -> CaseConversion {
             CaseConversion(
                 from: from,
                 to: to
             )
         }
+
+        public var from: Case
+        public var to: Case
 
         func convert(_ value: String) -> String {
             let words = from.words(in: value)

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.Scalar.Module.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.Scalar.Module.swift
@@ -1,9 +1,6 @@
 extension Configuration.Output.Schema.Scalars.Scalar {
     /// A module imported by the generated `Schema.swift` file.
     public struct Module: Sendable {
-        public var name: String
-        public var prefix: Bool
-
         /// Creates a module configuration for a generated scalar declaration.
         ///
         /// - Parameters:
@@ -12,5 +9,8 @@ extension Configuration.Output.Schema.Scalars.Scalar {
         public static func module(name: String, prefix: Bool = false) -> Module {
             Module(name: name, prefix: prefix)
         }
+
+        public var name: String
+        public var prefix: Bool
     }
 }

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.Scalar.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Schema.Scalars.Scalar.swift
@@ -1,9 +1,6 @@
 extension Configuration.Output.Schema.Scalars {
     /// The Swift type and optional module used to represent a GraphQL scalar.
     public struct Scalar: Sendable {
-        public var typeName: String
-        public var module: Module?
-
         /// Creates a Swift type mapping for a GraphQL scalar.
         ///
         /// - Parameters:
@@ -12,5 +9,8 @@ extension Configuration.Output.Schema.Scalars {
         public static func scalar(typeName: String, module: Module? = nil) -> Scalar {
             Scalar(typeName: typeName, module: module)
         }
+
+        public var typeName: String
+        public var module: Module?
     }
 }

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -2,7 +2,7 @@ extension String {
     subscript(utf16Range range: Range<Int>) -> Substring {
         self[
             String.Index(utf16Offset: range.lowerBound, in: self) ..<
-            String.Index(utf16Offset: range.upperBound, in: self)
+                String.Index(utf16Offset: range.upperBound, in: self)
         ]
     }
 

--- a/Sources/GraphQLCodegen/Helpers/String.swift
+++ b/Sources/GraphQLCodegen/Helpers/String.swift
@@ -1,12 +1,12 @@
 extension String {
+    var capitalizedFirst: String {
+        prefix(1).capitalized + dropFirst()
+    }
+
     subscript(utf16Range range: Range<Int>) -> Substring {
         self[
             String.Index(utf16Offset: range.lowerBound, in: self) ..<
                 String.Index(utf16Offset: range.upperBound, in: self)
         ]
-    }
-
-    var capitalizedFirst: String {
-        prefix(1).capitalized + dropFirst()
     }
 }

--- a/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
@@ -6,6 +6,10 @@ struct SwiftTypeIdentifier: Hashable {
 
     let unescaped: String
 
+    var source: String {
+        identifier(unescaped)
+    }
+
     init(capitalizing graphQLName: String) {
         unescaped = graphQLName.capitalizedFirst
     }
@@ -53,9 +57,5 @@ struct SwiftTypeIdentifier: Hashable {
             }
             unescaped = typeName.hasSuffix(operationType) ? typeName : typeName + operationType
         }
-    }
-
-    var source: String {
-        identifier(unescaped)
     }
 }

--- a/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftTypeIdentifier.swift
@@ -11,17 +11,17 @@ struct SwiftTypeIdentifier: Hashable {
     }
 
     init(capitalizing graphQLName: String) {
-        unescaped = graphQLName.capitalizedFirst
+        self.unescaped = graphQLName.capitalizedFirst
     }
 
     init(swiftName: String) {
-        unescaped = swiftName
+        self.unescaped = swiftName
     }
 
     init(operation: Document.Operation, in document: Document) throws {
         let operationType = operation.ast.operation.rawValue.capitalizedFirst
         if let name = operation.ast.name {
-            unescaped = name.value + operationType
+            self.unescaped = name.value + operationType
         } else {
             let operationCount = document.definitions.count { definition in
                 switch definition {
@@ -55,7 +55,7 @@ struct SwiftTypeIdentifier: Hashable {
             if typeName.first?.isNumber == true {
                 typeName = "_" + typeName
             }
-            unescaped = typeName.hasSuffix(operationType) ? typeName : typeName + operationType
+            self.unescaped = typeName.hasSuffix(operationType) ? typeName : typeName + operationType
         }
     }
 }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -84,6 +84,12 @@ enum GraphQLAST {
         case fragmentSpread(FragmentSpread)
         case inlineFragment(InlineFragment)
 
+        private enum Kind: String, Decodable {
+            case Field
+            case FragmentSpread
+            case InlineFragment
+        }
+
         var hasOptionalDirective: Bool {
             directives.contains {
                 $0.name.value == "skip" || $0.name.value == "include"
@@ -96,12 +102,6 @@ enum GraphQLAST {
             case .fragmentSpread(let fragmentSpread): fragmentSpread.directives ?? []
             case .inlineFragment(let inlineFragment): inlineFragment.directives ?? []
             }
-        }
-
-        private enum Kind: String, Decodable {
-            case Field
-            case FragmentSpread
-            case InlineFragment
         }
 
         init(from decoder: Decoder) throws {
@@ -344,10 +344,10 @@ enum GraphQLAST {
         var typeName: SourceTypeName {
             switch self {
             case .named(let namedType): return .optional(
-                .name(
-                    SourceTypeName(nativeGraphQLScalarName: namedType.name.value)?.formatted() ?? namedType.name.value
+                    .name(
+                        SourceTypeName(nativeGraphQLScalarName: namedType.name.value)?.formatted() ?? namedType.name.value
+                    )
                 )
-            )
             case .list(let innerType): return .optional(.list(innerType.type.typeName))
             case .nonNull(let innerType): return innerType.type.typeName
             }

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLJS.swift
@@ -39,7 +39,7 @@ struct GraphQLJS {
             return .failure(.bundleResourceMissing)
         }
         do {
-            return .success(try String(contentsOf: url, encoding: .utf8))
+            return try .success(String(contentsOf: url, encoding: .utf8))
         } catch {
             return .failure(.bundleReadFailed(url, String(describing: error)))
         }
@@ -60,7 +60,8 @@ struct GraphQLJS {
         guard let library = context.objectForKeyedSubscript("GraphQL"),
               library.isObject,
               !library.isNull,
-              !library.isUndefined else {
+              !library.isUndefined
+        else {
             throw Error.missingExport("GraphQL")
         }
         self.context = context
@@ -87,8 +88,8 @@ struct GraphQLJS {
         schemaJSON: String,
         argumentsOnly: Bool
     ) throws -> Data {
-        Data(
-            try stringResult(
+        try Data(
+            stringResult(
                 function: "findDeprecatedUsages",
                 arguments: [sourceTexts, schemaJSON, argumentsOnly]
             ).utf8
@@ -96,12 +97,12 @@ struct GraphQLJS {
     }
 
     func parse(_ sourceText: String) throws -> Data {
-        Data(try stringResult(function: "parseGraphQL", arguments: [sourceText]).utf8)
+        try Data(stringResult(function: "parseGraphQL", arguments: [sourceText]).utf8)
     }
 
     func validate(_ sourceTexts: [String], schemaJSON: String) throws -> Data {
-        Data(
-            try stringResult(
+        try Data(
+            stringResult(
                 function: "validateDocuments",
                 arguments: [sourceTexts, schemaJSON]
             ).utf8
@@ -112,7 +113,8 @@ struct GraphQLJS {
         guard let function = library.objectForKeyedSubscript(name),
               function.isObject,
               !function.isNull,
-              !function.isUndefined else {
+              !function.isUndefined
+        else {
             throw Error.missingExport(name)
         }
         context.exception = nil
@@ -128,21 +130,24 @@ struct GraphQLJS {
         }
         guard let statusValue = result.objectForKeyedSubscript("status"),
               statusValue.isString,
-              let status = statusValue.toString() else {
+              let status = statusValue.toString()
+        else {
             throw Error.unexpectedResult(function: name, expected: "an outcome status")
         }
         switch status {
         case "success":
             guard let value = result.objectForKeyedSubscript("value"),
                   value.isString,
-                  let string = value.toString() else {
+                  let string = value.toString()
+            else {
                 throw Error.unexpectedResult(function: name, expected: "a string value")
             }
             return string
         case "invalidInput":
             guard let messageValue = result.objectForKeyedSubscript("message"),
                   messageValue.isString,
-                  let message = messageValue.toString() else {
+                  let message = messageValue.toString()
+            else {
                 throw Error.unexpectedResult(function: name, expected: "an input error message")
             }
             throw Error.inputRejected(function: name, message: message)

--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -23,10 +23,11 @@ struct DocumentsLoader {
         } else {
             excludedSchemaURL = nil
         }
-        let requiringUniqueFilenames = switch configuration.output.documents.directory {
-        case .definition: false
-        case .directory: true
-        }
+        let requiringUniqueFilenames =
+            switch configuration.output.documents.directory {
+            case .definition: false
+            case .directory: true
+            }
         let documentFiles = try DocumentScanner(
             directories: configuration.input.documentDirectories
         ).scan(excluding: excludedSchemaURL, requiringUniqueFilenames: requiringUniqueFilenames)

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionQuery.swift
@@ -4,7 +4,7 @@ struct IntrospectionQuery: Encodable {
     let query: String
 
     init() {
-        query = """
+        self.query = """
         query IntrospectionQuery {
           __schema {
             description

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -360,7 +360,7 @@ extension __Schema.__Field {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: IntrospectionDeprecationCodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
         args = try container.decode([__Schema.__InputValue].self, forKey: .args)
         type = try container.decode(__Schema.__TypeRef.self, forKey: .type)
         deprecation = try Deprecation(introspection: decoder)
@@ -371,7 +371,7 @@ extension __Schema.__EnumValue {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: IntrospectionDeprecationCodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
         deprecation = try Deprecation(introspection: decoder)
     }
 }
@@ -380,7 +380,7 @@ extension __Schema.__InputValue {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: IntrospectionDeprecationCodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
-        description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
         type = try container.decode(__Schema.__TypeRef.self, forKey: .type)
         defaultValue = try container.decodeIfPresent(String.self, forKey: .defaultValue)
         deprecation = try Deprecation(introspection: decoder)

--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/__Schema.swift
@@ -47,7 +47,7 @@ struct __Schema: Decodable {
         }
 
         struct Enum: Decodable {
-            private static let typeSystemEnums: Set<String> = ["__TypeKind", "__DirectiveLocation"]
+            private static let typeSystemEnums: Set = ["__TypeKind", "__DirectiveLocation"]
 
             let description: String?
             let name: String

--- a/Sources/GraphQLCodegen/Input/Schema/Schema.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Schema.swift
@@ -2,11 +2,6 @@ import Foundation
 import OrderedCollections
 
 struct Schema {
-    let queryTypeRef: __Schema.__TypeRef.Object
-    let mutationTypeRef: __Schema.__TypeRef.Object?
-    let subscriptionTypeRef: __Schema.__TypeRef.Object?
-    let typeCache: TypeCache
-
     struct Object {
         let ast: __Schema.__NamedType.Object
         let fields: [String: __Schema.__Field]
@@ -71,6 +66,9 @@ struct Schema {
     }
 
     indirect enum Field {
+        case nullable(Value)
+        case nonNull(Value)
+
         indirect enum Value {
             case SCALAR(Scalar)
             case OBJECT(Object)
@@ -79,12 +77,12 @@ struct Schema {
             case ENUM(Enum)
             case LIST(Field)
         }
-
-        case nullable(Value)
-        case nonNull(Value)
     }
 
     indirect enum Input {
+        case nullable(Value)
+        case nonNull(Value)
+
         indirect enum Value {
             case SCALAR(Scalar)
             case ENUM(Enum)
@@ -92,15 +90,17 @@ struct Schema {
             case LIST(Input)
         }
 
-        case nullable(Value)
-        case nonNull(Value)
-
         var value: Value {
             switch self {
-            case .nullable(let value), .nonNull(let value): value
+            case .nonNull(let value), .nullable(let value): value
             }
         }
     }
+
+    let queryTypeRef: __Schema.__TypeRef.Object
+    let mutationTypeRef: __Schema.__TypeRef.Object?
+    let subscriptionTypeRef: __Schema.__TypeRef.Object?
+    let typeCache: TypeCache
 
     func queryType() throws -> Object {
         try type(queryTypeRef)
@@ -133,37 +133,6 @@ struct Schema {
 
     func fieldType(_ type: __Schema.__Field) throws -> Field {
         try fieldType(type.type)
-    }
-
-    private func fieldType(_ typeRef: __Schema.__TypeRef) throws -> Field {
-        switch typeRef {
-        case .SCALAR(let scalar): .nullable(.SCALAR(try type(scalar)))
-        case .ENUM(let `enum`): .nullable(.ENUM(try type(`enum`)))
-        case .OBJECT(let objectType): .nullable(.OBJECT(try type(objectType)))
-        case .INTERFACE(let interfaceType): .nullable(.INTERFACE(try type(interfaceType)))
-        case .UNION(let unionType): .nullable(.UNION(try type(unionType)))
-        case .LIST(let ofType): .nullable(.LIST(try fieldType(ofType)))
-        case .NON_NULL(let ofType): .nonNull(try fieldValue(ofType))
-        case .INPUT_OBJECT:
-            throw Codegen.Error(description: """
-            Selected a field \(typeRef) whose type is an input object.
-            Input objects are not supported as field types
-            https://spec.graphql.org/September2025/#sec-Input-Objects.Result-Coercion
-            """)
-        }
-    }
-
-    private func fieldValue(_ typeRef: __Schema.__NullableTypeRef) throws -> Field.Value {
-        switch typeRef {
-        case .SCALAR(let scalar): .SCALAR(try type(scalar))
-        case .ENUM(let `enum`): .ENUM(try type(`enum`))
-        case .OBJECT(let objectType): .OBJECT(try type(objectType))
-        case .INTERFACE(let interfaceType): .INTERFACE(try type(interfaceType))
-        case .UNION(let unionType): .UNION(try type(unionType))
-        case .LIST(let ofType): .LIST(try fieldType(ofType))
-        case .INPUT_OBJECT:
-            throw Codegen.Error(description: "Invalid output type \(typeRef)")
-        }
     }
 
     func isFragment(
@@ -199,6 +168,45 @@ struct Schema {
         try fragmentType(definition.typeCondition)
     }
 
+    func inputType(_ variableDefinition: GraphQLAST.VariableDefinition) throws -> Input {
+        try inputType(variableDefinition.type)
+    }
+
+    func inputType(_ inputValue: __Schema.__InputValue) throws -> Input {
+        try inputType(inputValue.type)
+    }
+
+    private func fieldType(_ typeRef: __Schema.__TypeRef) throws -> Field {
+        switch typeRef {
+        case .SCALAR(let scalar): try .nullable(.SCALAR(type(scalar)))
+        case .ENUM(let `enum`): try .nullable(.ENUM(type(`enum`)))
+        case .OBJECT(let objectType): try .nullable(.OBJECT(type(objectType)))
+        case .INTERFACE(let interfaceType): try .nullable(.INTERFACE(type(interfaceType)))
+        case .UNION(let unionType): try .nullable(.UNION(type(unionType)))
+        case .LIST(let ofType): try .nullable(.LIST(fieldType(ofType)))
+        case .NON_NULL(let ofType): try .nonNull(fieldValue(ofType))
+        case .INPUT_OBJECT:
+            throw Codegen.Error(description: """
+            Selected a field \(typeRef) whose type is an input object.
+            Input objects are not supported as field types
+            https://spec.graphql.org/September2025/#sec-Input-Objects.Result-Coercion
+            """)
+        }
+    }
+
+    private func fieldValue(_ typeRef: __Schema.__NullableTypeRef) throws -> Field.Value {
+        switch typeRef {
+        case .SCALAR(let scalar): try .SCALAR(type(scalar))
+        case .ENUM(let `enum`): try .ENUM(type(`enum`))
+        case .OBJECT(let objectType): try .OBJECT(type(objectType))
+        case .INTERFACE(let interfaceType): try .INTERFACE(type(interfaceType))
+        case .UNION(let unionType): try .UNION(type(unionType))
+        case .LIST(let ofType): try .LIST(fieldType(ofType))
+        case .INPUT_OBJECT:
+            throw Codegen.Error(description: "Invalid output type \(typeRef)")
+        }
+    }
+
     private func fragmentType(_ type: GraphQLAST.NamedType) throws -> SelectionSet {
         let name = type.name.value
         if let objectType = typeCache.objects[name] {
@@ -216,26 +224,18 @@ struct Schema {
         }
     }
 
-    func inputType(_ variableDefinition: GraphQLAST.VariableDefinition) throws -> Input {
-        try inputType(variableDefinition.type)
-    }
-
-    func inputType(_ inputValue: __Schema.__InputValue) throws -> Input {
-        try inputType(inputValue.type)
-    }
-
     private func inputType(_ typeNode: GraphQLAST.TypeNode) throws -> Input {
         switch typeNode {
-        case .named(let namedType): .nullable(try inputValue(namedType))
-        case .list(let listType): .nullable(.LIST(try inputType(listType.type)))
-        case .nonNull(let nonNullType): .nonNull(try inputValue(nonNullType.type))
+        case .named(let namedType): try .nullable(inputValue(namedType))
+        case .list(let listType): try .nullable(.LIST(inputType(listType.type)))
+        case .nonNull(let nonNullType): try .nonNull(inputValue(nonNullType.type))
         }
     }
 
     private func inputValue(_ typeNode: GraphQLAST.NullableTypeNode) throws -> Input.Value {
         switch typeNode {
         case .named(let namedType): try inputValue(namedType)
-        case .list(let listType): .LIST(try inputType(listType.type))
+        case .list(let listType): try .LIST(inputType(listType.type))
         }
     }
 
@@ -254,21 +254,21 @@ struct Schema {
 
     private func inputType(_ typeRef: __Schema.__TypeRef) throws -> Input {
         switch typeRef {
-        case .SCALAR(let scalar): .nullable(.SCALAR(try type(scalar)))
-        case .ENUM(let `enum`): .nullable(.ENUM(try type(`enum`)))
-        case .INPUT_OBJECT(let inputObject): .nullable(.INPUT_OBJECT(try type(inputObject)))
-        case .LIST(let ofType): .nullable(.LIST(try inputType(ofType)))
-        case .NON_NULL(let ofType): .nonNull(try inputValue(ofType))
+        case .SCALAR(let scalar): try .nullable(.SCALAR(type(scalar)))
+        case .ENUM(let `enum`): try .nullable(.ENUM(type(`enum`)))
+        case .INPUT_OBJECT(let inputObject): try .nullable(.INPUT_OBJECT(type(inputObject)))
+        case .LIST(let ofType): try .nullable(.LIST(inputType(ofType)))
+        case .NON_NULL(let ofType): try .nonNull(inputValue(ofType))
         case .INTERFACE, .OBJECT, .UNION: throw Codegen.Error(description: "Invalid Input Type \(typeRef)")
         }
     }
 
     private func inputValue(_ typeRef: __Schema.__NullableTypeRef) throws -> Input.Value {
         switch typeRef {
-        case .SCALAR(let scalar): .SCALAR(try type(scalar))
-        case .ENUM(let `enum`): .ENUM(try type(`enum`))
-        case .INPUT_OBJECT(let inputObject): .INPUT_OBJECT(try type(inputObject))
-        case .LIST(let ofType): .LIST(try inputType(ofType))
+        case .SCALAR(let scalar): try .SCALAR(type(scalar))
+        case .ENUM(let `enum`): try .ENUM(type(`enum`))
+        case .INPUT_OBJECT(let inputObject): try .INPUT_OBJECT(type(inputObject))
+        case .LIST(let ofType): try .LIST(inputType(ofType))
         case .INTERFACE, .OBJECT, .UNION:
             throw Codegen.Error(description: "Invalid input type \(typeRef)")
         }

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaCoordinate.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaCoordinate.swift
@@ -1,4 +1,4 @@
-// https://spec.graphql.org/September2025/#sec-Schema-Coordinates
+/// https://spec.graphql.org/September2025/#sec-Schema-Coordinates
 enum SchemaCoordinate: CustomStringConvertible {
     case argument(type: String, field: String, argument: String)
     case directive(String)

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -57,7 +57,7 @@ struct TypeCache {
     var inputObjects: [String: Schema.InputObject] = [:]
 
     init(_ cache: TypeASTCache) {
-        scalars = cache.scalars.mapValues { Schema.Scalar(ast: $0) }
+        self.scalars = cache.scalars.mapValues { Schema.Scalar(ast: $0) }
         for (name, ast) in cache.objects {
             objects[name] = Schema.Object(
                 ast: ast,
@@ -78,8 +78,8 @@ struct TypeCache {
                 possibleTypes: Set(ast.possibleTypes.map(\.name))
             )
         }
-        enums = cache.enums.mapValues { Schema.Enum(ast: $0) }
-        inputObjects = cache.inputObjects.mapValues { Schema.InputObject(ast: $0) }
+        self.enums = cache.enums.mapValues { Schema.Enum(ast: $0) }
+        self.inputObjects = cache.inputObjects.mapValues { Schema.InputObject(ast: $0) }
     }
 }
 

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -10,8 +10,8 @@ private struct LoadedIntrospection {
     let schemaJSON: String
 }
 
-// Type names are guaranteed to be unique
-// https://spec.graphql.org/September2025/#sel-DAHTCKBDLA5BotN
+/// Type names are guaranteed to be unique
+/// https://spec.graphql.org/September2025/#sel-DAHTCKBDLA5BotN
 struct TypeASTCache {
     var scalars: [String: __Schema.__NamedType.Scalar] = [:]
     var objects: [String: __Schema.__NamedType.Object] = [:]
@@ -19,6 +19,7 @@ struct TypeASTCache {
     var unions: [String: __Schema.__NamedType.Union] = [:]
     var enums: [String: __Schema.__NamedType.Enum] = [:]
     var inputObjects: [String: __Schema.__NamedType.InputObject] = [:]
+
     init(_ schema: __Schema) {
         for type in schema.types {
             switch type {
@@ -37,7 +38,8 @@ struct TypeASTCache {
         var remaining = directInterfaces.map(\.name)
         while let name = remaining.popLast() {
             guard inherited.insert(name).inserted,
-                  let interface = interfaces[name] else {
+                  let interface = interfaces[name]
+            else {
                 continue
             }
             remaining.append(contentsOf: interface.interfaces.map(\.name))
@@ -128,22 +130,23 @@ struct SchemaLoader {
         ).run()
         let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
         guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let schemaObject = response["data"] else {
+              let schemaObject = response["data"]
+        else {
             throw Codegen.Error(description: "The introspection endpoint returned an invalid GraphQL response.")
         }
         let schemaJSON = try JSONSerialization.data(withJSONObject: schemaObject)
-        return LoadedIntrospection(
+        return try LoadedIntrospection(
             schema: __schema,
-            schemaJSON: try decodeUTF8(schemaJSON, source: endpoint)
+            schemaJSON: decodeUTF8(schemaJSON, source: endpoint)
         )
     }
 
     private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> LoadedIntrospection {
         let data = try Data(contentsOf: schemaFile)
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: data).__schema
-        return LoadedIntrospection(
+        return try LoadedIntrospection(
             schema: __schema,
-            schemaJSON: try decodeUTF8(data, source: schemaFile)
+            schemaJSON: decodeUTF8(data, source: schemaFile)
         )
     }
 

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -111,7 +111,7 @@ extension SwiftStructBuilder {
                         field: responseKey,
                         fragmentSpread: fragmentSpread
                     )
-                case .selectionSetNeedsTypename, .none: throw error
+                case .none, .selectionSetNeedsTypename: throw error
                 }
             }
             addNestedType(nestedStruct)

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -2,10 +2,6 @@ import Foundation
 import OrderedCollections
 
 struct DocumentsWriter {
-    private enum GeneratedFileFinderError: Error {
-        case failedToEnumerateDirectory(URL)
-    }
-
     enum DefinitionPlan {
         case fragment(
             ResolvedFragment,
@@ -26,8 +22,16 @@ struct DocumentsWriter {
         let definitions: [DefinitionPlan]
     }
 
+    private enum GeneratedFileFinderError: Error {
+        case failedToEnumerateDirectory(URL)
+    }
+
     let configuration: Configuration
     let documentPlans: [DocumentPlan]
+
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        documentPlans.flatMap(\.definitions).map(\.declaration)
+    }
 
     init(configuration: Configuration, resolvedDocuments: ResolvedDocuments) throws {
         var documentPlans: [DocumentPlan] = []
@@ -36,8 +40,8 @@ struct DocumentsWriter {
             for definition in resolvedDocument.resolvedDefinitions {
                 switch definition {
                 case .operation(let operation):
-                    let declaration = GeneratedTypeDeclaration(
-                        name: try SwiftTypeIdentifier(
+                    let declaration = try GeneratedTypeDeclaration(
+                        name: SwiftTypeIdentifier(
                             operation: operation.operation,
                             in: resolvedDocument.document
                         ),
@@ -71,10 +75,6 @@ struct DocumentsWriter {
         self.documentPlans = documentPlans
     }
 
-    var topLevelDeclarations: [GeneratedTypeDeclaration] {
-        documentPlans.flatMap(\.definitions).map(\.declaration)
-    }
-
     func write(using fileOutput: FileOutput) throws {
         try validateOutputURLs()
         if case .directory(let url) = configuration.output.documents.directory {
@@ -99,8 +99,8 @@ struct DocumentsWriter {
                     let includesSelectionSet,
                     let declaration
                 ):
-                    file.addType(
-                        try buildFragment(
+                    try file.addType(
+                        buildFragment(
                             resolvedFragment,
                             typeName: declaration.name,
                             includesSelectionSet: includesSelectionSet,

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -124,7 +124,7 @@ final class FileOutput {
         }
 
         for directory in commitState.createdDirectories.sorted(by: pathOrder).reversed()
-        where fileExists(at: directory) {
+            where fileExists(at: directory) {
             if let failure = recoveryFailure(
                 "Failed to remove created directory \(directory.path)",
                 operation: { try FileManager.default.removeItem(at: directory) }

--- a/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifest.swift
+++ b/Sources/GraphQLCodegen/Output/PersistedOperations/PersistedOperationManifest.swift
@@ -9,6 +9,20 @@ public struct PersistedOperationManifest: Codable, Sendable {
         public let type: String
     }
 
+    private static func hash(_ sourceText: String) -> String {
+        let digits = Array("0123456789abcdef".utf8)
+        let capacity = 2 * SHA256.Digest.byteCount
+        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
+            var index = 0
+            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
+                buffer[index] = digits[Int(byte >> 4)]
+                buffer[index + 1] = digits[Int(byte & 0x0F)]
+                index += 2
+            }
+            return capacity
+        }
+    }
+
     public let format: String
     public let version: Int
     public var operations: [Operation]
@@ -30,19 +44,5 @@ public struct PersistedOperationManifest: Codable, Sendable {
                     type: operation.ast.operation.rawValue
                 )
             }
-    }
-
-    private static func hash(_ sourceText: String) -> String {
-        let digits = Array("0123456789abcdef".utf8)
-        let capacity = 2 * SHA256.Digest.byteCount
-        return String(unsafeUninitializedCapacity: capacity) { buffer -> Int in
-            var index = 0
-            for byte in SHA256.hash(data: Data(sourceText.utf8)) {
-                buffer[index] = digits[Int(byte >> 4)]
-                buffer[index + 1] = digits[Int(byte & 0x0F)]
-                index += 2
-            }
-            return capacity
-        }
     }
 }

--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -20,6 +20,15 @@ struct SchemaWriter {
     let indirectOneOfInputObjectFields: [String: Set<String>]
     let typePlans: [TypePlan]
 
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        typePlans.map { type in
+            GeneratedTypeDeclaration(
+                name: SwiftTypeIdentifier(swiftName: type.name),
+                origin: .schema(.type(type.name))
+            )
+        }
+    }
+
     init(configuration: Configuration, schema: Schema, resolvedDocuments: ResolvedDocuments) {
         self.configuration = configuration
         self.indirectOneOfInputObjectFields = resolvedDocuments.indirectOneOfInputObjectFields
@@ -31,15 +40,6 @@ struct SchemaWriter {
                 return `enum`.ast.isSystemType ? nil : .enum(`enum`)
             }
             return schema.typeCache.inputObjects[name].map(TypePlan.inputObject)
-        }
-    }
-
-    var topLevelDeclarations: [GeneratedTypeDeclaration] {
-        typePlans.map { type in
-            GeneratedTypeDeclaration(
-                name: SwiftTypeIdentifier(swiftName: type.name),
-                origin: .schema(.type(type.name))
-            )
         }
     }
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -12,6 +12,17 @@ struct DefaultEncodersWriter: SupportOutput {
         return typeNames
     }
 
+    var source: String {
+        switch plan.mode {
+        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
+        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
+        case .getWithoutPersistence: getWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
+        case .postWithoutPersistence: postWithNoPersistedOperations()
+        }
+    }
+
     private var persistedOperationHashSource: String {
         """
         private func persistedOperationHash(_ document: String) -> String {
@@ -88,17 +99,6 @@ struct DefaultEncodersWriter: SupportOutput {
     private var registeredOperationArgument: String {
         guard plan.allowsUnregisteredOperations else { return "" }
         return ", useRegisteredOperation: useRegisteredOperation"
-    }
-
-    var source: String {
-        switch plan.mode {
-        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
-        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
-        case .getWithoutPersistence: getWithNoPersistedOperations()
-        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
-        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
-        case .postWithoutPersistence: postWithNoPersistedOperations()
-        }
     }
 
     private func getWithAutomaticPersistedOperations() -> String {

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
@@ -15,10 +15,6 @@ struct EncodersWriter: SupportOutput {
         return typeNames
     }
 
-    private var includeSubscriptionSupport: Bool {
-        plan.includesSubscriptions
-    }
-
     var source: String {
         switch plan.mode {
         case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
@@ -28,6 +24,10 @@ struct EncodersWriter: SupportOutput {
         case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
         case .postWithoutPersistence: postWithNoPersistedOperations()
         }
+    }
+
+    private var includeSubscriptionSupport: Bool {
+        plan.includesSubscriptions
     }
 
     private func getWithAutomaticPersistedOperations() -> String {

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
@@ -4,6 +4,7 @@ struct GraphQLOperationWriter: SupportOutput {
     let configuration: Configuration
     let hasMutation: Bool
     let hasSubscription: Bool
+
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [
             SwiftTypeIdentifier(swiftName: "GraphQLOperation"),

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -3,20 +3,13 @@ import Foundation
 struct GraphQLRequestWriter: SupportOutput {
     let plan: HTTPGenerationPlan
     let configuration: Configuration
+
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "GraphQLRequest")]
         if case .automatic = plan.persistence {
             typeNames.append(SwiftTypeIdentifier(swiftName: "PersistedOperationRetry"))
         }
         return typeNames
-    }
-
-    private var includeSubscriptionSupport: Bool {
-        plan.includesSubscriptions
-    }
-
-    private var enableGETQueries: Bool {
-        plan.enablesGETQueries
     }
 
     var source: String {
@@ -28,6 +21,14 @@ struct GraphQLRequestWriter: SupportOutput {
         case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
         case .postWithoutPersistence: postWithNoPersistedOperations()
         }
+    }
+
+    private var includeSubscriptionSupport: Bool {
+        plan.includesSubscriptions
+    }
+
+    private var enableGETQueries: Bool {
+        plan.enablesGETQueries
     }
 
     private func requestDeclaration() -> String {
@@ -138,7 +139,7 @@ struct GraphQLRequestWriter: SupportOutput {
                 /// The retry configuration for an unknown persisted operation.
                 let persistedOperationRetry: PersistedOperationRetry?
             """
-        case .registered, .none:
+        case .none, .registered:
             ""
         }
     }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
@@ -5,10 +5,6 @@ struct URLSessionWriter: SupportOutput {
     let configuration: Configuration
     let topLevelTypeNames: [SwiftTypeIdentifier] = []
 
-    private var includeSubscriptionSupport: Bool {
-        hasSubscription && configuration.output.support.HTTPSupport?.subscriptionSupport == true
-    }
-
     var source: String {
         """
         /// Defaults conform to https://graphql.github.io/graphql-over-http/draft/
@@ -54,6 +50,10 @@ struct URLSessionWriter: SupportOutput {
         """
     }
 
+    private var includeSubscriptionSupport: Bool {
+        hasSubscription && configuration.output.support.HTTPSupport?.subscriptionSupport == true
+    }
+
     private func requestErrorHandling() -> String {
         switch configuration.output.support.HTTPSupport?.persistedOperations {
         case .automatic:
@@ -74,7 +74,7 @@ struct URLSessionWriter: SupportOutput {
                         }
                         throw requestError
             """
-        case .registered, .none:
+        case .none, .registered:
             "case .requestError(let requestError): throw requestError"
         }
     }
@@ -352,7 +352,7 @@ struct URLSessionWriter: SupportOutput {
                                             // TODO: Support automatic persisted operation fallback for subscriptions.
                                             throw requestError
             """
-        case .registered, .none:
+        case .none, .registered:
             "case .requestError(let requestError): throw requestError"
         }
     }

--- a/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
@@ -5,6 +5,15 @@ struct SupportWriter {
 
     private let outputs: [any SupportOutput]
 
+    var topLevelDeclarations: [GeneratedTypeDeclaration] {
+        outputs.flatMap(\.topLevelTypeNames).map { typeName in
+            GeneratedTypeDeclaration(
+                name: typeName,
+                origin: .support(typeName.unescaped)
+            )
+        }
+    }
+
     init(
         configuration: Configuration,
         hasMutation: Bool,
@@ -43,15 +52,6 @@ struct SupportWriter {
         }
         self.configuration = configuration
         self.outputs = outputs
-    }
-
-    var topLevelDeclarations: [GeneratedTypeDeclaration] {
-        outputs.flatMap(\.topLevelTypeNames).map { typeName in
-            GeneratedTypeDeclaration(
-                name: typeName,
-                origin: .support(typeName.unescaped)
-            )
-        }
     }
 
     func write(using fileOutput: FileOutput) throws {

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftEnumBuilder.swift
@@ -7,7 +7,7 @@ struct SwiftEnumBuilder: SwiftTypeBuildable {
         name: String,
         conformances: [String]
     ) {
-        builder = SwiftTypeBuilder(
+        self.builder = SwiftTypeBuilder(
             description: description,
             isPublic: isPublic,
             type: "enum",

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftReservedKeywords.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftReservedKeywords.swift
@@ -2,7 +2,7 @@ func identifier(_ identifier: String) -> String {
     swiftReservedKeywords.contains(identifier) ? "`\(identifier)`" : identifier
 }
 
-private let swiftReservedKeywords: Set<String> = [
+private let swiftReservedKeywords: Set = [
     "Any",
     "Self",
     "as",

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
@@ -47,14 +47,14 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
         name: String,
         conformances: [String]
     ) {
-        builder = SwiftTypeBuilder(
+        self.builder = SwiftTypeBuilder(
             description: description,
             isPublic: isPublic,
             type: "struct",
             name: identifier(name),
             conformances: conformances
         )
-        usesCodingKeys = conformances.contains { conformance in
+        self.usesCodingKeys = conformances.contains { conformance in
             SwiftConformanceName(source: conformance).usesCodingKeys
         }
     }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
@@ -1,9 +1,4 @@
 struct SwiftStructBuilder: SwiftTypeBuildable {
-    private struct StoredProperty {
-        let name: String
-        let storageName: String
-    }
-
     enum PropertyValue {
         case unassigned(type: String, initialized: Initialized?)
         case assigned(String, type: String?)
@@ -34,6 +29,11 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
                 let defaultValue: String?
             }
         }
+    }
+
+    private struct StoredProperty {
+        let name: String
+        let storageName: String
     }
 
     private var builder: SwiftTypeBuilder
@@ -95,10 +95,11 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
             case .assigned, .unassigned: immutable ? "let" : "var"
             }
         let safeName = identifier(name)
-        let usesBackingStorage = switch value {
-        case .unassigned: deprecation != nil
-        case .assigned, .computed: false
-        }
+        let usesBackingStorage =
+            switch value {
+            case .unassigned: deprecation != nil
+            case .assigned, .computed: false
+            }
         let backingName = usesBackingStorage ? backingStorageName(for: name) : safeName
         if isStatic == false {
             switch value {
@@ -187,15 +188,6 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
         storedProperties.first { $0.name == name }?.storageName ?? identifier(name)
     }
 
-    private func backingStorageName(for propertyName: String) -> String {
-        var name = "__\(propertyName)"
-        let storedPropertyNames = Set(storedProperties.map(\.storageName))
-        while reservedPropertyNames.contains(name) || storedPropertyNames.contains(name) {
-            name = "_\(name)"
-        }
-        return name
-    }
-
     mutating func addNestedType(_ type: SwiftTypeBuildable) {
         builder.addNestedType(type)
     }
@@ -210,6 +202,15 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
             body: body,
             isThrowing: isThrowing
         )
+    }
+
+    private func backingStorageName(for propertyName: String) -> String {
+        var name = "__\(propertyName)"
+        let storedPropertyNames = Set(storedProperties.map(\.storageName))
+        while reservedPropertyNames.contains(name) || storedPropertyNames.contains(name) {
+            name = "_\(name)"
+        }
+        return name
     }
 }
 

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
@@ -14,6 +14,7 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
         var body: [String] = []
         var parameterDocumentation: [ParameterDocumentation] = []
     }
+
     private let declaration: [String]
     private let isPublic: Bool
     private var propertyInitializer = Initializer()
@@ -129,7 +130,7 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
 
     private func buildInitializer(_ initializer: Initializer, indentation: String) -> [String] {
         guard !initializer.body.isEmpty else { return [] }
-        var lines: [String] = [""]
+        var lines = [""]
         if !initializer.parameterDocumentation.isEmpty {
             lines.append(indentation + "/// - Parameters:")
             for parameter in initializer.parameterDocumentation {

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -22,14 +22,14 @@ struct DocumentsResolver {
         let resolvedFragments = try resolveFragments(usedFragments)
         let resolvedDocuments = try resolveDocuments(documents)
         let usage = try usage(in: resolvedDocuments, resolvedFragments: resolvedFragments)
-        return ResolvedDocuments(
+        return try ResolvedDocuments(
             documents: resolvedDocuments,
             fragmentLookup: resolvedFragments,
             fulfilledFragments: usage.fulfilledFragments,
             hasMutation: usage.hasMutation,
             hasSubscription: usage.hasSubscription,
-            indirectOneOfInputObjectFields: try indirectOneOfInputObjectFields(in: usage.usedTypes),
-            requiresIndirectNullable: try requiresIndirectNullable(in: usage.usedTypes),
+            indirectOneOfInputObjectFields: indirectOneOfInputObjectFields(in: usage.usedTypes),
+            requiresIndirectNullable: requiresIndirectNullable(in: usage.usedTypes),
             usedTypes: usage.usedTypes
         )
     }
@@ -73,7 +73,7 @@ struct DocumentsResolver {
         var resolvedFragments: [String: ResolvedFragment] = [:]
         for (name, fragment) in usedFragments.sorted(by: { $0.key < $1.key }) {
             let selectionSet = try SelectionSetResolver(
-                onType: try schema.fragmentType(fragment.ast),
+                onType: schema.fragmentType(fragment.ast),
                 selectionSet: fragment.ast.selectionSet,
                 schema: schema,
                 documents: documents
@@ -158,7 +158,7 @@ struct DocumentsResolver {
                         case .map(let nestedSelectionSet):
                             selectionSets.append(nestedSelectionSet)
                             fieldType = nil
-                        case .optional(let innerType), .list(let innerType):
+                        case .list(let innerType), .optional(let innerType):
                             fieldType = innerType
                         }
                     }
@@ -173,14 +173,14 @@ struct DocumentsResolver {
         _ variableDefinition: GraphQLAST.VariableDefinition,
         to usedTypes: inout Set<String>
     ) throws {
-        var inputTypes = [try schema.inputType(variableDefinition)]
+        var inputTypes = try [schema.inputType(variableDefinition)]
         while let inputType = inputTypes.popLast() {
             switch inputType.value {
             case .SCALAR(let scalar): usedTypes.insert(scalar.ast.name)
             case .ENUM(let `enum`): usedTypes.insert(`enum`.ast.name)
             case .INPUT_OBJECT(let inputObject):
                 guard usedTypes.insert(inputObject.ast.name).inserted else { continue }
-                inputTypes.append(contentsOf: try inputObject.ast.inputFields.map { try schema.inputType($0) })
+                try inputTypes.append(contentsOf: inputObject.ast.inputFields.map { try schema.inputType($0) })
             case .LIST(let innerType): inputTypes.append(innerType)
             }
         }
@@ -222,7 +222,8 @@ struct DocumentsResolver {
                 case .nonNull: true
                 }
             guard storesWithoutNullableWrapper,
-                  case .INPUT_OBJECT(let nestedInputObject) = type.value else {
+                  case .INPUT_OBJECT(let nestedInputObject) = type.value
+            else {
                 return nil
             }
             return InputObjectDependency(

--- a/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
@@ -8,8 +8,8 @@ struct FieldResolver {
     let documents: Documents
 
     func resolve() throws -> ResolvedField {
-        ResolvedField(
-            type: try resolveFieldType(schema.fieldType(fieldSchema)),
+        try ResolvedField(
+            type: resolveFieldType(schema.fieldType(fieldSchema)),
             deprecation: fieldSchema.deprecation,
             description: fieldSchema.description
         )
@@ -19,7 +19,7 @@ struct FieldResolver {
         _ fieldType: Schema.Field
     ) throws -> ResolvedFieldType {
         switch fieldType {
-        case .nullable(let value): .optional(innerType: try resolveFieldValue(value))
+        case .nullable(let value): try .optional(innerType: resolveFieldValue(value))
         case .nonNull(let value): try resolveFieldValue(value)
         }
     }
@@ -39,7 +39,7 @@ struct FieldResolver {
         case .ENUM(let `enum`):
             return .scalar(typeName: `enum`.ast.name, isEnum: true)
         case .LIST(let innerType):
-            return .list(innerType: try resolveFieldType(innerType))
+            return try .list(innerType: resolveFieldType(innerType))
         }
     }
 
@@ -47,8 +47,8 @@ struct FieldResolver {
         guard let selectionSet = fieldSelection.selectionSet else {
             throw missingSelectionSetError()
         }
-        return .map(
-            try SelectionSetResolver(
+        return try .map(
+            SelectionSetResolver(
                 onType: type,
                 selectionSet: selectionSet,
                 schema: schema,

--- a/Sources/GraphQLCodegen/Resolution/Field/ResolvedField.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/ResolvedField.swift
@@ -15,8 +15,12 @@ struct ResolvedField {
             throw MergeError.incompatibleFields(self, other)
         }
         var descriptions = OrderedSet<String>()
-        if let description { descriptions.append(description) }
-        if let otherDescription = other.description { descriptions.append(otherDescription) }
+        if let description {
+            descriptions.append(description)
+        }
+        if let otherDescription = other.description {
+            descriptions.append(otherDescription)
+        }
         return try ResolvedField(
             type: type.merging(with: other.type),
             deprecation: deprecation,

--- a/Sources/GraphQLCodegen/Resolution/Field/ResolvedFieldType.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/ResolvedFieldType.swift
@@ -16,7 +16,7 @@ indirect enum ResolvedFieldType: Sendable {
             }
             return self
         case (.map(let selectionSet1), .map(let selectionSet2)):
-            return .map(try selectionSet1.merging(selectionSet2) { try $0.merging(with: $1) })
+            return try .map(selectionSet1.merging(selectionSet2) { try $0.merging(with: $1) })
         case (.optional(let inner1), .optional(let inner2)):
             return try .optional(innerType: inner1.merging(with: inner2))
         case (.list(let inner1), .list(let inner2)):

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -6,6 +6,10 @@ enum ResolvedSelection {
     case fragmentSpread(String, checkTypenames: Set<String>?)
     case field(ResolvedField, conditional: Bool)
 
+    private enum MergeError: Error {
+        case incompatibleSelectionTypes(ResolvedSelection, ResolvedSelection)
+    }
+
     func merging(with other: ResolvedSelection) throws -> ResolvedSelection {
         switch self {
         case .fragmentSpread(let name, let checkTypenames):
@@ -21,12 +25,8 @@ enum ResolvedSelection {
             switch other {
             case .fragmentSpread: throw MergeError.incompatibleSelectionTypes(self, other)
             case .field(let otherField, let otherConditional):
-                return .field(try field.merging(with: otherField), conditional: conditional && otherConditional)
+                return try .field(field.merging(with: otherField), conditional: conditional && otherConditional)
             }
         }
-    }
-
-    private enum MergeError: Error {
-        case incompatibleSelectionTypes(ResolvedSelection, ResolvedSelection)
     }
 }

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -41,16 +41,16 @@ struct SelectionSetResolver {
             switch selection {
             case .field(let field):
                 let resolvedField = field.name.value == "__typename" ? ResolvedField(
-                        type: .scalar(typeName: "String", isEnum: false),
-                        deprecation: nil,
-                        description: nil
+                    type: .scalar(typeName: "String", isEnum: false),
+                    deprecation: nil,
+                    description: nil
                 ) : try FieldResolver(
-                        fieldSelection: field,
-                        fieldSchema: onType.field(field),
-                        schema: schema,
-                        schemaCoordinate: .member(type: onType.name, member: field.name.value),
-                        documents: documents
-                    ).resolve()
+                    fieldSelection: field,
+                    fieldSchema: onType.field(field),
+                    schema: schema,
+                    schemaCoordinate: .member(type: onType.name, member: field.name.value),
+                    documents: documents
+                ).resolve()
                 let conditional = typeCondition.isConditional ||
                     inOptionalDirective ||
                     selection.hasOptionalDirective

--- a/Sources/GraphQLCodegen/Validation/DeprecationUsageValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DeprecationUsageValidator.swift
@@ -32,16 +32,6 @@ struct DeprecationUsageValidator {
         }
     }
 
-    private struct GraphQLIssue: Decodable {
-        struct Location: Decodable {
-            let line: Int
-            let column: Int
-        }
-
-        let message: String
-        let locations: [Location]
-    }
-
     struct ExcludedUsageError: CustomStringConvertible, Error {
         let diagnostics: [Diagnostic]
 
@@ -54,6 +44,16 @@ struct DeprecationUsageValidator {
         }
     }
 
+    private struct GraphQLIssue: Decodable {
+        struct Location: Decodable {
+            let line: Int
+            let column: Int
+        }
+
+        let message: String
+        let locations: [Location]
+    }
+
     let documents: Documents
     let graphQLJS: GraphQLJS
     let policy: Configuration.Input.DeprecationPolicy
@@ -62,10 +62,11 @@ struct DeprecationUsageValidator {
     func validate() throws -> [Diagnostic] {
         guard !documents.documents.isEmpty else { return [] }
 
-        let argumentsOnly = switch policy {
-        case .include: true
-        case .exclude: false
-        }
+        let argumentsOnly =
+            switch policy {
+            case .include: true
+            case .exclude: false
+            }
         let issuesJSON = try graphQLJS.findDeprecatedUsages(
             documents.documents.map(\.sourceText),
             schemaJSON: schemaJSON,

--- a/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/DocumentsValidator.swift
@@ -1,27 +1,6 @@
 import Foundation
 
 struct DocumentsValidator {
-    private struct GraphQLError: Decodable {
-        struct Location: Decodable {
-            let line: Int
-            let column: Int
-
-            var description: String {
-                "line: \(line), column: \(column)"
-            }
-        }
-
-        let message: String
-        let locations: [Location]
-
-        var description: String {
-            """
-            \(message)
-            \(locations.map(\.description).joined(separator: "\n"))
-            """
-        }
-    }
-
     struct ValidationError: CustomStringConvertible, Error {
         let documentErrors: [DocumentError]
 
@@ -45,6 +24,27 @@ struct DocumentsValidator {
 
         var description: String {
             "Operation: \(operationName ?? "<unnamed>")\n\n\(errors.joined(separator: "\n\n"))"
+        }
+    }
+
+    private struct GraphQLError: Decodable {
+        struct Location: Decodable {
+            let line: Int
+            let column: Int
+
+            var description: String {
+                "line: \(line), column: \(column)"
+            }
+        }
+
+        let message: String
+        let locations: [Location]
+
+        var description: String {
+            """
+            \(message)
+            \(locations.map(\.description).joined(separator: "\n"))
+            """
         }
     }
 

--- a/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
+++ b/Sources/GraphQLCodegen/Validation/GeneratedTypeNameValidator.swift
@@ -9,6 +9,10 @@ struct GeneratedTypeNameValidator {
     private let outputPlan: CodegenOutputPlan
     private let schemaTypeNames: Set<SwiftTypeIdentifier>
 
+    private var configuration: Configuration {
+        outputPlan.configuration
+    }
+
     init(outputPlan: CodegenOutputPlan) {
         self.outputPlan = outputPlan
         self.schemaTypeNames = Set(outputPlan.schemaWriter.topLevelDeclarations.map(\.name))
@@ -18,10 +22,6 @@ struct GeneratedTypeNameValidator {
         try validateTopLevelDeclarations()
         try validateSchemaEnumCaseNames()
         try validateDocumentScopes()
-    }
-
-    private var configuration: Configuration {
-        outputPlan.configuration
     }
 
     private func validateTopLevelDeclarations() throws {

--- a/Sources/graphql-codegen/ExecutableConfigurationFile+Configuration.swift
+++ b/Sources/graphql-codegen/ExecutableConfigurationFile+Configuration.swift
@@ -2,6 +2,41 @@ import Foundation
 import GraphQLCodegen
 
 extension ExecutableConfigurationFile {
+    private static func deprecationPolicy(_ value: String) throws -> Configuration.Input.DeprecationPolicy {
+        switch value {
+        case "include":
+            .include
+        case "exclude":
+            .exclude
+        default:
+            throw ConfigurationError(description: "Unsupported deprecation policy: \(value)")
+        }
+    }
+
+    private static func accessLevel(_ value: String) throws -> Configuration.Output.AccessLevel {
+        switch value {
+        case "internal":
+            .internal
+        case "public":
+            .public
+        default:
+            throw ConfigurationError(description: "Unsupported access level: \(value)")
+        }
+    }
+
+    private static func casing(
+        _ value: String
+    ) throws -> Configuration.Output.Schema.Enums.CaseConversion.Case {
+        switch value {
+        case "lowerCamel":
+            .lowerCamel
+        case "macro":
+            .macro
+        default:
+            throw ConfigurationError(description: "Unsupported enum case conversion: \(value)")
+        }
+    }
+
     /// Converts this file representation into a configuration, resolving relative file URLs.
     func configuration(relativeTo directory: URL, outputDirectory: URL? = nil) throws -> Configuration {
         let schemaSource: Configuration.Input.SchemaSource
@@ -257,40 +292,5 @@ extension ExecutableConfigurationFile {
             }
         }
         return support
-    }
-
-    private static func deprecationPolicy(_ value: String) throws -> Configuration.Input.DeprecationPolicy {
-        switch value {
-        case "include":
-            .include
-        case "exclude":
-            .exclude
-        default:
-            throw ConfigurationError(description: "Unsupported deprecation policy: \(value)")
-        }
-    }
-
-    private static func accessLevel(_ value: String) throws -> Configuration.Output.AccessLevel {
-        switch value {
-        case "internal":
-            .internal
-        case "public":
-            .public
-        default:
-            throw ConfigurationError(description: "Unsupported access level: \(value)")
-        }
-    }
-
-    private static func casing(
-        _ value: String
-    ) throws -> Configuration.Output.Schema.Enums.CaseConversion.Case {
-        switch value {
-        case "lowerCamel":
-            .lowerCamel
-        case "macro":
-            .macro
-        default:
-            throw ConfigurationError(description: "Unsupported enum case conversion: \(value)")
-        }
     }
 }

--- a/Sources/graphql-codegen/ExecutableConfigurationFile+Configuration.swift
+++ b/Sources/graphql-codegen/ExecutableConfigurationFile+Configuration.swift
@@ -17,17 +17,17 @@ extension ExecutableConfigurationFile {
                 : .SDLSchemaFile(url)
         }
 
-        var configuredInput = Configuration.Input.input(
+        var configuredInput = try Configuration.Input.input(
             schemaSource: schemaSource,
-            documentDirectories: try resolveDocumentDirectories(relativeTo: directory)
+            documentDirectories: resolveDocumentDirectories(relativeTo: directory)
         )
         if let deprecationPolicy = input.deprecationPolicy {
             configuredInput.deprecationPolicy = try Self.deprecationPolicy(deprecationPolicy)
         }
 
-        var configuredOutput = Configuration.Output.output(
-            schema: try schemaConfiguration(relativeTo: directory, outputDirectory: outputDirectory),
-            support: try supportConfiguration(relativeTo: directory, outputDirectory: outputDirectory)
+        var configuredOutput = try Configuration.Output.output(
+            schema: schemaConfiguration(relativeTo: directory, outputDirectory: outputDirectory),
+            support: supportConfiguration(relativeTo: directory, outputDirectory: outputDirectory)
         )
         if let indentation = output.indentation {
             switch indentation.style {
@@ -80,7 +80,8 @@ extension ExecutableConfigurationFile {
             relativeTo: directory,
             override: outputDirectory,
             parameter: "output.schema.directory"
-        ) else {
+        )
+        else {
             throw ConfigurationError(description: "Missing required output directory: output.schema.directory")
         }
         var schema = Configuration.Output.Schema.schema(directory: schemaDirectory)
@@ -112,9 +113,9 @@ extension ExecutableConfigurationFile {
                 schema.enums.conformances = conformances
             }
             if let caseConversion = enums.caseConversion {
-                schema.enums.caseConversion = .conversion(
-                    from: try Self.casing(caseConversion.from),
-                    to: try Self.casing(caseConversion.to)
+                schema.enums.caseConversion = try .conversion(
+                    from: Self.casing(caseConversion.from),
+                    to: Self.casing(caseConversion.to)
                 )
             }
         }
@@ -211,7 +212,8 @@ extension ExecutableConfigurationFile {
             relativeTo: directory,
             override: outputDirectory,
             parameter: "output.support.directory"
-        ) else {
+        )
+        else {
             throw ConfigurationError(description: "Missing required output directory: output.support.directory")
         }
         var support = Configuration.Output.Support.support(directory: supportDirectory)

--- a/Sources/graphql-codegen/GraphQLCodegenCommand.swift
+++ b/Sources/graphql-codegen/GraphQLCodegenCommand.swift
@@ -7,7 +7,8 @@ enum GraphQLCodegenCommand {
         let arguments = Array(CommandLine.arguments.dropFirst())
         guard arguments.count == 2 || arguments.count == 4,
               arguments[0] == "--file-configuration",
-              arguments.count == 2 || arguments[2] == "--output-directory" else {
+              arguments.count == 2 || arguments[2] == "--output-directory"
+        else {
             throw CommandError.invalidArguments
         }
 

--- a/StarwarsExample/client-build-plugin/iOS/ContentView.swift
+++ b/StarwarsExample/client-build-plugin/iOS/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 struct ContentView: View {
@@ -56,7 +49,7 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder private var episodeOptions: some View {
+    private var episodeOptions: some View {
         ForEach(EpisodeChoice.allCases) { episode in
             Text(episode.title).tag(episode)
         }

--- a/StarwarsExample/client-build-plugin/iOS/StarWarsViewModel.swift
+++ b/StarwarsExample/client-build-plugin/iOS/StarWarsViewModel.swift
@@ -7,7 +7,9 @@ enum EpisodeChoice: String, CaseIterable, Identifiable {
     case empire
     case jedi
 
-    var id: Self { self }
+    var id: Self {
+        self
+    }
 
     var title: String {
         switch self {

--- a/StarwarsExample/client-build-plugin/iOS/StarwarsExampleApp.swift
+++ b/StarwarsExample/client-build-plugin/iOS/StarwarsExampleApp.swift
@@ -1,10 +1,3 @@
-//
-//  StarwarsExampleApp.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 @main

--- a/StarwarsExample/client-cli/iOS/ContentView.swift
+++ b/StarwarsExample/client-cli/iOS/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 struct ContentView: View {
@@ -56,7 +49,7 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder private var episodeOptions: some View {
+    private var episodeOptions: some View {
         ForEach(EpisodeChoice.allCases) { episode in
             Text(episode.title).tag(episode)
         }

--- a/StarwarsExample/client-cli/iOS/StarWarsViewModel.swift
+++ b/StarwarsExample/client-cli/iOS/StarWarsViewModel.swift
@@ -7,7 +7,9 @@ enum EpisodeChoice: String, CaseIterable, Identifiable {
     case empire
     case jedi
 
-    var id: Self { self }
+    var id: Self {
+        self
+    }
 
     var title: String {
         switch self {

--- a/StarwarsExample/client-cli/iOS/StarwarsExampleApp.swift
+++ b/StarwarsExample/client-cli/iOS/StarwarsExampleApp.swift
@@ -1,10 +1,3 @@
-//
-//  StarwarsExampleApp.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 @main

--- a/StarwarsExample/client-swift-api/iOS/ContentView.swift
+++ b/StarwarsExample/client-swift-api/iOS/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 struct ContentView: View {
@@ -56,7 +49,7 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder private var episodeOptions: some View {
+    private var episodeOptions: some View {
         ForEach(EpisodeChoice.allCases) { episode in
             Text(episode.title).tag(episode)
         }

--- a/StarwarsExample/client-swift-api/iOS/StarWarsViewModel.swift
+++ b/StarwarsExample/client-swift-api/iOS/StarWarsViewModel.swift
@@ -7,7 +7,9 @@ enum EpisodeChoice: String, CaseIterable, Identifiable {
     case empire
     case jedi
 
-    var id: Self { self }
+    var id: Self {
+        self
+    }
 
     var title: String {
         switch self {

--- a/StarwarsExample/client-swift-api/iOS/StarwarsExampleApp.swift
+++ b/StarwarsExample/client-swift-api/iOS/StarwarsExampleApp.swift
@@ -1,10 +1,3 @@
-//
-//  StarwarsExampleApp.swift
-//  StarwarsExample
-//
-//  Created by Peter Meyers on 8/9/26.
-//
-
 import SwiftUI
 
 @main

--- a/Tests/Fixtures/Plugin/PluginFixture.swift
+++ b/Tests/Fixtures/Plugin/PluginFixture.swift
@@ -1,7 +1,7 @@
 public struct PluginFixture {
-    public init() {}
-
     public var operationType: Any.Type {
         ValueQuery.self
     }
+
+    public init() {}
 }

--- a/Tests/Tests/DeprecationSupportTests.swift
+++ b/Tests/Tests/DeprecationSupportTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-@testable import GraphQLCodegen
 import Testing
+@testable import GraphQLCodegen
 
 struct DeprecationSupportTests {
     struct DeprecatedUsage: Sendable {

--- a/Tests/Tests/ExecutableConfigurationFileTests.swift
+++ b/Tests/Tests/ExecutableConfigurationFileTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-@testable import graphql_codegen
 import GraphQLCodegen
 import Testing
+@testable import graphql_codegen
 
 struct ExecutableConfigurationFileTests {
     @Test

--- a/Tests/Tests/ExecutableConfigurationFileTests.swift
+++ b/Tests/Tests/ExecutableConfigurationFileTests.swift
@@ -73,28 +73,28 @@ struct ExecutableConfigurationFileTests {
     func decodesScalarMappingsWithModuleDefaults() throws {
         let configuration = try configuration(
             from:
-                """
-                {
-                  "input": {
-                    "schemaSource": "schema.graphqls",
-                    "documentDirectories": []
-                  },
-                  "output": {
-                    "schema": {
-                      "directory": "Schema",
-                      "scalars": {
-                        "scalarMapping": {
-                          "UUID": {
-                            "typeName": "UUID",
-                            "module": { "name": "Foundation" }
-                          }
-                        }
+            """
+            {
+              "input": {
+                "schemaSource": "schema.graphqls",
+                "documentDirectories": []
+              },
+              "output": {
+                "schema": {
+                  "directory": "Schema",
+                  "scalars": {
+                    "scalarMapping": {
+                      "UUID": {
+                        "typeName": "UUID",
+                        "module": { "name": "Foundation" }
                       }
-                    },
-                    "support": { "directory": "Support" }
+                    }
                   }
-                }
-                """
+                },
+                "support": { "directory": "Support" }
+              }
+            }
+            """
         )
         let scalar = try #require(configuration.output.schema.scalars.scalarMapping["UUID"])
         #expect(scalar.typeName == "UUID")
@@ -117,7 +117,8 @@ struct ExecutableConfigurationFileTests {
             httpSupport: #"{"persistedOperations":{"strategy":"registered"}}"#
         )
         guard case .registered(let defaultAllowUnregisteredOperations)? =
-            registeredByDefault.output.support.HTTPSupport?.persistedOperations else {
+            registeredByDefault.output.support.HTTPSupport?.persistedOperations
+        else {
             Issue.record("Expected registered persisted operations with the factory default")
             return
         }
@@ -127,7 +128,8 @@ struct ExecutableConfigurationFileTests {
             httpSupport: #"{"persistedOperations":{"strategy":"registered","allowUnregisteredOperations":true}}"#
         )
         guard case .registered(let allowUnregisteredOperations)? =
-            registered.output.support.HTTPSupport?.persistedOperations else {
+            registered.output.support.HTTPSupport?.persistedOperations
+        else {
             Issue.record("Expected registered persisted operations")
             return
         }
@@ -138,19 +140,19 @@ struct ExecutableConfigurationFileTests {
     func decodesIntrospectionEndpointsWithoutBuildPluginRestrictions() throws {
         let configuration = try configuration(
             from:
-                """
-                {
-                  "input": {
-                    "schemaSource": "https://example.com/graphql",
-                    "schemaHeaders": { "Authorization": "Bearer token" },
-                    "documentDirectories": []
-                  },
-                  "output": {
-                    "schema": { "directory": "Schema" },
-                    "support": { "directory": "Support" }
-                  }
-                }
-                """
+            """
+            {
+              "input": {
+                "schemaSource": "https://example.com/graphql",
+                "schemaHeaders": { "Authorization": "Bearer token" },
+                "documentDirectories": []
+              },
+              "output": {
+                "schema": { "directory": "Schema" },
+                "support": { "directory": "Support" }
+              }
+            }
+            """
         )
 
         guard case .introspectionEndpoint(let url, let headers) = configuration.input.schemaSource else {
@@ -165,44 +167,44 @@ struct ExecutableConfigurationFileTests {
     func decodesExecutableConfigurationOptions() throws {
         let configuration = try configuration(
             from:
-                """
-                {
-                  "input": {
-                    "schemaSource": "schema.graphqls",
-                    "documentDirectories": ["Documents"],
-                    "deprecationPolicy": "exclude"
-                  },
-                  "output": {
-                    "indentation": { "style": "tab" },
-                    "schema": {
-                      "directory": "Schema",
-                      "includeHeader": false,
-                      "scalars": {
-                        "scalarMapping": {
-                          "UUID": {
-                            "typeName": "UUID",
-                            "module": { "name": "Foundation", "prefix": true }
-                          }
-                        }
-                      },
-                      "enums": {
-                        "caseConversion": { "from": "macro", "to": "lowerCamel" }
-                      },
-                      "accessLevel": "public"
-                    },
-                    "documents": {
-                      "includeHeader": false,
-                      "accessLevel": "public"
-                    },
-                    "support": {
-                      "directory": "Support",
-                      "httpSupport": {
-                        "persistedOperations": { "strategy": "disabled" }
+            """
+            {
+              "input": {
+                "schemaSource": "schema.graphqls",
+                "documentDirectories": ["Documents"],
+                "deprecationPolicy": "exclude"
+              },
+              "output": {
+                "indentation": { "style": "tab" },
+                "schema": {
+                  "directory": "Schema",
+                  "includeHeader": false,
+                  "scalars": {
+                    "scalarMapping": {
+                      "UUID": {
+                        "typeName": "UUID",
+                        "module": { "name": "Foundation", "prefix": true }
                       }
                     }
+                  },
+                  "enums": {
+                    "caseConversion": { "from": "macro", "to": "lowerCamel" }
+                  },
+                  "accessLevel": "public"
+                },
+                "documents": {
+                  "includeHeader": false,
+                  "accessLevel": "public"
+                },
+                "support": {
+                  "directory": "Support",
+                  "httpSupport": {
+                    "persistedOperations": { "strategy": "disabled" }
                   }
                 }
-                """
+              }
+            }
+            """
         )
 
         #expect(configuration.input.deprecationPolicy == .exclude)
@@ -233,19 +235,19 @@ struct ExecutableConfigurationFileTests {
         let outputDirectory = URL(fileURLWithPath: "/tmp/GraphQLProject/Generated")
         let configuration = try configuration(
             from:
-                """
-                {
-                  "input": {
-                    "schemaSource": "schema.graphqls",
-                    "documentDirectories": ["Documents"]
-                  },
-                  "output": {
-                    "schema": \(schema),
-                    "documents": \(documents),
-                    "support": \(support)
-                  }
-                }
-                """,
+            """
+            {
+              "input": {
+                "schemaSource": "schema.graphqls",
+                "documentDirectories": ["Documents"]
+              },
+              "output": {
+                "schema": \(schema),
+                "documents": \(documents),
+                "support": \(support)
+              }
+            }
+            """,
             outputDirectory: outputDirectory
         )
 
@@ -303,21 +305,21 @@ struct ExecutableConfigurationFileTests {
     private func configuration(httpSupport json: String) throws -> Configuration {
         try configuration(
             from:
-                """
-                {
-                  "input": {
-                    "schemaSource": "schema.graphqls",
-                    "documentDirectories": []
-                  },
-                  "output": {
-                    "schema": { "directory": "Schema" },
-                    "support": {
-                      "directory": "Support",
-                      "httpSupport": \(json)
-                    }
-                  }
+            """
+            {
+              "input": {
+                "schemaSource": "schema.graphqls",
+                "documentDirectories": []
+              },
+              "output": {
+                "schema": { "directory": "Schema" },
+                "support": {
+                  "directory": "Support",
+                  "httpSupport": \(json)
                 }
-                """
+              }
+            }
+            """
         )
     }
 

--- a/Tests/Tests/GraphQL17BoundaryModelTests.swift
+++ b/Tests/Tests/GraphQL17BoundaryModelTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-@testable import GraphQLCodegen
 import Testing
+@testable import GraphQLCodegen
 
 struct GraphQL17BoundaryModelTests {
     @Test

--- a/Tests/Tests/GraphQLDefaultValuesGeneratorTests.swift
+++ b/Tests/Tests/GraphQLDefaultValuesGeneratorTests.swift
@@ -6,13 +6,14 @@ struct GraphQLDefaultValuesGeneratorTests {
     private static let testsDirectory = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent() // Inside 'Tests'
         .deletingLastPathComponent() // Inside root 'Tests'
+
     private let definitionsDirectory = GraphQLDefaultValuesGeneratorTests.testsDirectory
         .appending(path: "Fixtures/Definitions/Defaults", directoryHint: .isDirectory)
     private let expectedDirectory = GraphQLDefaultValuesGeneratorTests.testsDirectory
         .appending(path: "Fixtures/Generated/Defaults", directoryHint: .isDirectory)
 
     @Test
-    func testGeneratesDefaultValuesAPI() async throws {
+    func generatesDefaultValuesAPI() async throws {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
             directoryHint: .isDirectory

--- a/Tests/Tests/GraphQLHasDefaultTests.swift
+++ b/Tests/Tests/GraphQLHasDefaultTests.swift
@@ -1,6 +1,6 @@
-@testable import Fixtures
 import Foundation
 import Testing
+@testable import Fixtures
 
 struct GraphQLHasDefaultTests {
     @Test

--- a/Tests/Tests/GraphQLHasDefaultTests.swift
+++ b/Tests/Tests/GraphQLHasDefaultTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct GraphQLHasDefaultTests {
     @Test
-    func testUseDefaultOmitsValues() throws {
+    func useDefaultOmitsValues() throws {
         let data = try JSONEncoder().encode(DefaultsQuery().variables)
         let json = try #require(String(data: data, encoding: .utf8))
 
@@ -12,7 +12,7 @@ struct GraphQLHasDefaultTests {
     }
 
     @Test
-    func testValueEncodesValues() throws {
+    func valueEncodesValues() throws {
         let variables = DefaultsQuery(
             input: .value(DefaultsInput()),
             required: .value(3),

--- a/Tests/Tests/GraphQLOneOfGeneratorTests.swift
+++ b/Tests/Tests/GraphQLOneOfGeneratorTests.swift
@@ -1,7 +1,7 @@
-@testable import Fixtures
 import Foundation
 import GraphQLCodegen
 import Testing
+@testable import Fixtures
 
 struct GraphQLOneOfGeneratorTests {
     private static let testsDirectory = URL(fileURLWithPath: #filePath)

--- a/Tests/Tests/GraphQLOneOfGeneratorTests.swift
+++ b/Tests/Tests/GraphQLOneOfGeneratorTests.swift
@@ -7,6 +7,7 @@ struct GraphQLOneOfGeneratorTests {
     private static let testsDirectory = URL(fileURLWithPath: #filePath)
         .deletingLastPathComponent()
         .deletingLastPathComponent()
+
     private let definitionsDirectory = GraphQLOneOfGeneratorTests.testsDirectory
         .appending(path: "Fixtures/Definitions/OneOf", directoryHint: .isDirectory)
     private let expectedDirectory = GraphQLOneOfGeneratorTests.testsDirectory

--- a/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -1,7 +1,7 @@
 import CryptoKit
-@testable import Fixtures
 import Foundation
 import Testing
+@testable import Fixtures
 
 struct DefaultURLQueryEncoderTests {
     private struct AnonymousQuery: GraphQLQuery {

--- a/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -4,6 +4,69 @@ import Foundation
 import Testing
 
 struct DefaultURLQueryEncoderTests {
+    private struct AnonymousQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = nil
+        static let document = "{viewer{id}}"
+
+        let variables: Never? = nil
+        let extensions: [String: Fixtures.AnyEncodable]? = nil
+    }
+
+    private struct CurrentUserQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = "CurrentUser"
+        static let document = "query CurrentUser{viewer{id}}"
+
+        let variables: Never? = nil
+        let extensions: [String: Fixtures.AnyEncodable]? = nil
+    }
+
+    private struct DescribedQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        static let operationName: String? = "Described"
+        static let document = "query Described{viewer{id}}"
+
+        let variables: Never? = nil
+        let extensions: [String: Fixtures.AnyEncodable]? = nil
+    }
+
+    private struct EncodedExtensions: Decodable {
+        let requestID: String
+    }
+
+    private struct EncodedVariables: Decodable {
+        let includeDetails: Bool
+    }
+
+    private struct ParameterizedQuery: GraphQLQuery {
+        struct Data: Decodable, Sendable {}
+
+        struct Variables: Encodable, Sendable {
+            // periphery:ignore - Used through the synthesized Encodable implementation.
+            let includeDetails: Bool
+        }
+
+        static let operationName: String? = "Parameterized"
+        static let document = "query Parameterized($includeDetails:Boolean!){viewer{id}}"
+
+        let variables = Variables(includeDetails: true)
+        let extensions: [String: Fixtures.AnyEncodable]? = [
+            "requestID": Fixtures.AnyEncodable("request-id"),
+        ]
+    }
+
+    private struct PersistedExtensions: Decodable {
+        struct PersistedQuery: Decodable {
+            let sha256Hash: String
+        }
+
+        let persistedQuery: PersistedQuery
+    }
+
     @Test
     func persistedHashUsesDocument() throws {
         let queryItems = try DefaultURLQueryEncoder().encode(
@@ -70,69 +133,6 @@ struct DefaultURLQueryEncoderTests {
         let extensionsData = try #require(extensionsValue.data(using: .utf8))
         let extensions = try JSONDecoder().decode(EncodedExtensions.self, from: extensionsData)
         #expect(extensions.requestID == "request-id")
-    }
-
-    private struct AnonymousQuery: GraphQLQuery {
-        struct Data: Decodable, Sendable {}
-
-        static let operationName: String? = nil
-        static let document = "{viewer{id}}"
-
-        let variables: Never? = nil
-        let extensions: [String: Fixtures.AnyEncodable]? = nil
-    }
-
-    private struct CurrentUserQuery: GraphQLQuery {
-        struct Data: Decodable, Sendable {}
-
-        static let operationName: String? = "CurrentUser"
-        static let document = "query CurrentUser{viewer{id}}"
-
-        let variables: Never? = nil
-        let extensions: [String: Fixtures.AnyEncodable]? = nil
-    }
-
-    private struct DescribedQuery: GraphQLQuery {
-        struct Data: Decodable, Sendable {}
-
-        static let operationName: String? = "Described"
-        static let document = "query Described{viewer{id}}"
-
-        let variables: Never? = nil
-        let extensions: [String: Fixtures.AnyEncodable]? = nil
-    }
-
-    private struct EncodedExtensions: Decodable {
-        let requestID: String
-    }
-
-    private struct EncodedVariables: Decodable {
-        let includeDetails: Bool
-    }
-
-    private struct ParameterizedQuery: GraphQLQuery {
-        struct Data: Decodable, Sendable {}
-
-        static let operationName: String? = "Parameterized"
-        static let document = "query Parameterized($includeDetails:Boolean!){viewer{id}}"
-
-        let variables = Variables(includeDetails: true)
-        let extensions: [String: Fixtures.AnyEncodable]? = [
-            "requestID": Fixtures.AnyEncodable("request-id")
-        ]
-
-        struct Variables: Encodable, Sendable {
-            // periphery:ignore - Used through the synthesized Encodable implementation.
-            let includeDetails: Bool
-        }
-    }
-
-    private struct PersistedExtensions: Decodable {
-        struct PersistedQuery: Decodable {
-            let sha256Hash: String
-        }
-
-        let persistedQuery: PersistedQuery
     }
 
     private func hash(_ document: String) -> String {

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -7,6 +7,7 @@ struct GraphQLCodeGeneratorTests {
         .deletingLastPathComponent() // Inside 'Integration'
         .deletingLastPathComponent() // Inside 'Tests'
         .deletingLastPathComponent() // Inside root 'Tests'
+
     private let definitionsDirectory = GraphQLCodeGeneratorTests.testsDirectory
         .appending(path: "Fixtures/Definitions/Integration", directoryHint: .isDirectory)
     private let expectedDirectory = GraphQLCodeGeneratorTests.testsDirectory
@@ -112,7 +113,7 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
-    func testGeneratesCodeForValidSchemaAndDocument() async throws {
+    func generatesCodeForValidSchemaAndDocument() async throws {
         let generatedDirectory = FileManager.default.temporaryDirectory.appending(
             path: UUID().uuidString,
             directoryHint: .isDirectory

--- a/Tests/Tests/Integration/GraphQLRequestTests.swift
+++ b/Tests/Tests/Integration/GraphQLRequestTests.swift
@@ -1,6 +1,6 @@
-@testable import Fixtures
 import Foundation
 import Testing
+@testable import Fixtures
 
 struct GraphQLRequestTests {
     private final class TrackingHTTPBodyEncoder: HTTPBodyEncoder {

--- a/Tests/Tests/Integration/GraphQLRequestTests.swift
+++ b/Tests/Tests/Integration/GraphQLRequestTests.swift
@@ -106,7 +106,7 @@ struct GraphQLRequestTests {
         #expect(postSubscriptionRequest.persistedOperationRetry == nil)
         let body = try JSONDecoder().decode(
             EncodedDocument.self,
-            from: try #require(postSubscriptionRequest.urlRequest.httpBody)
+            from: #require(postSubscriptionRequest.urlRequest.httpBody)
         )
         #expect(body.query == StateChangedSubscription.document)
     }
@@ -181,7 +181,7 @@ struct GraphQLRequestTests {
         #expect(urlRequest.value(forHTTPHeaderField: "content-type") == "application/json")
         #expect(urlRequest.value(forHTTPHeaderField: "authorization") == "Bearer token")
 
-        let body = try JSONDecoder().decode(EncodedRequest.self, from: try #require(urlRequest.httpBody))
+        let body = try JSONDecoder().decode(EncodedRequest.self, from: #require(urlRequest.httpBody))
         #expect(body.operationName == "Node")
         #expect(body.query == NodeQuery.document)
         #expect(body.variables.state == "STOPPED")

--- a/Tests/Tests/Integration/GraphQLResponseTests.swift
+++ b/Tests/Tests/Integration/GraphQLResponseTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import Testing
 
 struct GraphQLResponseTests {
+    private struct Payload: Decodable, Sendable {}
+
     @Test
     func treatsExplicitNullDataAsAnExecutionResult() throws {
         let response = try JSONDecoder().decode(
@@ -56,6 +58,4 @@ struct GraphQLResponseTests {
             )
         }
     }
-
-    private struct Payload: Decodable, Sendable {}
 }

--- a/Tests/Tests/Integration/GraphQLResponseTests.swift
+++ b/Tests/Tests/Integration/GraphQLResponseTests.swift
@@ -1,6 +1,6 @@
-@testable import Fixtures
 import Foundation
 import Testing
+@testable import Fixtures
 
 struct GraphQLResponseTests {
     private struct Payload: Decodable, Sendable {}

--- a/Tests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/Tests/Integration/ServerSentEventTests.swift
@@ -9,10 +9,10 @@ struct ServerSentEventTests {
         let session = makeSession()
         defer { session.invalidateAndCancel() }
 
-        let stream = try await session.subscribe(try makeRequest(path: "standards"))
+        let stream = try await session.subscribe(makeRequest(path: "standards"))
         var values: [GraphQLEnum<State>] = []
         for try await response in stream {
-            values.append(try #require(response.data).stateChanged)
+            try values.append(#require(response.data).stateChanged)
         }
 
         #expect(values == [.known(.stopped)])
@@ -23,7 +23,7 @@ struct ServerSentEventTests {
         let session = makeSession()
         defer { session.invalidateAndCancel() }
 
-        let stream = try await session.subscribe(try makeRequest(path: "complete-without-data"))
+        let stream = try await session.subscribe(makeRequest(path: "complete-without-data"))
         var yieldedResult = false
         for try await _ in stream {
             yieldedResult = true
@@ -39,7 +39,7 @@ struct ServerSentEventTests {
 
         var rejected = false
         do {
-            let stream = try await session.subscribe(try makeRequest(path: "missing-complete"))
+            let stream = try await session.subscribe(makeRequest(path: "missing-complete"))
             for try await _ in stream {}
         } catch URLSession.SubscriptionError.missingCompleteEvent {
             rejected = true
@@ -56,7 +56,7 @@ struct ServerSentEventTests {
         var rejectedMaximumByteCount: Int?
         do {
             let stream = try await session.subscribe(
-                try makeRequest(path: "oversized"),
+                makeRequest(path: "oversized"),
                 maximumEventByteCount: 8
             )
             for try await _ in stream {}
@@ -75,7 +75,7 @@ struct ServerSentEventTests {
         var rejectedMaximumByteCount: Int?
         do {
             let stream = try await session.subscribe(
-                try makeRequest(path: "oversized-line"),
+                makeRequest(path: "oversized-line"),
                 maximumLineByteCount: 8
             )
             for try await _ in stream {}
@@ -92,7 +92,7 @@ struct ServerSentEventTests {
         defer { session.invalidateAndCancel() }
 
         let stream = try await session.subscribe(
-            try makeRequest(path: "maximum-line"),
+            makeRequest(path: "maximum-line"),
             maximumLineByteCount: 15
         )
         var yieldedResult = false
@@ -111,7 +111,7 @@ struct ServerSentEventTests {
         var rejectedMaximumByteCount: Int?
         do {
             _ = try await session.subscribe(
-                try makeRequest(path: "unused"),
+                makeRequest(path: "unused"),
                 maximumLineByteCount: 0
             )
         } catch URLSession.SubscriptionError.invalidMaximumLineByteCount(let maximumByteCount) {
@@ -128,7 +128,7 @@ struct ServerSentEventTests {
 
         var rejected = false
         do {
-            let stream = try await session.subscribe(try makeRequest(path: "invalid-utf8"))
+            let stream = try await session.subscribe(makeRequest(path: "invalid-utf8"))
             for try await _ in stream {}
         } catch URLSession.SubscriptionError.invalidUTF8 {
             rejected = true
@@ -145,7 +145,7 @@ struct ServerSentEventTests {
         let secondResultDecoded = DispatchSemaphore(value: 0)
         let request = try GraphQLRequest(
             subscription: OverflowProbeSubscription(),
-            endpoint: URL(string: "https://subscriptions.test/overflow")!
+            endpoint: #require(URL(string: "https://subscriptions.test/overflow"))
         )
         let stream = try await session.subscribe(
             request,
@@ -273,11 +273,12 @@ private final class SubscriptionURLProtocol: URLProtocol {
 private struct OverflowProbeData: Decodable, Sendable {}
 
 private struct OverflowProbeSubscription: GraphQLSubscription {
-    static let operationName: String? = "OverflowProbe"
-    static let document = "subscription OverflowProbe { stateChanged }"
-    let variables: Never? = nil
-    let extensions: [String: Fixtures.AnyEncodable]? = nil
-
     typealias Data = OverflowProbeData
     typealias Variables = Never?
+
+    static let operationName: String? = "OverflowProbe"
+    static let document = "subscription OverflowProbe { stateChanged }"
+
+    let variables: Never? = nil
+    let extensions: [String: Fixtures.AnyEncodable]? = nil
 }

--- a/Tests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/Tests/Integration/ServerSentEventTests.swift
@@ -1,7 +1,7 @@
 import Dispatch
-@testable import Fixtures
 import Foundation
 import Testing
+@testable import Fixtures
 
 struct ServerSentEventTests {
     @Test
@@ -204,7 +204,7 @@ struct ServerSentEventTests {
 
 private final class SubscriptionURLProtocol: URLProtocol {
     // swiftlint:disable:next non_overridable_class_declaration static_over_final_class
-    override class func canInit(with request: URLRequest) -> Bool {
+    override class func canInit(with _: URLRequest) -> Bool {
         true
     }
 

--- a/Tests/Tests/IntrospectionQueryTests.swift
+++ b/Tests/Tests/IntrospectionQueryTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-@testable import GraphQLCodegen
 import Testing
+@testable import GraphQLCodegen
 
 struct IntrospectionQueryTests {
     @Test
@@ -21,10 +21,12 @@ struct IntrospectionQueryTests {
             #"{"description":null,"name":"Choice","inputFields":[],"isOneOf":true}"#.utf8
         )
         let inputValueData = Data(
-            #"{"name":"oldValue","description":null,"type":{"kind":"SCALAR","name":"String"},"defaultValue":null,"isDeprecated":true,"deprecationReason":"Use newValue."}"#.utf8
+            #"{"name":"oldValue","description":null,"type":{"kind":"SCALAR","name":"String"},"defaultValue":null,"isDeprecated":true,"deprecationReason":"Use newValue."}"#
+                .utf8
         )
         let fieldData = Data(
-            #"{"name":"oldField","description":null,"args":[],"type":{"kind":"SCALAR","name":"String"},"isDeprecated":true,"deprecationReason":"Use newField."}"#.utf8
+            #"{"name":"oldField","description":null,"args":[],"type":{"kind":"SCALAR","name":"String"},"isDeprecated":true,"deprecationReason":"Use newField."}"#
+                .utf8
         )
         let enumValueData = Data(
             #"{"name":"OLD_VALUE","description":null,"isDeprecated":true,"deprecationReason":"Use NEW_VALUE."}"#.utf8
@@ -46,7 +48,8 @@ struct IntrospectionQueryTests {
     @Test
     func rejectsDeprecatedInputValueWithoutReason() {
         let inputValueData = Data(
-            #"{"name":"oldValue","description":null,"type":{"kind":"SCALAR","name":"String"},"defaultValue":null,"isDeprecated":true,"deprecationReason":null}"#.utf8
+            #"{"name":"oldValue","description":null,"type":{"kind":"SCALAR","name":"String"},"defaultValue":null,"isDeprecated":true,"deprecationReason":null}"#
+                .utf8
         )
 
         #expect(throws: DecodingError.self) {

--- a/Tests/Tests/SchemaCoordinateTests.swift
+++ b/Tests/Tests/SchemaCoordinateTests.swift
@@ -1,5 +1,5 @@
-@testable import GraphQLCodegen
 import Testing
+@testable import GraphQLCodegen
 
 struct SchemaCoordinateTests {
     @Test

--- a/mise.lock
+++ b/mise.lock
@@ -48,29 +48,6 @@ checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f18
 url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
 url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
 
-[[tools.swift]]
-version = "6.3.3"
-backend = "core:swift"
-
-[tools.swift."platforms.macos-arm64"]
-url = "https://download.swift.org/swift-6.3.3-release/xcode/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-osx.pkg"
-
-[tools.swift."platforms.macos-x64"]
-url = "https://download.swift.org/swift-6.3.3-release/xcode/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-osx.pkg"
-
-[[tools.swift]]
-version = "6.3.3"
-backend = "core:swift"
-
-[tools.swift.options]
-swift_platform = "ubuntu24.04"
-
-[tools.swift."platforms.linux-arm64"]
-url = "https://download.swift.org/swift-6.3.3-release/ubuntu2404-aarch64/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-ubuntu24.04-aarch64.tar.gz"
-
-[tools.swift."platforms.linux-x64"]
-url = "https://download.swift.org/swift-6.3.3-release/ubuntu2404/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-ubuntu24.04.tar.gz"
-
 [[tools.swiftformat]]
 version = "0.62.1"
 backend = "asdf:swiftformat"

--- a/mise.lock
+++ b/mise.lock
@@ -14,6 +14,40 @@ checksum = "sha256:07d4e286e31dd79164df39097e0b59f533c94badbe18158464a455ea88a16
 url = "https://github.com/peripheryapp/periphery/releases/download/3.8.0/periphery-3.8.0.zip"
 url_api = "https://api.github.com/repos/peripheryapp/periphery/releases/assets/489291944"
 
+[[tools.pre-commit]]
+version = "4.6.1"
+backend = "aqua:pre-commit/pre-commit"
+
+[tools.pre-commit."platforms.linux-arm64"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
+[tools.pre-commit."platforms.linux-arm64-musl"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
+[tools.pre-commit."platforms.linux-x64"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
+[tools.pre-commit."platforms.linux-x64-musl"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
+[tools.pre-commit."platforms.macos-arm64"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
+[tools.pre-commit."platforms.macos-x64"]
+checksum = "sha256:6768cc8f4f810509b9272211c70ef7bb405c52da2ba81b673b2c361a72f1815d"
+url = "https://github.com/pre-commit/pre-commit/releases/download/v4.6.1/pre-commit-4.6.1.pyz"
+url_api = "https://api.github.com/repos/pre-commit/pre-commit/releases/assets/485150759"
+
 [[tools.swift]]
 version = "6.3.3"
 backend = "core:swift"
@@ -36,6 +70,10 @@ url = "https://download.swift.org/swift-6.3.3-release/ubuntu2404-aarch64/swift-6
 
 [tools.swift."platforms.linux-x64"]
 url = "https://download.swift.org/swift-6.3.3-release/ubuntu2404/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-ubuntu24.04.tar.gz"
+
+[[tools.swiftformat]]
+version = "0.62.1"
+backend = "asdf:swiftformat"
 
 [[tools.swiftlint]]
 version = "0.65.0"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,13 @@
 [tools]
 periphery = "3.8.0"
+pre-commit = "4.6.1"
 swift = "6.3.3"
+swiftformat = "0.62.1"
 swiftlint = "0.65.0"
+
+[tasks.format]
+description = "Format Swift sources"
+run = "swiftformat . --cache ignore"
 
 [tasks.lint]
 description = "Lint Swift sources"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,6 @@
 [tools]
 periphery = "3.8.0"
 pre-commit = "4.6.1"
-swift = "6.3.3"
 swiftformat = "0.62.1"
 swiftlint = "0.65.0"
 

--- a/setup
+++ b/setup
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+repository_directory=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cd "$repository_directory"
+
+if ! command -v mise >/dev/null 2>&1; then
+    curl -fsSL https://mise.run | sh
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+mise trust
+mise install
+mise exec -- pre-commit install


### PR DESCRIPTION
## Summary
- install pinned SwiftFormat and pre-commit tools through mise, with a root-level setup script for developer bootstrapping
- format staged Swift sources before commits and fail CI when formatting changes tracked files before SwiftLint runs
- align formatter rules and generated-source exclusions with SwiftLint, and format the existing hand-written Swift baseline

## Validation
- SwiftFormat lint passed
- strict SwiftLint passed with its cache disabled
- pre-commit run --all-files passed
- setup shell syntax and mise task validation passed
- git diff --check passed
- builds and tests were not run