### PR TITLE
Simplify GraphQL code generator implementation

### DIFF
--- a/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/DocumentsLoader.swift
@@ -122,7 +122,7 @@ struct DocumentsLoader {
                         fragmentLookup: fragmentLookup,
                         operationAST: operationAST,
                         operationSourceText: operationSourceText
-                    ).expandSourceText { $0.sourceText }
+                    ).expandSourceText()
                     let canonicalText = try graphQLJS.canonicalize(expandedText)
                     updatedDefinitions.append(
                         .operation(

--- a/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/OperationTextResolver.swift
@@ -1,17 +1,13 @@
-import OrderedCollections
-
 struct OperationTextResolver {
     let fragmentLookup: [String: Document.Fragment]
     let operationAST: GraphQLAST.OperationDefinition
     let operationSourceText: Substring
 
-    func expandSourceText(
-        mapFragmentSpread: (Document.Fragment) -> Substring
-    ) throws -> String {
+    func expandSourceText() throws -> String {
         var text = """
         \(operationSourceText)
         """
-        let fragmentSpreads = try fragmentSpreadsDeep().compactMap(mapFragmentSpread)
+        let fragmentSpreads = try fragmentSpreadsDeep().map(\.sourceText)
         if !fragmentSpreads.isEmpty {
             text.append("\n")
             text.append(fragmentSpreads.joined(separator: "\n"))
@@ -29,18 +25,16 @@ struct OperationTextResolver {
                 case .inlineFragment(let inlineFragment):
                     stack.append(inlineFragment.selectionSet)
                 case .fragmentSpread(let fragmentSpread):
-                    if !visited.contains(fragmentSpread.name.value) {
-                        visited.insert(fragmentSpread.name.value)
-                        guard let fragment = fragmentLookup[fragmentSpread.name.value] else {
-                            throw Codegen.Error(description: """
-                            Fragment spread '...\(fragmentSpread.name.value)' used in operation \
-                            \(operationAST.name?.value ?? "")
-                            but no definition was found for the fragment.
-                            """)
-                        }
-                        result.append(fragment)
-                        stack.append(fragment.ast.selectionSet)
+                    guard visited.insert(fragmentSpread.name.value).inserted else { continue }
+                    guard let fragment = fragmentLookup[fragmentSpread.name.value] else {
+                        throw Codegen.Error(description: """
+                        Fragment spread '...\(fragmentSpread.name.value)' used in operation \
+                        \(operationAST.name?.value ?? "")
+                        but no definition was found for the fragment.
+                        """)
                     }
+                    result.append(fragment)
+                    stack.append(fragment.ast.selectionSet)
                 case .field(let field):
                     if let selectionSet = field.selectionSet {
                         stack.append(selectionSet)

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -120,7 +120,6 @@ struct OperationBuilder {
             )
             return
         }
-        let typeNames = variableDefinitions.map(\.typeName)
         operationStruct.addProperty(
             description: nil,
             deprecation: nil,
@@ -131,27 +130,14 @@ struct OperationBuilder {
             value: .unassigned(
                 type: SwiftTypeIdentifier.variables.source,
                 initialized: .flattened(
-                    variableDefinitions.enumerated().map { idx, variableDefinition in
-                        .named(
-                            variableDefinition.variable.name.value,
-                            type: typeNames[idx],
+                    variableDefinitions.map { variableDefinition in
+                        .init(
+                            name: variableDefinition.variable.name.value,
+                            type: variableDefinition.typeName,
                             description: variableDefinition.description?.value,
-                            defaultValue: {
-                                switch variableDefinition.type.typeName {
-                                case .optional:
-                                    if let defaultValue = variableDefinition.defaultValue {
-                                        "nil \(SwiftSource(value: defaultValue.description).blockComment)"
-                                    } else {
-                                        "nil"
-                                    }
-                                case .list, .name:
-                                    if let defaultValue = variableDefinition.defaultValue {
-                                        ".useDefault \(SwiftSource(value: defaultValue.description).blockComment)"
-                                    } else {
-                                        nil
-                                    }
-                                }
-                            }()
+                            defaultValue: variableDefinition.type.typeName.inputDefaultValue(
+                                variableDefinition.defaultValue?.description
+                            )
                         )
                     },
                     indentation: configuration.output.indentation
@@ -163,14 +149,13 @@ struct OperationBuilder {
     private func addVariablesStruct(to operationStruct: inout SwiftStructBuilder) {
         let variableDefinitions = operation.ast.variableDefinitions ?? []
         guard !variableDefinitions.isEmpty else { return }
-        let typeNames = variableDefinitions.map(\.typeName)
         var variablesStruct = SwiftStructBuilder(
             description: nil,
             isPublic: isPublic,
             name: SwiftTypeIdentifier.variables.source,
             conformances: configuration.output.documents.operations.variables.conformances
         )
-        for (idx, variableDefinition) in variableDefinitions.enumerated() {
+        for variableDefinition in variableDefinitions {
             variablesStruct.addProperty(
                 description: variableDefinition.description?.value,
                 deprecation: nil,
@@ -178,7 +163,7 @@ struct OperationBuilder {
                 isStatic: false,
                 immutable: configuration.output.documents.operations.variables.immutable,
                 name: variableDefinition.variable.name.value,
-                value: .unassigned(type: typeNames[idx], initialized: nil)
+                value: .unassigned(type: variableDefinition.typeName, initialized: nil)
             )
         }
         operationStruct.addNestedType(variablesStruct)

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -115,16 +115,7 @@ extension SwiftStructBuilder {
                 }
             }
             addNestedType(nestedStruct)
-        case .optional(let innerType):
-            try addNestedStruct(
-                responseKey: responseKey,
-                for: innerType,
-                immutable: immutable,
-                isPublic: isPublic,
-                conformances: conformances,
-                configuration: configuration
-            )
-        case .list(let innerType):
+        case .list(let innerType), .optional(let innerType):
             try addNestedStruct(
                 responseKey: responseKey,
                 for: innerType,

--- a/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DocumentsWriter.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OrderedCollections
 
 struct DocumentsWriter {
     enum DefinitionPlan {
@@ -124,11 +123,11 @@ struct DocumentsWriter {
         case .directory(let directory):
             directories = [directory]
         }
-        let generatedFileURLs = try directories
-            .sorted { $0.path < $1.path }
-            .map(generatedFileURLs(in:))
-            .flatMap { $0 }
-        return Set(generatedFileURLs)
+        return try Set(
+            directories
+                .sorted { $0.path < $1.path }
+                .flatMap(generatedFileURLs(in:))
+        )
     }
 
     private func generatedFileURLs(in directory: URL) throws -> [URL] {

--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -95,15 +95,7 @@ final class FileOutput {
     }
 
     func discard() throws {
-        var failures: [String] = []
-        for stagedFile in stagedFiles where fileExists(at: stagedFile.temporaryURL) {
-            if let failure = recoveryFailure(
-                "Failed to remove staged file \(stagedFile.temporaryURL.path)",
-                operation: { try FileManager.default.removeItem(at: stagedFile.temporaryURL) }
-            ) {
-                failures.append(failure)
-            }
-        }
+        let failures = removeStagedFiles()
         guard failures.isEmpty else {
             throw TransactionError(description: """
             Failed to discard staged generated output. The files were retained for recovery.
@@ -167,15 +159,18 @@ final class FileOutput {
             }
         }
 
-        for stagedFile in stagedFiles where fileExists(at: stagedFile.temporaryURL) {
-            if let failure = recoveryFailure(
+        failures.append(contentsOf: removeStagedFiles())
+        return failures
+    }
+
+    private func removeStagedFiles() -> [String] {
+        stagedFiles.compactMap { stagedFile in
+            guard fileExists(at: stagedFile.temporaryURL) else { return nil }
+            return recoveryFailure(
                 "Failed to remove staged file \(stagedFile.temporaryURL.path)",
                 operation: { try FileManager.default.removeItem(at: stagedFile.temporaryURL) }
-            ) {
-                failures.append(failure)
-            }
+            )
         }
-        return failures
     }
 
     private func removeCommittedBackups(_ backups: [Backup]) {

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
@@ -115,24 +115,7 @@ struct SchemaInputObjectBuilder: SwiftTypeBuildable {
                 name: inputField.name,
                 value: .unassigned(
                     type: inputField.typeName,
-                    initialized: .direct(
-                        defaultValue: {
-                            switch inputField.type.swiftName {
-                            case .optional:
-                                if let defaultValue = inputField.defaultValue {
-                                    "nil \(SwiftSource(value: defaultValue.description).blockComment)"
-                                } else {
-                                    "nil"
-                                }
-                            case .list, .name:
-                                if let defaultValue = inputField.defaultValue {
-                                    ".useDefault \(SwiftSource(value: defaultValue.description).blockComment)"
-                                } else {
-                                    nil
-                                }
-                            }
-                        }()
-                    )
+                    initialized: .direct(defaultValue: inputField.type.swiftName.inputDefaultValue(inputField.defaultValue))
                 )
             )
         }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/DefaultEncodersWriter.swift
@@ -17,9 +17,9 @@ struct DefaultEncodersWriter: SupportOutput {
         case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
         case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
         case .getWithoutPersistence: getWithNoPersistedOperations()
-        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
-        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
-        case .postWithoutPersistence: postWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: httpBodyEncoderWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence: httpBodyEncoderWithRegisteredPersistedOperations()
+        case .postWithoutPersistence: httpBodyEncoderWithNoPersistedOperations()
         }
     }
 
@@ -85,10 +85,6 @@ struct DefaultEncodersWriter: SupportOutput {
             }
         }
         """
-    }
-
-    private var includeSubscriptionSupport: Bool {
-        plan.includesSubscriptions
     }
 
     private var registeredOperationParameter: String {
@@ -177,24 +173,6 @@ struct DefaultEncodersWriter: SupportOutput {
 
         \(urlQueryItemsExtensionSource)
 
-        \(httpBodyEncoderWithNoPersistedOperations())
-        """
-    }
-
-    private func postWithAutomaticPersistedOperations() -> String {
-        """
-        \(httpBodyEncoderWithAutomaticPersistedOperations())
-        """
-    }
-
-    private func postWithRegisteredPersistedOperations() -> String {
-        """
-        \(httpBodyEncoderWithRegisteredPersistedOperations())
-        """
-    }
-
-    private func postWithNoPersistedOperations() -> String {
-        """
         \(httpBodyEncoderWithNoPersistedOperations())
         """
     }
@@ -369,7 +347,7 @@ struct DefaultEncodersWriter: SupportOutput {
     }
 
     private func subscriptionSupportWithRegisteredPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 
@@ -382,7 +360,7 @@ struct DefaultEncodersWriter: SupportOutput {
     }
 
     private func subscriptionSupportWithNoPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/EncodersWriter.swift
@@ -21,14 +21,12 @@ struct EncodersWriter: SupportOutput {
         case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
         case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
         case .getWithoutPersistence: getWithNoPersistedOperations()
-        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
-        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
-        case .postWithoutPersistence: postWithNoPersistedOperations()
+        case .postWithAutomaticPersistence: httpBodyEncoderWithAutomaticPersistedOperations()
+        case .postWithRegisteredPersistence where plan.allowsUnregisteredOperations:
+            httpBodyEncoderWithRegisteredPersistedOperations()
+        case .postWithRegisteredPersistence, .postWithoutPersistence:
+            httpBodyEncoderWithNoPersistedOperations()
         }
-    }
-
-    private var includeSubscriptionSupport: Bool {
-        plan.includesSubscriptions
     }
 
     private func getWithAutomaticPersistedOperations() -> String {
@@ -125,25 +123,6 @@ struct EncodersWriter: SupportOutput {
         """
     }
 
-    private func postWithAutomaticPersistedOperations() -> String {
-        """
-        \(httpBodyEncoderWithAutomaticPersistedOperations())
-        """
-    }
-
-    private func postWithRegisteredPersistedOperations() -> String {
-        guard plan.allowsUnregisteredOperations else { return postWithNoPersistedOperations() }
-        return """
-        \(httpBodyEncoderWithRegisteredPersistedOperations())
-        """
-    }
-
-    private func postWithNoPersistedOperations() -> String {
-        """
-        \(httpBodyEncoderWithNoPersistedOperations())
-        """
-    }
-
     private func httpBodyEncoderWithAutomaticPersistedOperations() -> String {
         """
         /// A `HTTPBodyEncoder` converts a GraphQL operation into the data to be set as the HTTP body
@@ -221,7 +200,7 @@ struct EncodersWriter: SupportOutput {
     }
 
     private func subscriptionSupportWithRegisteredPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 
@@ -238,7 +217,7 @@ struct EncodersWriter: SupportOutput {
     }
 
     private func subscriptionSupportWithNoPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -14,21 +14,28 @@ struct GraphQLRequestWriter: SupportOutput {
 
     var source: String {
         switch plan.mode {
-        case .getWithAutomaticPersistence: getWithAutomaticPersistedOperations()
-        case .getWithRegisteredPersistence: getWithRegisteredPersistedOperations()
-        case .getWithoutPersistence: getWithNoPersistedOperations()
-        case .postWithAutomaticPersistence: postWithAutomaticPersistedOperations()
-        case .postWithRegisteredPersistence: postWithRegisteredPersistedOperations()
-        case .postWithoutPersistence: postWithNoPersistedOperations()
+        case .getWithAutomaticPersistence:
+            requestContent(
+                querySupport: automaticQuerySupport(),
+                subscriptionSupport: subscriptionSupportGetWithAutomaticPersistedOperations()
+            )
+        case .getWithRegisteredPersistence:
+            requestContent(
+                querySupport: registeredQuerySupport(),
+                subscriptionSupport: subscriptionSupportGetWithRegisteredPersistedOperations()
+            )
+        case .getWithoutPersistence:
+            requestContent(
+                querySupport: querySupportWithoutPersistence(),
+                subscriptionSupport: subscriptionSupportGetWithNoPersistedOperations()
+            )
+        case .postWithAutomaticPersistence:
+            requestContent(subscriptionSupport: subscriptionSupportPostWithAutomaticPersistedOperations())
+        case .postWithRegisteredPersistence:
+            requestContent(subscriptionSupport: subscriptionSupportPostWithRegisteredPersistedOperations())
+        case .postWithoutPersistence:
+            requestContent(subscriptionSupport: subscriptionSupportPostWithNoPersistedOperations())
         }
-    }
-
-    private var includeSubscriptionSupport: Bool {
-        plan.includesSubscriptions
-    }
-
-    private var enableGETQueries: Bool {
-        plan.enablesGETQueries
     }
 
     private func requestDeclaration() -> String {
@@ -80,7 +87,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func persistedOperationGETRetryCase() -> String {
-        guard enableGETQueries else { return "" }
+        guard plan.enablesGETQueries else { return "" }
         return "    case GET(queryEncoder: URLQueryEncoder)"
     }
 
@@ -115,7 +122,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func persistedOperationGETUpdate() -> String {
-        guard enableGETQueries else { return "" }
+        guard plan.enablesGETQueries else { return "" }
         return """
 
                 case .GET(let queryEncoder):
@@ -238,13 +245,6 @@ struct GraphQLRequestWriter: SupportOutput {
         """
     }
 
-    private func getWithAutomaticPersistedOperations() -> String {
-        requestContent(
-            querySupport: automaticQuerySupport(),
-            subscriptionSupport: subscriptionSupportGetWithAutomaticPersistedOperations()
-        )
-    }
-
     private func automaticQuerySupport() -> String {
         """
 
@@ -357,13 +357,6 @@ struct GraphQLRequestWriter: SupportOutput {
         """
     }
 
-    private func getWithRegisteredPersistedOperations() -> String {
-        requestContent(
-            querySupport: registeredQuerySupport(),
-            subscriptionSupport: subscriptionSupportGetWithRegisteredPersistedOperations()
-        )
-    }
-
     private func registeredQuerySupport() -> String {
         guard plan.allowsUnregisteredOperations else { return querySupportWithoutPersistence() }
         return """
@@ -421,13 +414,6 @@ struct GraphQLRequestWriter: SupportOutput {
         """
     }
 
-    private func getWithNoPersistedOperations() -> String {
-        requestContent(
-            querySupport: querySupportWithoutPersistence(),
-            subscriptionSupport: subscriptionSupportGetWithNoPersistedOperations()
-        )
-    }
-
     private func querySupportWithoutPersistence() -> String {
         """
 
@@ -474,18 +460,6 @@ struct GraphQLRequestWriter: SupportOutput {
         """
     }
 
-    private func postWithAutomaticPersistedOperations() -> String {
-        requestContent(subscriptionSupport: subscriptionSupportPostWithAutomaticPersistedOperations())
-    }
-
-    private func postWithRegisteredPersistedOperations() -> String {
-        requestContent(subscriptionSupport: subscriptionSupportPostWithRegisteredPersistedOperations())
-    }
-
-    private func postWithNoPersistedOperations() -> String {
-        requestContent(subscriptionSupport: subscriptionSupportPostWithNoPersistedOperations())
-    }
-
     private func requestContent(
         querySupport: String = "",
         subscriptionSupport: String
@@ -500,7 +474,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func queryItemEncoding() -> String {
-        guard enableGETQueries else { return "" }
+        guard plan.enablesGETQueries else { return "" }
         return """
         private extension URL {
             func appending(queryItems: [URLEncodedQueryItem]) -> URL {
@@ -535,7 +509,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportGetWithAutomaticPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 
@@ -580,7 +554,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportGetWithRegisteredPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         guard plan.allowsUnregisteredOperations else {
             return subscriptionSupportGetWithNoPersistedOperations()
         }
@@ -628,7 +602,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportGetWithNoPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 
@@ -665,7 +639,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportPostWithAutomaticPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 
@@ -697,7 +671,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportPostWithRegisteredPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         guard plan.allowsUnregisteredOperations else {
             return subscriptionSupportPostWithNoPersistedOperations()
         }
@@ -731,7 +705,7 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func subscriptionSupportPostWithNoPersistedOperations() -> String {
-        guard includeSubscriptionSupport else { return "" }
+        guard plan.includesSubscriptions else { return "" }
         return """
 
 

--- a/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
@@ -37,7 +37,7 @@ struct SupportWriter {
                 configuration: configuration,
                 hasSubscription: hasSubscription
             )
-            outputs.append(contentsOf: [
+            let httpOutputs: [any SupportOutput] = [
                 DefaultEncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 GraphQLOperationWriter(
                     configuration: configuration,
@@ -47,7 +47,8 @@ struct SupportWriter {
                 EncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 URLSessionWriter(hasSubscription: hasSubscription, configuration: configuration),
                 GraphQLRequestWriter(plan: httpGenerationPlan, configuration: configuration),
-            ])
+            ]
+            outputs.append(contentsOf: httpOutputs)
         }
         self.configuration = configuration
         self.outputs = outputs

--- a/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
@@ -37,7 +37,7 @@ struct SupportWriter {
                 configuration: configuration,
                 hasSubscription: hasSubscription
             )
-            let httpOutputs: [any SupportOutput] = [
+            outputs.append(contentsOf: [
                 DefaultEncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 GraphQLOperationWriter(
                     configuration: configuration,
@@ -47,8 +47,7 @@ struct SupportWriter {
                 EncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 URLSessionWriter(hasSubscription: hasSubscription, configuration: configuration),
                 GraphQLRequestWriter(plan: httpGenerationPlan, configuration: configuration),
-            ]
-            outputs.append(contentsOf: httpOutputs)
+            ])
         }
         self.configuration = configuration
         self.outputs = outputs

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SourceTypeName.swift
@@ -66,4 +66,15 @@ extension SourceTypeName {
         case .list, .name: inputTypeName(hasDefaultValue: false)
         }
     }
+
+    func inputDefaultValue(_ defaultValue: String?) -> String? {
+        switch self {
+        case .optional:
+            guard let defaultValue else { return "nil" }
+            return "nil \(SwiftSource(value: defaultValue).blockComment)"
+        case .list, .name:
+            guard let defaultValue else { return nil }
+            return ".useDefault \(SwiftSource(value: defaultValue).blockComment)"
+        }
+    }
 }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftFileWriter.swift
@@ -27,11 +27,7 @@ struct SwiftFileWriter {
     }
 
     mutating func setImports(_ importedModules: any Sequence<String>) {
-        var imports: Set<String> = []
-        for importedModule in importedModules {
-            imports.insert("import " + importedModule)
-        }
-        self.imports = imports.sorted()
+        imports = Set(importedModules.map { "import " + $0 }).sorted()
     }
 
     mutating func addType(_ type: SwiftTypeBuildable) {

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftStructBuilder.swift
@@ -9,20 +9,6 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
             case flattened([InitializerArgument], indentation: Configuration.Output.Indentation)
 
             struct InitializerArgument {
-                static func named(
-                    _ name: String,
-                    type: String,
-                    description: String?,
-                    defaultValue: String?
-                ) -> InitializerArgument {
-                    InitializerArgument(
-                        name: name,
-                        type: type,
-                        description: description,
-                        defaultValue: defaultValue
-                    )
-                }
-
                 let name: String
                 let type: String
                 let description: String?
@@ -158,7 +144,7 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
             case .direct(let defaultValue):
                 builder.addPropertyInitializerArguments("\(safeName): \(type)".addingDefaultValue(defaultValue))
                 let storedName = usesBackingStorage ? backingName : safeName
-                builder.addPropertyInitializerBody(["self.\(storedName) = \(safeName)"], isThrowing: false)
+                builder.addPropertyInitializerBody(["self.\(storedName) = \(safeName)"])
             case .flattened(let initializerArguments, let indentation):
                 for argument in initializerArguments {
                     builder.addPropertyInitializerArguments(
@@ -178,7 +164,7 @@ struct SwiftStructBuilder: SwiftTypeBuildable {
                     assignmentLines.append(ln)
                 }
                 assignmentLines.append(")")
-                builder.addPropertyInitializerBody(assignmentLines, isThrowing: false)
+                builder.addPropertyInitializerBody(assignmentLines)
             case .none: break
             }
         }

--- a/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/SwiftSourceBuilders/SwiftTypeBuilder.swift
@@ -77,9 +77,8 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
         }
     }
 
-    mutating func addPropertyInitializerBody(_ lines: [String], isThrowing: Bool) {
+    mutating func addPropertyInitializerBody(_ lines: [String]) {
         propertyInitializer.body.append(contentsOf: lines)
-        propertyInitializer.isThrowing = propertyInitializer.isThrowing || isThrowing
     }
 
     mutating func addComment(_ comment: String) {
@@ -87,7 +86,9 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
     }
 
     mutating func addDeprecation(_ deprecationReason: String) {
-        contents.append(_deprecation(deprecationReason))
+        contents.append(
+            "@available(*, deprecated, message: \(SwiftSource(value: deprecationReason).singleLineStringLiteral))"
+        )
     }
 
     mutating func addDeprecationDocumentation(_ deprecationReason: String) {
@@ -170,10 +171,6 @@ struct SwiftTypeBuilder: SwiftTypeBuildable {
         lines.append(contentsOf: initializer.body.map { indentation + indentation + $0 })
         lines.append(indentation + "}")
         return lines
-    }
-
-    private func _deprecation(_ deprecationReason: String) -> String {
-        "@available(*, deprecated, message: \(SwiftSource(value: deprecationReason).singleLineStringLiteral))"
     }
 }
 

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -20,7 +20,7 @@ struct DocumentsResolver {
     func resolve() throws -> ResolvedDocuments {
         let usedFragments = try usedFragments()
         let resolvedFragments = try resolveFragments(usedFragments)
-        let resolvedDocuments = try resolveDocuments(documents)
+        let resolvedDocuments = try resolveDocuments()
         let usage = try usage(in: resolvedDocuments, resolvedFragments: resolvedFragments)
         return try ResolvedDocuments(
             documents: resolvedDocuments,
@@ -54,11 +54,10 @@ struct DocumentsResolver {
                     }
                 case .fragmentSpread(let fragmentSpread):
                     let fragmentSpreadName = fragmentSpread.name.value
-                    if !usedFragments.keys.contains(fragmentSpreadName) {
-                        let fragment = try documents.fragment(fragmentSpreadName)
-                        usedFragments[fragmentSpreadName] = fragment
-                        selectionSets.append(fragment.ast.selectionSet)
-                    }
+                    guard usedFragments[fragmentSpreadName] == nil else { continue }
+                    let fragment = try documents.fragment(fragmentSpreadName)
+                    usedFragments[fragmentSpreadName] = fragment
+                    selectionSets.append(fragment.ast.selectionSet)
                 case .inlineFragment(let inlineFragment):
                     selectionSets.append(inlineFragment.selectionSet)
                 }
@@ -86,7 +85,7 @@ struct DocumentsResolver {
         return resolvedFragments
     }
 
-    private func resolveDocuments(_ documents: Documents) throws -> [ResolvedDocument] {
+    private func resolveDocuments() throws -> [ResolvedDocument] {
         var resolvedDocuments: [ResolvedDocument] = []
         for document in documents.documents {
             var resolvedDefinitions: [ResolvedDefinition] = []
@@ -202,9 +201,10 @@ struct DocumentsResolver {
     }
 
     private func indirectOneOfInputObjectFields(in usedTypes: Set<String>) throws -> [String: Set<String>] {
-        let recursiveDependencies = try recursiveInputObjectDependencies(in: usedTypes) { inputObject in
-            try directlyStoredInputObjectDependencies(in: inputObject)
-        }
+        let recursiveDependencies = try recursiveInputObjectDependencies(
+            in: usedTypes,
+            dependencies: directlyStoredInputObjectDependencies(in:)
+        )
         return recursiveDependencies.reduce(into: [:]) { result, dependency in
             guard schema.typeCache.inputObjects[dependency.inputObjectName]?.ast.isOneOf == true else { return }
             result[dependency.inputObjectName, default: []].insert(dependency.fieldName)


### PR DESCRIPTION
## Summary
- Share GraphQL input default-value rendering between operation variables and schema input objects.
- Remove redundant HTTP writer dispatch wrappers, configuration aliases, and builder scaffolding.
- Simplify fragment traversal, nested selections, import collection, and staged-file cleanup without changing generated fixtures.

## Validation
- SwiftFormat lint passed for all 16 changed Swift files.
- Repository-wide strict SwiftLint passed.
- git diff --check passed.
- Builds and tests were not run.