### PR TITLE
Avoid rewriting unchanged generated files

### DIFF
--- a/Sources/GraphQLCodegen/Output/FileOutput.swift
+++ b/Sources/GraphQLCodegen/Output/FileOutput.swift
@@ -40,6 +40,11 @@ final class FileOutput {
     }
 
     func write(_ data: Data, to url: URL) throws {
+        if fileExists(at: url),
+           try Data(contentsOf: url, options: .mappedIfSafe) == data {
+            return
+        }
+
         let tempURL = temporaryURL()
         try data.write(to: tempURL)
         stagedFiles.append(StagedFile(temporaryURL: tempURL, finalURL: url))


### PR DESCRIPTION
## Summary
- Skip staging generated files when their existing contents already match.
- Compare existing output with `.mappedIfSafe` to preserve file modification times and avoid unnecessary Swift recompilation.

## Validation
- `git diff --check`
- Builds and tests not run.