### PR TITLE
Allow GraphQL fragments named typename

### DIFF
--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -60,11 +60,7 @@ struct SelectionSetResolver {
                 )
             case .fragmentSpread(let fragmentSpread):
                 let fragmentName = fragmentSpread.name.value
-                if fragmentName == "typename" {
-                    throw Codegen.Error(description: """
-                    "typename" is not allowed as a fragment spread name.
-                    """)
-                }
+                let fragmentResponseKey = fragmentName == "typename" ? "__typenameFragment" : "__" + fragmentName
                 if inOptionalDirective || selection.hasOptionalDirective {
                     throw Codegen.Error(description: """
                     'skip' or 'include' directives are not currently supported on fragment spreads.
@@ -85,12 +81,12 @@ struct SelectionSetResolver {
                 case .always:
                     try resolvedSelectionSet.addSelection(
                         .fragmentSpread(fragmentName, checkTypenames: nil),
-                        responseKey: "__" + fragmentName
+                        responseKey: fragmentResponseKey
                     )
                 case .typename(let typename):
                     try resolvedSelectionSet.addSelection(
                         .fragmentSpread(fragmentName, checkTypenames: [typename]),
-                        responseKey: "__" + fragmentName
+                        responseKey: fragmentResponseKey
                     )
                 case .abstract:
                     // Because we can't verify whether these fragments are fulfilled, we'll

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -288,6 +288,38 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func acceptsFragmentNamedTypenameAlongsideTypenameField() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment typename on Character { name }
+
+            query Hero {
+              hero {
+                __typename
+                ... on Human {
+                  ...typename
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { name: String! }
+            type Human implements Character { name: String! }
+            type Droid implements Character { name: String! }
+            """
+        )
+
+        #expect(output.contains("let __typename: String"))
+        #expect(output.contains("let __typenameFragment: Typename?"))
+        #expect(
+            output.contains(
+                "__typenameFragment = __typename == \"Human\" ? try Typename(from: decoder) : nil"
+            )
+        )
+    }
+
+    @Test
     func rejectsAliasesThatProduceConflictingNestedTypeNames() async {
         await expectCodegenError(containing: "conflicting Swift nested type names") {
             try await runCodegen(


### PR DESCRIPTION
## Summary
- accept the valid GraphQL fragment name `typename`
- generate `__typenameFragment` for that fragment to avoid collisions with the `__typename` field
- add focused coverage for conditional fragment decoding alongside `__typename`

## Validation
- `git diff --check`
- Tests not run (not requested)