### PR TITLE
Validate GraphQL response Content-Type headers

### DIFF
--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
@@ -15,6 +15,7 @@ struct URLSessionWriter: SupportOutput {
         extension URLSession {
             \(accessLevel)enum HTTPError: Error {
                 case invalidType(URLResponse)
+                case invalidContentType(String?)
                 case badResponse(HTTPURLResponse, Data?)
             }
 
@@ -30,12 +31,18 @@ struct URLSessionWriter: SupportOutput {
                 guard let httpResponse = response as? HTTPURLResponse else {
                     throw HTTPError.invalidType(response)
                 }
-                guard
-                    (200..<300).contains(httpResponse.statusCode) ||
-                    httpResponse.mimeType?.caseInsensitiveCompare(
-                        \"application/graphql-response+json\"
-                    ) == .orderedSame
-                else {
+                let contentType = httpResponse.value(forHTTPHeaderField: \"content-type\")
+                let mediaType = contentType?.split(separator: \";\", maxSplits: 1).first.map {
+                    $0.trimmingCharacters(in: .whitespaces)
+                }
+                let isGraphQLResponse = mediaType?.caseInsensitiveCompare(
+                    \"application/graphql-response+json\"
+                ) == .orderedSame
+                let isJSONResponse = mediaType?.caseInsensitiveCompare(\"application/json\") == .orderedSame
+                guard isGraphQLResponse || isJSONResponse else {
+                    throw HTTPError.invalidContentType(contentType)
+                }
+                guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
                     throw HTTPError.badResponse(httpResponse, data)
                 }
                 switch try decoder(data) {

--- a/Tests/Fixtures/Generated/Support/Support.swift
+++ b/Tests/Fixtures/Generated/Support/Support.swift
@@ -416,6 +416,7 @@ enum AutomaticPersistedOperationPhase {
 extension URLSession {
     enum HTTPError: Error {
         case invalidType(URLResponse)
+        case invalidContentType(String?)
         case badResponse(HTTPURLResponse, Data?)
     }
 
@@ -431,12 +432,18 @@ extension URLSession {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw HTTPError.invalidType(response)
         }
-        guard
-            (200..<300).contains(httpResponse.statusCode) ||
-            httpResponse.mimeType?.caseInsensitiveCompare(
-                "application/graphql-response+json"
-            ) == .orderedSame
-        else {
+        let contentType = httpResponse.value(forHTTPHeaderField: "content-type")
+        let mediaType = contentType?.split(separator: ";", maxSplits: 1).first.map {
+            $0.trimmingCharacters(in: .whitespaces)
+        }
+        let isGraphQLResponse = mediaType?.caseInsensitiveCompare(
+            "application/graphql-response+json"
+        ) == .orderedSame
+        let isJSONResponse = mediaType?.caseInsensitiveCompare("application/json") == .orderedSame
+        guard isGraphQLResponse || isJSONResponse else {
+            throw HTTPError.invalidContentType(contentType)
+        }
+        guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
             throw HTTPError.badResponse(httpResponse, data)
         }
         switch try decoder(data) {


### PR DESCRIPTION
## Summary
- Read the response Content-Type header directly and reject missing or unsupported media types with a dedicated HTTP error.
- Decode GraphQL response media types regardless of HTTP status, while accepting application/json only for successful responses.
- Keep the checked-in generated support fixture aligned with the generator.

## Validation
- git diff --check
- Builds and tests were not run.