### PR TITLE
Escape scalar specifiedBy documentation URLs

### DIFF
--- a/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Schema/TypeBuilders/SchemaScalarBuilder.swift
@@ -9,7 +9,9 @@ struct SchemaScalarBuilder: SwiftTypeBuildable {
             }
         }
         if let specifiedByURL = scalar.ast.specifiedByURL {
-            lines.append("/// @specifiedBy \(specifiedByURL)")
+            for line in "@specifiedBy \(specifiedByURL)".components(separatedBy: .newlines) {
+                lines.append("/// \(line)")
+            }
         }
         let isPublic = configuration.output.schema.accessLevel == .public
         let typeName = SwiftTypeIdentifier(swiftName: scalar.ast.name).source


### PR DESCRIPTION
## Summary

- Split schema-provided specifiedBy URLs on newlines before emitting scalar documentation.
- Prefix every generated annotation line with a Swift documentation comment to prevent build-time source injection.

## Validation

- git diff --check
- Builds and tests were not run.