### PR TITLE
Accept wrapped GraphQL introspection JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ struct MyCodegenCLI {
 }
 ```
 
-JSON schema files and introspection endpoints are also supported through `Configuration.Input.SchemaSource`.
+JSON schema files and introspection endpoints are also supported through `Configuration.Input.SchemaSource`. JSON schema files
+can contain either the introspection query's `data` object (`{"__schema": ...}`) or the complete GraphQL response
+(`{"data": {"__schema": ...}}`).
 
 #### Run the Generator
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Input.SchemaSource.swift
@@ -16,9 +16,10 @@ extension Configuration.Input {
         )
 
         /// Instructs codegen to load your GraphQL schema from a .json file on the local filesystem.
-        /// The JSON must match the object returned in the `data` field by the introspection query bundled with
-        /// this version of the codegen, include deprecated schema members, and conform to the September 2025 GraphQL
-        /// specification. The selected deprecation policy is applied after loading the complete schema.
+        /// The JSON can contain either the introspection query's `data` object (`{"__schema": ...}`) or the complete
+        /// GraphQL response (`{"data": {"__schema": ...}}`). The schema must include deprecated members and conform
+        /// to the September 2025 GraphQL specification. The selected deprecation policy is applied after loading the
+        /// complete schema.
         case JSONSchemaFile(URL)
 
         /// Instructs codegen to load your GraphQL schema from a `.graphqls`, `.sdl`, or `.graphql` file on the

--- a/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
+++ b/Sources/GraphQLCodegen/Input/Schema/SchemaLoader.swift
@@ -143,6 +143,17 @@ struct SchemaLoader {
 
     private func loadSchemaFromJSONFile(_ schemaFile: URL) throws -> LoadedIntrospection {
         let data = try Data(contentsOf: schemaFile)
+
+        if let response = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let schemaObject = response["data"] as? [String: Any] {
+            let __schema = try JSONDecoder().decode(IntrospectionResponse.self, from: data).data.__schema
+            let schemaJSON = try JSONSerialization.data(withJSONObject: schemaObject)
+            return try LoadedIntrospection(
+                schema: __schema,
+                schemaJSON: decodeUTF8(schemaJSON, source: schemaFile)
+            )
+        }
+
         let __schema = try JSONDecoder().decode(IntrospectionResponse.Data.self, from: data).__schema
         return try LoadedIntrospection(
             schema: __schema,

--- a/Tests/Tests/DeprecationSupportTests.swift
+++ b/Tests/Tests/DeprecationSupportTests.swift
@@ -114,8 +114,8 @@ struct DeprecationSupportTests {
         #expect(location.column == 10)
     }
 
-    @Test
-    func rejectsDeprecatedUsageFromJSONSchema() async throws {
+    @Test(arguments: [false, true])
+    func rejectsDeprecatedUsageFromJSONSchema(isGraphQLResponse: Bool) async throws {
         let fixture = try makeFixture(document: #"query Search { search(old: "value") }"#)
         defer { try? FileManager.default.removeItem(at: fixture.directory) }
         let graphQLJS = try GraphQLJS()
@@ -124,7 +124,8 @@ struct DeprecationSupportTests {
             introspectionQuery: IntrospectionQuery().query
         )
         let schemaJSONURL = fixture.directory.appending(path: "schema.json", directoryHint: .notDirectory)
-        try introspection.text.write(to: schemaJSONURL, atomically: true, encoding: .utf8)
+        let schemaJSON = isGraphQLResponse ? "{\"data\":\(introspection.text)}" : introspection.text
+        try schemaJSON.write(to: schemaJSONURL, atomically: true, encoding: .utf8)
         let configuration = makeConfiguration(
             schemaSource: .JSONSchemaFile(schemaJSONURL),
             deprecationPolicy: .exclude,


### PR DESCRIPTION
## Summary
- Accept both bare introspection payloads and complete GraphQL responses from JSON schema files.
- Normalize wrapped responses to their `data` object before GraphQL.js validation.
- Document both supported shapes and exercise both through existing deprecation-validation coverage.

## Validation
- Targeted SwiftFormat lint passed for all three changed Swift files.
- `git diff --check` passed.
- Builds and tests were not run.