### PR TITLE
Simplify input object recursion handling

### DIFF
--- a/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/SchemaWriter.swift
@@ -16,8 +16,6 @@ struct SchemaWriter {
     }
 
     let configuration: Configuration
-
-    let indirectOneOfInputObjectFields: [String: Set<String>]
     let typePlans: [TypePlan]
 
     var topLevelDeclarations: [GeneratedTypeDeclaration] {
@@ -31,7 +29,6 @@ struct SchemaWriter {
 
     init(configuration: Configuration, schema: Schema, resolvedDocuments: ResolvedDocuments) {
         self.configuration = configuration
-        self.indirectOneOfInputObjectFields = resolvedDocuments.indirectOneOfInputObjectFields
         self.typePlans = resolvedDocuments.usedTypes.sorted().compactMap { name -> TypePlan? in
             if let scalar = schema.typeCache.scalars[name] {
                 return scalar.ast.requiresGeneratedTypeDefinition ? .scalar(scalar) : nil
@@ -64,12 +61,7 @@ struct SchemaWriter {
             case .enum(let `enum`):
                 file.addType(SchemaEnumBuilder(enum: `enum`))
             case .inputObject(let inputObject):
-                file.addType(
-                    SchemaInputObjectBuilder(
-                        inputObject: inputObject,
-                        indirectInputFields: indirectOneOfInputObjectFields[inputObject.ast.name, default: []]
-                    )
-                )
+                file.addType(SchemaInputObjectBuilder(inputObject: inputObject))
             case .scalar(let scalar):
                 file.addType(SchemaScalarBuilder(scalar: scalar))
             }

--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaInputObjectBuilder.swift
@@ -1,6 +1,5 @@
 struct SchemaInputObjectBuilder: SwiftTypeBuildable {
     let inputObject: Schema.InputObject
-    let indirectInputFields: Set<String>
 
     func build(configuration: Configuration) -> [String] {
         if inputObject.ast.isOneOf {
@@ -28,7 +27,10 @@ struct SchemaInputObjectBuilder: SwiftTypeBuildable {
             if let deprecation = inputField.deprecation {
                 builder.addDeprecationDocumentation(deprecation.reason)
             }
-            let indirect = indirectInputFields.contains(inputField.name) ? "indirect " : ""
+            let indirect = switch inputField.type {
+            case .INPUT_OBJECT: "indirect "
+            default: ""
+            }
             builder.addLine("\(indirect)case \(identifier(inputField.name))(\(inputField.oneOfTypeName))")
         }
 

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -1,12 +1,6 @@
 import OrderedCollections
 
 struct DocumentsResolver {
-    private struct InputObjectDependency: Hashable {
-        let fieldName: String
-        let inputObjectName: String
-        let nestedInputObjectName: String
-    }
-
     private struct Usage {
         var fulfilledFragments: Set<String> = []
         var hasMutation = false
@@ -28,7 +22,6 @@ struct DocumentsResolver {
             fulfilledFragments: usage.fulfilledFragments,
             hasMutation: usage.hasMutation,
             hasSubscription: usage.hasSubscription,
-            indirectOneOfInputObjectFields: indirectOneOfInputObjectFields(in: usage.usedTypes),
             requiresIndirectNullable: requiresIndirectNullable(in: usage.usedTypes),
             usedTypes: usage.usedTypes
         )
@@ -186,81 +179,31 @@ struct DocumentsResolver {
     }
 
     private func requiresIndirectNullable(in usedTypes: Set<String>) throws -> Bool {
-        try !recursiveInputObjectDependencies(in: usedTypes) { inputObject in
-            try inputObject.ast.inputFields.compactMap { field in
+        var visiting: Set<String> = []
+        var visited: Set<String> = []
+
+        func hasCycle(in inputObject: Schema.InputObject) throws -> Bool {
+            let name = inputObject.ast.name
+            guard !visited.contains(name) else { return false }
+            guard visiting.insert(name).inserted else { return true }
+            defer { visiting.remove(name) }
+
+            for field in inputObject.ast.inputFields {
                 guard case .INPUT_OBJECT(let nestedInputObject) = try schema.inputType(field).value else {
-                    return nil
+                    continue
                 }
-                return InputObjectDependency(
-                    fieldName: field.name,
-                    inputObjectName: inputObject.ast.name,
-                    nestedInputObjectName: nestedInputObject.ast.name
-                )
+                if try hasCycle(in: nestedInputObject) { return true }
             }
-        }.isEmpty
-    }
 
-    private func indirectOneOfInputObjectFields(in usedTypes: Set<String>) throws -> [String: Set<String>] {
-        let recursiveDependencies = try recursiveInputObjectDependencies(
-            in: usedTypes,
-            dependencies: directlyStoredInputObjectDependencies(in:)
-        )
-        return recursiveDependencies.reduce(into: [:]) { result, dependency in
-            guard schema.typeCache.inputObjects[dependency.inputObjectName]?.ast.isOneOf == true else { return }
-            result[dependency.inputObjectName, default: []].insert(dependency.fieldName)
+            visited.insert(name)
+            return false
         }
-    }
 
-    private func directlyStoredInputObjectDependencies(
-        in inputObject: Schema.InputObject
-    ) throws -> [InputObjectDependency] {
-        try inputObject.ast.inputFields.compactMap { field in
-            let type = try schema.inputType(field)
-            let storesWithoutNullableWrapper =
-                switch type {
-                case .nullable: inputObject.ast.isOneOf
-                case .nonNull: true
-                }
-            guard storesWithoutNullableWrapper,
-                  case .INPUT_OBJECT(let nestedInputObject) = type.value
-            else {
-                return nil
-            }
-            return InputObjectDependency(
-                fieldName: field.name,
-                inputObjectName: inputObject.ast.name,
-                nestedInputObjectName: nestedInputObject.ast.name
-            )
-        }
-    }
-
-    private func recursiveInputObjectDependencies(
-        in usedTypes: Set<String>,
-        dependencies: (Schema.InputObject) throws -> [InputObjectDependency]
-    ) throws -> Set<InputObjectDependency> {
-        var dependenciesByInputObject: [String: [InputObjectDependency]] = [:]
-        for name in usedTypes.sorted() {
+        for name in usedTypes {
             guard let inputObject = schema.typeCache.inputObjects[name] else { continue }
-            dependenciesByInputObject[name] = try dependencies(inputObject)
+            if try hasCycle(in: inputObject) { return true }
         }
 
-        func canReach(_ destination: String, from source: String, visited: inout Set<String>) -> Bool {
-            if source == destination {
-                return true
-            }
-            guard visited.insert(source).inserted else { return false }
-            return dependenciesByInputObject[source, default: []].contains { dependency in
-                canReach(destination, from: dependency.nestedInputObjectName, visited: &visited)
-            }
-        }
-
-        return Set(dependenciesByInputObject.values.joined().filter { dependency in
-            var visited: Set<String> = []
-            return canReach(
-                dependency.inputObjectName,
-                from: dependency.nestedInputObjectName,
-                visited: &visited
-            )
-        })
+        return false
     }
 }

--- a/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
@@ -6,7 +6,6 @@ struct ResolvedDocuments {
     let fulfilledFragments: Set<String>
     let hasMutation: Bool
     let hasSubscription: Bool
-    let indirectOneOfInputObjectFields: [String: Set<String>]
     let requiresIndirectNullable: Bool
     let usedTypes: Set<String>
 }


### PR DESCRIPTION
## Summary

- Mark direct input-object cases in `@oneOf` enums as `indirect`, without changing scalar or list cases.
- Remove recursive dependency graph construction and `@oneOf` indirection metadata from document resolution and schema writing.
- Detect `GraphQLNullable` recursion with an O(V + E) depth-first search that stops when it finds a cycle.

## Validation

- `git diff --check`
- SwiftFormat lint passed for all four changed Swift files.
- Builds and tests were not run.
