### PR TITLE
Recognize structured persisted-query errors

### DIFF
--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
@@ -53,7 +53,10 @@ struct URLSessionWriter: SupportOutput {
             """
             case .requestError(let requestError):
                         let containsPersistedQueryNotFound = requestError.errors.contains { error in
-                            error.message == "PersistedQueryNotFound"
+                            if case .string("PERSISTED_QUERY_NOT_FOUND")? = error.extensions?["code"] {
+                                return true
+                            }
+                            return error.message == "PersistedQueryNotFound"
                         }
                         if containsPersistedQueryNotFound,
                            let retry = request.persistedOperationRetry {

--- a/Tests/Fixtures/Generated/Support/Support.swift
+++ b/Tests/Fixtures/Generated/Support/Support.swift
@@ -443,7 +443,10 @@ extension URLSession {
         case .executionResult(let executionResult): return executionResult
         case .requestError(let requestError):
             let containsPersistedQueryNotFound = requestError.errors.contains { error in
-                error.message == "PersistedQueryNotFound"
+                if case .string("PERSISTED_QUERY_NOT_FOUND")? = error.extensions?["code"] {
+                    return true
+                }
+                return error.message == "PersistedQueryNotFound"
             }
             if containsPersistedQueryNotFound,
                let retry = request.persistedOperationRetry {


### PR DESCRIPTION
## Summary
- Retry automatic persisted operations when a GraphQL error extension contains PERSISTED_QUERY_NOT_FOUND.
- Preserve fallback for the PersistedQueryNotFound error message and update the checked-in generated support fixture.

## Validation
- git diff --check passed before publication.
- Builds and tests were not run, as instructed.