### PR TITLE
Pass operations to GraphQL response decoders

### DIFF
--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -154,9 +154,9 @@ struct GraphQLRequestWriter: SupportOutput {
     private func defaultDecoderDeclaration() -> String {
         """
 
-            /// The decoding function used by default for a GraphQL response.
-            \(accessLevel)static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-                { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+            /// The decoding function used by default for an operation and its GraphQL response.
+            \(accessLevel)static var defaultDecoder: @Sendable (Operation, Data) throws -> GraphQLResponse<Operation.Data> {
+                { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
             }
         """
     }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/URLSessionWriter.swift
@@ -18,10 +18,10 @@ struct URLSessionWriter: SupportOutput {
             /// Executes a single-response GraphQL operation.
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed.
-            ///   - decoder: The function used to turn response data into an Operation.Data instance.
+            ///   - decoder: The function used to decode response data for the operation.
             \(accessLevel)func request<Operation: GraphQLSingleResponseOperation>(
                 _ request: GraphQLRequest<Operation>,
-                decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
+                decoder: (Operation, Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
             ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
                 let (data, response) = try await data(for: request.urlRequest)
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -41,7 +41,7 @@ struct URLSessionWriter: SupportOutput {
                 guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
                     throw HTTPError.badResponse(httpResponse, data)
                 }
-                switch try decoder(data) {
+                switch try decoder(request.operation, data) {
                 case .executionResult(let executionResult): return executionResult
                 \(requestErrorHandling())
                 }
@@ -105,14 +105,14 @@ struct URLSessionWriter: SupportOutput {
             /// - Parameters:
             ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
             ///   `text/event-stream` set in the "accept" header.
-            ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+            ///   - decoder: The function used to decode response data for the subscription.
             ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
             ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
             ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
             ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
             \(accessLevel)func subscribe<Subscription: GraphQLSubscription>(
                 _ request: GraphQLRequest<Subscription>,
-                decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+                decoder: @escaping @Sendable (Subscription, Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
                 maximumEventByteCount: Int = 1_048_576,
                 maximumLineByteCount: Int = 1_052_672,
                 maximumBufferedResultCount: Int = 16
@@ -136,6 +136,7 @@ struct URLSessionWriter: SupportOutput {
                 guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
                     throw SubscriptionError.invalidContentType(response.mimeType)
                 }
+                let operation = request.operation
                 return AsyncThrowingStream(
                     bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
                 ) { continuation in
@@ -156,7 +157,7 @@ struct URLSessionWriter: SupportOutput {
                                 guard let event else { continue }
                                 switch event.name {
                                 case .next:
-                                    switch try decoder(event.data) {
+                                    switch try decoder(operation, event.data) {
                                     case .executionResult(let executionResult):
                                         switch continuation.yield(executionResult) {
                                         case .enqueued: break

--- a/StarwarsExample/client-cli/Packages/GraphQL/Sources/GraphQL/Generated/Support.swift
+++ b/StarwarsExample/client-cli/Packages/GraphQL/Sources/GraphQL/Generated/Support.swift
@@ -446,10 +446,10 @@ extension URLSession {
     /// Executes a single-response GraphQL operation.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed.
-    ///   - decoder: The function used to turn response data into an Operation.Data instance.
+    ///   - decoder: The function used to decode response data for the operation.
     public func request<Operation: GraphQLSingleResponseOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
+        decoder: (Operation, Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -469,7 +469,7 @@ extension URLSession {
         guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
             throw HTTPError.badResponse(httpResponse, data)
         }
-        switch try decoder(data) {
+        switch try decoder(request.operation, data) {
         case .executionResult(let executionResult): return executionResult
         case .requestError(let requestError):
             let containsPersistedQueryNotFound = requestError.errors.contains { error in
@@ -512,14 +512,14 @@ extension URLSession {
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.
-    ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+    ///   - decoder: The function used to decode response data for the subscription.
     ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
     ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
     ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
     ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
     public func subscribe<Subscription: GraphQLSubscription>(
         _ request: GraphQLRequest<Subscription>,
-        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+        decoder: @escaping @Sendable (Subscription, Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
         maximumEventByteCount: Int = 1_048_576,
         maximumLineByteCount: Int = 1_052_672,
         maximumBufferedResultCount: Int = 16
@@ -543,6 +543,7 @@ extension URLSession {
         guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
             throw SubscriptionError.invalidContentType(response.mimeType)
         }
+        let operation = request.operation
         return AsyncThrowingStream(
             bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
         ) { continuation in
@@ -563,7 +564,7 @@ extension URLSession {
                         guard let event else { continue }
                         switch event.name {
                         case .next:
-                            switch try decoder(event.data) {
+                            switch try decoder(operation, event.data) {
                             case .executionResult(let executionResult):
                                 switch continuation.yield(executionResult) {
                                 case .enqueued: break
@@ -790,9 +791,9 @@ public struct GraphQLRequest<Operation: GraphQLOperation> {
 }
 
 extension GraphQLRequest {
-    /// The decoding function used by default for a GraphQL response.
-    public static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-        { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+    /// The decoding function used by default for an operation and its GraphQL response.
+    public static var defaultDecoder: @Sendable (Operation, Data) throws -> GraphQLResponse<Operation.Data> {
+        { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
     /// Returns a request updated to retry an unknown persisted operation with its full document.

--- a/StarwarsExample/client-swift-api/Packages/GraphQL/Sources/GraphQL/Generated/Support.swift
+++ b/StarwarsExample/client-swift-api/Packages/GraphQL/Sources/GraphQL/Generated/Support.swift
@@ -439,10 +439,10 @@ extension URLSession {
     /// Executes a single-response GraphQL operation.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed.
-    ///   - decoder: The function used to turn response data into an Operation.Data instance.
+    ///   - decoder: The function used to decode response data for the operation.
     public func request<Operation: GraphQLSingleResponseOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
+        decoder: (Operation, Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -462,7 +462,7 @@ extension URLSession {
         guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
             throw HTTPError.badResponse(httpResponse, data)
         }
-        switch try decoder(data) {
+        switch try decoder(request.operation, data) {
         case .executionResult(let executionResult): return executionResult
         case .requestError(let requestError): throw requestError
         }
@@ -489,14 +489,14 @@ extension URLSession {
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.
-    ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+    ///   - decoder: The function used to decode response data for the subscription.
     ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
     ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
     ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
     ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
     public func subscribe<Subscription: GraphQLSubscription>(
         _ request: GraphQLRequest<Subscription>,
-        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+        decoder: @escaping @Sendable (Subscription, Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
         maximumEventByteCount: Int = 1_048_576,
         maximumLineByteCount: Int = 1_052_672,
         maximumBufferedResultCount: Int = 16
@@ -520,6 +520,7 @@ extension URLSession {
         guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
             throw SubscriptionError.invalidContentType(response.mimeType)
         }
+        let operation = request.operation
         return AsyncThrowingStream(
             bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
         ) { continuation in
@@ -540,7 +541,7 @@ extension URLSession {
                         guard let event else { continue }
                         switch event.name {
                         case .next:
-                            switch try decoder(event.data) {
+                            switch try decoder(operation, event.data) {
                             case .executionResult(let executionResult):
                                 switch continuation.yield(executionResult) {
                                 case .enqueued: break
@@ -747,9 +748,9 @@ public struct GraphQLRequest<Operation: GraphQLOperation> {
 }
 
 extension GraphQLRequest {
-    /// The decoding function used by default for a GraphQL response.
-    public static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-        { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+    /// The decoding function used by default for an operation and its GraphQL response.
+    public static var defaultDecoder: @Sendable (Operation, Data) throws -> GraphQLResponse<Operation.Data> {
+        { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
     /// Describes how the `GraphQLRequest` should encode a `GraphQLQuery` operation into its `URLRequest`.

--- a/Tests/Fixtures/Generated/Support/Support.swift
+++ b/Tests/Fixtures/Generated/Support/Support.swift
@@ -446,10 +446,10 @@ extension URLSession {
     /// Executes a single-response GraphQL operation.
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed.
-    ///   - decoder: The function used to turn response data into an Operation.Data instance.
+    ///   - decoder: The function used to decode response data for the operation.
     func request<Operation: GraphQLSingleResponseOperation>(
         _ request: GraphQLRequest<Operation>,
-        decoder: (Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
+        decoder: (Operation, Data) throws -> GraphQLResponse<Operation.Data> = GraphQLRequest<Operation>.defaultDecoder
     ) async throws -> GraphQLResponse<Operation.Data>.ExecutionResult {
         let (data, response) = try await data(for: request.urlRequest)
         guard let httpResponse = response as? HTTPURLResponse else {
@@ -469,7 +469,7 @@ extension URLSession {
         guard isGraphQLResponse || (200..<300).contains(httpResponse.statusCode) else {
             throw HTTPError.badResponse(httpResponse, data)
         }
-        switch try decoder(data) {
+        switch try decoder(request.operation, data) {
         case .executionResult(let executionResult): return executionResult
         case .requestError(let requestError):
             let containsPersistedQueryNotFound = requestError.errors.contains { error in
@@ -512,14 +512,14 @@ extension URLSession {
     /// - Parameters:
     ///   - request: The request containing the `URLRequest` to be performed. The `URLRequest` must have
     ///   `text/event-stream` set in the "accept" header.
-    ///   - decoder: The function used to turn response data into a Subscription.Data instance.
+    ///   - decoder: The function used to decode response data for the subscription.
     ///   - maximumEventByteCount: The largest combined payload allowed across an event's `data` fields.
     ///   - maximumLineByteCount: The largest SSE line allowed, excluding its terminator. The default provides
     ///   framing headroom beyond `maximumEventByteCount` for a payload sent on one `data` line.
     ///   - maximumBufferedResultCount: The number of decoded results that may wait for the stream consumer.
     func subscribe<Subscription: GraphQLSubscription>(
         _ request: GraphQLRequest<Subscription>,
-        decoder: @escaping @Sendable (Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
+        decoder: @escaping @Sendable (Subscription, Data) throws -> GraphQLResponse<Subscription.Data> = GraphQLRequest<Subscription>.defaultDecoder,
         maximumEventByteCount: Int = 1_048_576,
         maximumLineByteCount: Int = 1_052_672,
         maximumBufferedResultCount: Int = 16
@@ -543,6 +543,7 @@ extension URLSession {
         guard response.mimeType?.caseInsensitiveCompare("text/event-stream") == .orderedSame else {
             throw SubscriptionError.invalidContentType(response.mimeType)
         }
+        let operation = request.operation
         return AsyncThrowingStream(
             bufferingPolicy: .bufferingOldest(maximumBufferedResultCount)
         ) { continuation in
@@ -563,7 +564,7 @@ extension URLSession {
                         guard let event else { continue }
                         switch event.name {
                         case .next:
-                            switch try decoder(event.data) {
+                            switch try decoder(operation, event.data) {
                             case .executionResult(let executionResult):
                                 switch continuation.yield(executionResult) {
                                 case .enqueued: break
@@ -790,9 +791,9 @@ struct GraphQLRequest<Operation: GraphQLOperation> {
 }
 
 extension GraphQLRequest {
-    /// The decoding function used by default for a GraphQL response.
-    static var defaultDecoder: @Sendable (Data) throws -> GraphQLResponse<Operation.Data> {
-        { data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+    /// The decoding function used by default for an operation and its GraphQL response.
+    static var defaultDecoder: @Sendable (Operation, Data) throws -> GraphQLResponse<Operation.Data> {
+        { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
     }
 
     /// Returns a request updated to retry an unknown persisted operation with its full document.

--- a/Tests/Tests/Integration/ServerSentEventTests.swift
+++ b/Tests/Tests/Integration/ServerSentEventTests.swift
@@ -149,7 +149,7 @@ struct ServerSentEventTests {
         )
         let stream = try await session.subscribe(
             request,
-            decoder: { data in
+            decoder: { _, data in
                 let text = try #require(String(bytes: data, encoding: .utf8))
                 if text.contains("RUNNING") {
                     secondResultDecoded.signal()


### PR DESCRIPTION
## Summary

- Pass the GraphQL operation into single-response and subscription response decoders.
- Preserve the default JSON decoder behavior while allowing custom decoders to inspect operation inputs.
- Update generated HTTP support fixtures, example clients, and the existing custom subscription decoder.

## Validation

- SwiftFormat and strict SwiftLint passed.
- git diff --check passed.
- Generated support consistency, persisted-query retry forwarding, and subscription operation capture were checked.
- Builds and tests were not run.