### PR TITLE
Encode GraphQL GET parameters using form rules

### DIFF
--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -45,7 +45,7 @@ struct DefaultEncodersWriter: SupportOutput {
         let optionalQueryItem = """
 
                 if let query = body.query {
-                    items.append(URLQueryItem(name: "query", value: query))
+                    items.append(URLEncodedQueryItem(name: "query", value: query))
                 }
         """
         let queryItem: String
@@ -55,19 +55,19 @@ struct DefaultEncodersWriter: SupportOutput {
         case .registered(let allowsUnregisteredOperations):
             queryItem = allowsUnregisteredOperations ? optionalQueryItem : ""
         case .none:
-            queryItem = "\n        items.append(URLQueryItem(name: \"query\", value: body.query))"
+            queryItem = "\n        items.append(URLEncodedQueryItem(name: \"query\", value: body.query))"
         }
 
         return """
-        private extension [URLQueryItem] {
+        private extension [URLEncodedQueryItem] {
             static func from(_ body: Body, jsonEncoder: JSONEncoder) throws -> Self {
-                var items = [URLQueryItem]()
+                var items = [URLEncodedQueryItem]()
                 if let operationName = body.operationName {
-                    items.append(URLQueryItem(name: "operationName", value: operationName))
+                    items.append(URLEncodedQueryItem(name: "operationName", value: operationName))
                 }\(queryItem)
                 if let variables = body.variables {
                     items.append(
-                        URLQueryItem(
+                        URLEncodedQueryItem(
                             name: "variables",
                             value: String(decoding: try jsonEncoder.encode(variables), as: UTF8.self)
                         )
@@ -75,7 +75,7 @@ struct DefaultEncodersWriter: SupportOutput {
                 }
                 if let extensions = body.extensions {
                     items.append(
-                        URLQueryItem(
+                        URLEncodedQueryItem(
                             name: "extensions",
                             value: String(decoding: try jsonEncoder.encode(extensions), as: UTF8.self)
                         )
@@ -103,7 +103,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
     private func getWithAutomaticPersistedOperations() -> String {
         """
-        /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
+        /// A URLQueryEncoder that encodes an operation into `URLEncodedQueryItem`s
         /// using the spec described at:
         /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
@@ -116,7 +116,7 @@ struct DefaultEncodersWriter: SupportOutput {
             \(accessLevel)func encode<Operation: GraphQLOperation>(
                 operation: Operation,
                 automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
-            ) throws -> [URLQueryItem] {
+            ) throws -> [URLEncodedQueryItem] {
                 try .from(
                     Body(
                         operation: operation,
@@ -135,7 +135,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
     private func getWithRegisteredPersistedOperations() -> String {
         """
-        /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
+        /// A URLQueryEncoder that encodes an operation into `URLEncodedQueryItem`s
         /// using the spec described at:
         /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
@@ -147,7 +147,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
             \(accessLevel)func encode<Query: GraphQLQuery>(
                 query: Query\(registeredOperationParameter)
-            ) throws -> [URLQueryItem] {
+            ) throws -> [URLEncodedQueryItem] {
                 try .from(Body(operation: query\(registeredOperationArgument)), jsonEncoder: jsonEncoder)
             }\(subscriptionSupportWithRegisteredPersistedOperations())
         }
@@ -160,7 +160,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
     private func getWithNoPersistedOperations() -> String {
         """
-        /// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
+        /// A URLQueryEncoder that encodes an operation into `URLEncodedQueryItem`s
         /// using the spec described at:
         /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
         \(accessLevel)struct DefaultURLQueryEncoder: URLQueryEncoder {
@@ -170,7 +170,7 @@ struct DefaultEncodersWriter: SupportOutput {
                 self.jsonEncoder = jsonEncoder
             }
 
-            \(accessLevel)func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem] {
+            \(accessLevel)func encode<Query: GraphQLQuery>(query: Query) throws -> [URLEncodedQueryItem] {
                 try .from(Body(operation: query), jsonEncoder: jsonEncoder)
             }\(subscriptionSupportWithNoPersistedOperations())
         }
@@ -375,7 +375,7 @@ struct DefaultEncodersWriter: SupportOutput {
 
             \(accessLevel)func encode<Subscription: GraphQLSubscription>(
                 subscription: Subscription\(registeredOperationParameter)
-            ) throws -> [URLQueryItem] {
+            ) throws -> [URLEncodedQueryItem] {
                 try .from(Body(operation: subscription\(registeredOperationArgument)), jsonEncoder: jsonEncoder)
             }
         """
@@ -386,7 +386,7 @@ struct DefaultEncodersWriter: SupportOutput {
         return """
 
 
-            \(accessLevel)func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLQueryItem] {
+            \(accessLevel)func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLEncodedQueryItem] {
                 try .from(Body(operation: subscription), jsonEncoder: jsonEncoder)
             }
         """

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
@@ -7,6 +7,7 @@ struct EncodersWriter: SupportOutput {
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "HTTPBodyEncoder")]
         if plan.enablesGETQueries {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "URLEncodedQueryItem"))
             typeNames.append(SwiftTypeIdentifier(swiftName: "URLQueryEncoder"))
         }
         if case .automatic = plan.persistence {
@@ -32,7 +33,9 @@ struct EncodersWriter: SupportOutput {
 
     private func getWithAutomaticPersistedOperations() -> String {
         """
-        /// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
+        \(urlEncodedQueryItem())
+
+        /// A `URLQueryEncoder` converts a GraphQL operation into `URLEncodedQueryItem`s for a GET request.
         \(accessLevel)protocol URLQueryEncoder {
 
             /// Encodes an operation for a GET request.
@@ -41,11 +44,11 @@ struct EncodersWriter: SupportOutput {
             ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
             ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
             ///   should always be sent.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
+            /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
             func encode<Operation: GraphQLOperation>(
                 operation: Operation,
                 automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
-            ) throws -> [URLQueryItem]
+            ) throws -> [URLEncodedQueryItem]
         }
 
         \(httpBodyEncoderWithAutomaticPersistedOperations())
@@ -55,7 +58,9 @@ struct EncodersWriter: SupportOutput {
     private func getWithRegisteredPersistedOperations() -> String {
         guard plan.allowsUnregisteredOperations else { return getWithNoPersistedOperations() }
         return """
-        /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
+        \(urlEncodedQueryItem())
+
+        /// A `URLQueryEncoder` converts a GraphQL query operation into `URLEncodedQueryItem`s when a GET request.
         /// is being used.
         \(accessLevel)protocol URLQueryEncoder {
 
@@ -63,11 +68,11 @@ struct EncodersWriter: SupportOutput {
             /// - Parameters:
             ///   query: The query operation to encode.
             ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
+            /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
             func encode<Query: GraphQLQuery>(
                 query: Query,
                 useRegisteredOperation: Bool
-            ) throws -> [URLQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
+            ) throws -> [URLEncodedQueryItem]\(subscriptionSupportWithRegisteredPersistedOperations())
         }
 
         \(httpBodyEncoderWithRegisteredPersistedOperations())
@@ -76,18 +81,47 @@ struct EncodersWriter: SupportOutput {
 
     private func getWithNoPersistedOperations() -> String {
         """
-        /// A `URLQueryEncoder` converts a GraphQL query operation into `URLQueryItem`s when a GET request.
+        \(urlEncodedQueryItem())
+
+        /// A `URLQueryEncoder` converts a GraphQL query operation into `URLEncodedQueryItem`s when a GET request.
         /// is being used.
         \(accessLevel)protocol URLQueryEncoder {
 
             /// Encodes a query operation for a GET request.
             /// - Parameters:
             ///   query: The query operation to encode.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Query: GraphQLQuery>(query: Query) throws -> [URLQueryItem]\(subscriptionSupportWithNoPersistedOperations())
+            /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
+            func encode<Query: GraphQLQuery>(query: Query) throws -> [URLEncodedQueryItem]\(subscriptionSupportWithNoPersistedOperations())
         }
 
         \(httpBodyEncoderWithNoPersistedOperations())
+        """
+    }
+
+    private func urlEncodedQueryItem() -> String {
+        """
+        /// A name-value pair encoded using `application/x-www-form-urlencoded` rules.
+        \(accessLevel)struct URLEncodedQueryItem: Sendable {
+            /// The unencoded parameter name.
+            \(accessLevel)let name: String
+
+            /// The unencoded parameter value.
+            \(accessLevel)let value: String
+
+            \(accessLevel)init(name: String, value: String) {
+                self.name = name
+                self.value = value
+            }
+
+            var percentEncoded: String {
+                let allowedCharacters = CharacterSet(
+                    charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789*-._"
+                )
+                let name = name.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
+                let value = value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
+                return (name + "=" + value).replacingOccurrences(of: "%20", with: "+")
+            }
+        }
         """
     }
 
@@ -195,11 +229,11 @@ struct EncodersWriter: SupportOutput {
             /// - Parameters:
             ///   subscription: The subscription operation to encode.
             ///   useRegisteredOperation: Whether to send the registered operation hash instead of the full document.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
+            /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
             func encode<Subscription: GraphQLSubscription>(
                 subscription: Subscription,
                 useRegisteredOperation: Bool
-            ) throws -> [URLQueryItem]
+            ) throws -> [URLEncodedQueryItem]
         """
     }
 
@@ -211,8 +245,8 @@ struct EncodersWriter: SupportOutput {
             /// Encodes a subscription operation for a GET request.
             /// - Parameters:
             ///   subscription: The subscription operation to encode.
-            /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
-            func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLQueryItem]
+            /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
+            func encode<Subscription: GraphQLSubscription>(subscription: Subscription) throws -> [URLEncodedQueryItem]
         """
     }
 }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -515,6 +515,7 @@ struct GraphQLRequestWriter: SupportOutput {
             }
         }
 
+
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -491,11 +491,30 @@ struct GraphQLRequestWriter: SupportOutput {
         subscriptionSupport: String
     ) -> String {
         """
-        \(persistedOperationRetryDeclaration())
+        \(queryItemEncoding())\(persistedOperationRetryDeclaration())
         \(requestDeclaration())
 
         extension GraphQLRequest {\(defaultDecoderDeclaration())\(persistedOperationUpdate())\(querySupport)\(operationInitializer())\(subscriptionSupport)
         }
+        """
+    }
+
+    private func queryItemEncoding() -> String {
+        guard enableGETQueries else { return "" }
+        return """
+        private extension URL {
+            func appending(queryItems: [URLEncodedQueryItem]) -> URL {
+                var components = URLComponents(url: self, resolvingAgainstBaseURL: false)!
+                let percentEncodedQuery = queryItems.map(\\.percentEncoded).joined(separator: "&")
+                if let existingQuery = components.percentEncodedQuery, !existingQuery.isEmpty {
+                    components.percentEncodedQuery = existingQuery + "&" + percentEncodedQuery
+                } else {
+                    components.percentEncodedQuery = percentEncodedQuery
+                }
+                return components.url!
+            }
+        }
+
         """
     }
 

--- a/Tests/Fixtures/Generated/Support/Support.swift
+++ b/Tests/Fixtures/Generated/Support/Support.swift
@@ -199,7 +199,7 @@ enum JSONValue: Decodable, Sendable {
     }
 }
 
-/// A URLQueryEncoder that encodes an operation into `URLQueryItem`s
+/// A URLQueryEncoder that encodes an operation into `URLEncodedQueryItem`s
 /// using the spec described at:
 /// https://graphql.github.io/graphql-over-http/draft/#sec-GET
 struct DefaultURLQueryEncoder: URLQueryEncoder {
@@ -212,7 +212,7 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
     func encode<Operation: GraphQLOperation>(
         operation: Operation,
         automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
-    ) throws -> [URLQueryItem] {
+    ) throws -> [URLEncodedQueryItem] {
         try .from(
             Body(
                 operation: operation,
@@ -223,18 +223,18 @@ struct DefaultURLQueryEncoder: URLQueryEncoder {
     }
 }
 
-private extension [URLQueryItem] {
+private extension [URLEncodedQueryItem] {
     static func from(_ body: Body, jsonEncoder: JSONEncoder) throws -> Self {
-        var items = [URLQueryItem]()
+        var items = [URLEncodedQueryItem]()
         if let operationName = body.operationName {
-            items.append(URLQueryItem(name: "operationName", value: operationName))
+            items.append(URLEncodedQueryItem(name: "operationName", value: operationName))
         }
         if let query = body.query {
-            items.append(URLQueryItem(name: "query", value: query))
+            items.append(URLEncodedQueryItem(name: "query", value: query))
         }
         if let variables = body.variables {
             items.append(
-                URLQueryItem(
+                URLEncodedQueryItem(
                     name: "variables",
                     value: String(decoding: try jsonEncoder.encode(variables), as: UTF8.self)
                 )
@@ -242,7 +242,7 @@ private extension [URLQueryItem] {
         }
         if let extensions = body.extensions {
             items.append(
-                URLQueryItem(
+                URLEncodedQueryItem(
                     name: "extensions",
                     value: String(decoding: try jsonEncoder.encode(extensions), as: UTF8.self)
                 )
@@ -364,7 +364,30 @@ protocol GraphQLMutation: GraphQLSingleResponseOperation {}
 
 protocol GraphQLSubscription: GraphQLOperation {}
 
-/// A `URLQueryEncoder` converts a GraphQL operation into `URLQueryItem`s for a GET request.
+/// A name-value pair encoded using `application/x-www-form-urlencoded` rules.
+struct URLEncodedQueryItem: Sendable {
+    /// The unencoded parameter name.
+    let name: String
+
+    /// The unencoded parameter value.
+    let value: String
+
+    init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+
+    var percentEncoded: String {
+        let allowedCharacters = CharacterSet(
+            charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789*-._"
+        )
+        let name = name.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
+        let value = value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
+        return (name + "=" + value).replacingOccurrences(of: "%20", with: "+")
+    }
+}
+
+/// A `URLQueryEncoder` converts a GraphQL operation into `URLEncodedQueryItem`s for a GET request.
 protocol URLQueryEncoder {
 
     /// Encodes an operation for a GET request.
@@ -373,11 +396,11 @@ protocol URLQueryEncoder {
     ///   automaticPersistedOperationPhase: The request phase of the automatic persisted operation.
     ///   Pass a `nil` value to indicate persisted operations are not enabled and the operation document
     ///   should always be sent.
-    /// - Returns: An array of `URLQueryItem`s to be used in the GET request as the URL's query component.
+    /// - Returns: An array of `URLEncodedQueryItem`s to be used as the URL's query component.
     func encode<Operation: GraphQLOperation>(
         operation: Operation,
         automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
-    ) throws -> [URLQueryItem]
+    ) throws -> [URLEncodedQueryItem]
 }
 
 /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
@@ -717,6 +740,19 @@ extension URLSession {
             }
             return try body(line)
         }
+    }
+}
+
+private extension URL {
+    func appending(queryItems: [URLEncodedQueryItem]) -> URL {
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: false)!
+        let percentEncodedQuery = queryItems.map(\.percentEncoded).joined(separator: "&")
+        if let existingQuery = components.percentEncodedQuery, !existingQuery.isEmpty {
+            components.percentEncodedQuery = existingQuery + "&" + percentEncodedQuery
+        } else {
+            components.percentEncodedQuery = percentEncodedQuery
+        }
+        return components.url!
     }
 }
 

--- a/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
+++ b/Tests/Tests/Integration/DefaultURLQueryEncoderTests.swift
@@ -68,6 +68,13 @@ struct DefaultURLQueryEncoderTests {
     }
 
     @Test
+    func queryItemsUseFormEncoding() {
+        let item = URLEncodedQueryItem(name: "request + id", value: "a+b@example.com ~*")
+
+        #expect(item.percentEncoded == "request+%2B+id=a%2Bb%40example.com+%7E*")
+    }
+
+    @Test
     func persistedHashUsesDocument() throws {
         let queryItems = try DefaultURLQueryEncoder().encode(
             operation: DescribedQuery(),
@@ -90,7 +97,6 @@ struct DefaultURLQueryEncoderTests {
         )
 
         #expect(queryItems.map(\.name) == ["operationName", "extensions"])
-        #expect(queryItems.allSatisfy { $0.value != nil })
     }
 
     @Test
@@ -101,7 +107,6 @@ struct DefaultURLQueryEncoderTests {
         )
 
         #expect(queryItems.map(\.name) == ["operationName", "query"])
-        #expect(queryItems.allSatisfy { $0.value != nil })
         #expect(queryItems.first { $0.name == "query" }?.value == CurrentUserQuery.document)
     }
 

--- a/Tests/Tests/Integration/GraphQLRequestTests.swift
+++ b/Tests/Tests/Integration/GraphQLRequestTests.swift
@@ -30,7 +30,7 @@ struct GraphQLRequestTests {
         func encode<Operation: GraphQLOperation>(
             operation: Operation,
             automaticPersistedOperationPhase: AutomaticPersistedOperationPhase?
-        ) throws -> [URLQueryItem] {
+        ) throws -> [URLEncodedQueryItem] {
             encodeCount += 1
             return try DefaultURLQueryEncoder().encode(
                 operation: operation,
@@ -74,6 +74,47 @@ struct GraphQLRequestTests {
     }
 
     @Test
+    func GETRequestsPercentEncodePlusSignsInQueryParameters() throws {
+        let endpoint = try #require(URL(string: "https://example.com/graphql?existing=a+b#section"))
+        let operation = NodeQuery(
+            state: .stopped,
+            extensions: ["email": Fixtures.AnyEncodable("a+b@example.com")]
+        )
+        let standardRequest = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .GET()
+        )
+        let request = try GraphQLRequest(
+            query: operation,
+            endpoint: endpoint,
+            strategy: .GETWithAutomaticPersistedOperations(retryPolicy: .GET())
+        )
+        let retry = try #require(request.persistedOperationRetry)
+        let retriedRequest = try request.updated(for: retry)
+        let subscriptionRequest = try GraphQLRequest(
+            subscription: StateChangedSubscription(
+                extensions: ["email": Fixtures.AnyEncodable("a+b@example.com")]
+            ),
+            endpoint: endpoint
+        )
+
+        for urlRequest in [
+            standardRequest.urlRequest,
+            request.urlRequest,
+            retriedRequest.urlRequest,
+            subscriptionRequest.urlRequest,
+        ] {
+            let url = try #require(urlRequest.url)
+            let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            let query = try #require(components.percentEncodedQuery)
+            #expect(query.hasPrefix("existing=a+b&"))
+            #expect(query.contains("a%2Bb%40example.com"))
+            #expect(components.fragment == "section")
+        }
+    }
+
+    @Test
     func compiledFixtureSupportsMutationAndSubscriptionRequests() throws {
         let mutationRequest = try GraphQLRequest(
             operation: SetStateMutation(state: .stopped),
@@ -91,7 +132,7 @@ struct GraphQLRequestTests {
         #expect(subscriptionRequest.persistedOperationRetry == nil)
 
         let url = try #require(subscriptionRequest.urlRequest.url)
-        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        let queryItems = try formDecodedQueryItems(from: url)
         #expect(
             queryItems.first { $0.name == "query" }?.value
                 == StateChangedSubscription.document
@@ -148,15 +189,15 @@ struct GraphQLRequestTests {
         #expect(urlRequest.value(forHTTPHeaderField: "authorization") == "Bearer token")
 
         let url = try #require(urlRequest.url)
-        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        let queryItems = try formDecodedQueryItems(from: url)
         #expect(queryItems.first { $0.name == "operationName" }?.value == "Node")
         #expect(queryItems.first { $0.name == "query" }?.value == NodeQuery.document)
 
-        let variablesData = try #require(queryItems.first { $0.name == "variables" }?.value?.data(using: .utf8))
+        let variablesData = try #require(queryItems.first { $0.name == "variables" }?.value.data(using: .utf8))
         let variables = try JSONDecoder().decode(EncodedRequest.Variables.self, from: variablesData)
         #expect(variables.state == "STOPPED")
 
-        let extensionsData = try #require(queryItems.first { $0.name == "extensions" }?.value?.data(using: .utf8))
+        let extensionsData = try #require(queryItems.first { $0.name == "extensions" }?.value.data(using: .utf8))
         let extensions = try JSONDecoder().decode(EncodedExtensions.self, from: extensionsData)
         #expect(extensions.persistedQuery.version == 1)
         #expect(extensions.persistedQuery.sha256Hash.count == 64)
@@ -206,7 +247,7 @@ struct GraphQLRequestTests {
         #expect(urlRequest.httpMethod == "GET")
         #expect(urlRequest.httpBody == nil)
         let url = try #require(urlRequest.url)
-        let queryItems = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        let queryItems = try formDecodedQueryItems(from: url)
         #expect(queryItems.first { $0.name == "query" }?.value == NodeQuery.document)
     }
 
@@ -233,5 +274,15 @@ struct GraphQLRequestTests {
 
         #expect(initialEncoder.persistRequestCount == 0)
         #expect(retryEncoder.persistRequestCount == 1)
+    }
+
+    private func formDecodedQueryItems(from url: URL) throws -> [URLEncodedQueryItem] {
+        let query = try #require(url.query(percentEncoded: true))
+        return try query.split(separator: "&").map { parameter in
+            let components = parameter.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            let name = try #require(components.first?.replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            let value = try #require(components.last?.replacingOccurrences(of: "+", with: " ").removingPercentEncoding)
+            return URLEncodedQueryItem(name: name, value: value)
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `URLEncodedQueryItem` with nonoptional `name` and `value`, encoded using `application/x-www-form-urlencoded` rules.
- Encode literal `+` as `%2B`, spaces as `+`, and reserved characters correctly across standard, persisted, retry, and subscription GET requests.
- Preserve existing endpoint query parameters, URL fragments, and configurable JSON encoders.
- Update generated support fixtures and integration coverage for wire-format encoding and form-aware decoding.

## Breaking change

Custom `URLQueryEncoder` implementations must return `[URLEncodedQueryItem]` instead of `[URLQueryItem]`.

## Validation

- `mise run format`
- `git diff --exit-code`
- `mise run lint -- --no-cache --quiet`
- Static generator/fixture consistency and GET-path checks.
- Builds and tests were not run locally.