### PR TITLE
Validate HTTP operation conformances

### DIFF
--- a/Sources/GraphQLCodegen/Configuration/Configuration.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.swift
@@ -28,6 +28,9 @@ public struct Configuration: Sendable {
         if case .spaces(let count) = output.indentation, count < 0 {
             throw Codegen.Error(description: "The indentation space count must not be negative.")
         }
+        if output.support.HTTPSupport != nil {
+            try validateHTTPOperationConformances()
+        }
         switch input.schemaSource {
         case .JSONSchemaFile(let url):
             try verifyLocalURL(
@@ -44,6 +47,30 @@ public struct Configuration: Sendable {
                 configuration: "schema source"
             )
         case .introspectionEndpoint: break
+        }
+    }
+
+    private func validateHTTPOperationConformances() throws {
+        let responseDataConformances = output.documents.operations.responseData.conformances.map {
+            SwiftConformanceName(source: $0)
+        }
+        guard responseDataConformances.contains(where: { $0.includesDecodable }),
+              responseDataConformances.contains(where: { $0.includesSendable })
+        else {
+            throw Codegen.Error(description: """
+            HTTP support requires output.documents.operations.responseData.conformances to include Decodable and Sendable.
+            """)
+        }
+
+        let variableConformances = output.documents.operations.variables.conformances.map {
+            SwiftConformanceName(source: $0)
+        }
+        guard variableConformances.contains(where: { $0.includesEncodable }),
+              variableConformances.contains(where: { $0.includesSendable })
+        else {
+            throw Codegen.Error(description: """
+            HTTP support requires output.documents.operations.variables.conformances to include Encodable and Sendable.
+            """)
         }
     }
 

--- a/Sources/GraphQLCodegen/Helpers/SwiftConformanceName.swift
+++ b/Sources/GraphQLCodegen/Helpers/SwiftConformanceName.swift
@@ -8,6 +8,20 @@ struct SwiftConformanceName {
         }
     }
 
+    var includesEncodable: Bool {
+        switch source {
+        case "Codable", "Encodable", "Swift.Codable", "Swift.Encodable": true
+        default: false
+        }
+    }
+
+    var includesSendable: Bool {
+        switch source {
+        case "Sendable", "Swift.Sendable", "@unchecked Sendable", "@unchecked Swift.Sendable": true
+        default: false
+        }
+    }
+
     var usesCodingKeys: Bool {
         switch source {
         case "Codable", "Decodable", "Encodable",

--- a/Tests/Tests/ConfigurationTests.swift
+++ b/Tests/Tests/ConfigurationTests.swift
@@ -25,4 +25,96 @@ struct ConfigurationTests {
             #expect(String(describing: error) == "The indentation space count must not be negative.")
         }
     }
+
+    @Test(arguments: ["Decodable", "Sendable"])
+    func rejectsResponseDataMissingRequiredHTTPConformance(_ missingConformance: String) async {
+        let configuration = configuration(
+            responseDataConformances: ["Decodable", "Sendable"].filter { $0 != missingConformance }
+        )
+
+        do {
+            try await Codegen(configuration).run()
+            Issue.record("Expected HTTP response data to require \(missingConformance)")
+        } catch {
+            #expect(String(describing: error) == """
+            HTTP support requires output.documents.operations.responseData.conformances to include Decodable and Sendable.
+            """)
+        }
+    }
+
+    @Test(arguments: ["Encodable", "Sendable"])
+    func rejectsVariablesMissingRequiredHTTPConformance(_ missingConformance: String) async {
+        let configuration = configuration(
+            variableConformances: ["Encodable", "Sendable"].filter { $0 != missingConformance }
+        )
+
+        do {
+            try await Codegen(configuration).run()
+            Issue.record("Expected HTTP variables to require \(missingConformance)")
+        } catch {
+            #expect(String(describing: error) == """
+            HTTP support requires output.documents.operations.variables.conformances to include Encodable and Sendable.
+            """)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func acceptsEquivalentRequiredHTTPConformances(_ qualified: Bool) async {
+        let configuration = configuration(
+            responseDataConformances: qualified
+                ? ["Swift.Decodable", "@unchecked Swift.Sendable"]
+                : ["Codable", "Sendable"],
+            variableConformances: qualified
+                ? ["Swift.Encodable", "@unchecked Sendable"]
+                : ["Swift.Codable", "Swift.Sendable"]
+        )
+
+        await expectSchemaValidationError(for: configuration)
+    }
+
+    @Test
+    func allowsMissingOperationConformancesWithoutHTTPSupport() async {
+        let configuration = configuration(
+            responseDataConformances: [],
+            variableConformances: [],
+            httpSupport: nil
+        )
+
+        await expectSchemaValidationError(for: configuration)
+    }
+
+    private func configuration(
+        responseDataConformances: [String] = ["Decodable", "Sendable"],
+        variableConformances: [String] = ["Encodable", "Sendable"],
+        httpSupport: Configuration.Output.Support.HTTPSupport? = .httpSupport()
+    ) -> Configuration {
+        Configuration.configuration(
+            input: .input(
+                schemaSource: .SDLSchemaFile(URL(string: "https://example.com/schema.graphqls")!),
+                documentDirectories: []
+            ),
+            output: .output(
+                schema: .schema(directory: URL(fileURLWithPath: "/tmp/schema")),
+                documents: .documents(
+                    operations: .operations(
+                        variables: .variables(conformances: variableConformances),
+                        responseData: .responseData(conformances: responseDataConformances)
+                    )
+                ),
+                support: .support(
+                    directory: URL(fileURLWithPath: "/tmp/support"),
+                    HTTPSupport: httpSupport
+                )
+            )
+        )
+    }
+
+    private func expectSchemaValidationError(for configuration: Configuration) async {
+        do {
+            try await Codegen(configuration).run()
+            Issue.record("Expected codegen to reject the nonlocal schema URL")
+        } catch {
+            #expect(String(describing: error).contains("must be a local file"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- reject HTTP-enabled configurations when response data lacks Decodable or Sendable, or operation variables lack Encodable or Sendable
- accept Codable, Swift-qualified protocol names, and unchecked Sendable while preserving unrestricted conformances without HTTP support
- add focused configuration coverage for invalid, equivalent, and HTTP-disabled conformances

## Validation
- SwiftFormat lint passed for the three changed files
- strict SwiftLint passed for the three changed files
- git diff --check passed
- builds and tests were not run