### PR TITLE
Accept JSON fallback for remote introspection

### DIFF
--- a/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionRunner.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/Introspection/Runner/IntrospectionRunner.swift
@@ -24,7 +24,7 @@ struct IntrospectionRunner {
         var urlRequest = URLRequest(url: endpoint)
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "content-type")
-        urlRequest.setValue("application/graphql-response+json", forHTTPHeaderField: "accept")
+        urlRequest.setValue("application/graphql-response+json, application/json;q=0.9", forHTTPHeaderField: "accept")
         for (field, value) in headers {
             urlRequest.setValue(value, forHTTPHeaderField: field)
         }


### PR DESCRIPTION
Remote schema introspection advertises application/json;q=0.9 alongside application/graphql-response+json, matching generated GraphQL operation requests. Custom Accept header overrides remain unchanged.

Validation: git diff --check passed. Builds and tests were not run.