### PR TITLE
Support @skip and @include on named fragment spreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ with stored properties and can optionally generate networking helpers tailored t
 - Operation and response models built from Swift structs with stored properties
 - GraphQL enums represented as Swift enums
 - Native `Codable` generation, `Sendable` defaults, and configurable model conformances
+- Typed named fragments with `@include` and `@skip` support, including nested conditional selections
 - Automatic and registered persisted operations
 - Optional `URLSession` support for POST requests, GET queries, and server-sent event subscriptions
 - SDL, JSON, and introspection schema inputs
@@ -352,6 +353,60 @@ struct HeroQuery: GraphQLQuery {
 
 The [Star Wars example](StarwarsExample) demonstrates the generator. The
 [generated Node query](Tests/Fixtures/Generated/Operations/NodeQuery.graphql.swift) shows a complete generated operation.
+
+### Named Fragments and Conditional Directives
+
+Named fragment spreads support `@include` and `@skip` directly and inside conditional inline fragments:
+
+```graphql
+fragment ViewerFields on Viewer {
+  name
+}
+
+fragment PrivateViewerFields on Viewer {
+  email
+}
+
+query Viewer($includeDetails: Boolean!, $hidePrivate: Boolean! = false) {
+  viewer {
+    id
+    ...ViewerFields @include(if: $includeDetails)
+    ... @skip(if: $hidePrivate) {
+      ...PrivateViewerFields
+    }
+  }
+}
+```
+
+Conditional named fragments remain typed and become optional properties on the generated response model:
+
+```swift
+struct Viewer: Decodable, Sendable, Hashable {
+    let id: ID
+    let __ViewerFields: ViewerFields?
+    let __PrivateViewerFields: PrivateViewerFields?
+}
+```
+
+The generated response decoder evaluates each fragment against its operation variables, including operation defaults. Only
+variables used by conditional named fragments are included in the decoding context. Fragments nested under conditional object
+fields or inline fragments preserve their enclosing conditions. Fragments with conditional concrete-type matches also require
+`__typename` in the same selection set.
+
+`GraphQLResponseDecodingContext`, its `CodingUserInfoKey`, and operation context properties are generated only when at least one
+operation contains a named fragment whose condition depends on an operation variable. Operations that do not use conditional
+named fragments need no generated context property.
+
+The default HTTP response decoder installs the operation context automatically. A custom response decoder must pass that context
+to its `JSONDecoder` before decoding a conditional named fragment:
+
+```swift
+let result = try await URLSession.shared.request(request) { operation, data in
+    let decoder = JSONDecoder()
+    decoder.userInfo[.graphQLResponseDecodingContext] = operation.responseDecodingContext
+    return try decoder.decode(GraphQLResponse<ViewerQuery.Data>.self, from: data)
+}
+```
 
 ## Design
 

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Fragments.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Documents.Fragments.swift
@@ -1,5 +1,8 @@
 extension Configuration.Output.Documents {
     /// Options controlling generated Swift structs for fragment definitions contained in `.graphql` documents.
+    ///
+    /// Named fragment spreads support `@include` and `@skip`, including spreads nested inside conditional
+    /// selections. Conditional spreads are represented by optional properties with their generated fragment type.
     public struct Fragments: Sendable {
         /// Call this function to create a new `Fragments` instance.
         ///

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.HTTPSupport.swift
@@ -7,6 +7,9 @@ extension Configuration.Output.Support {
     /// Codegen will use options from `Configuration` to craft Networking APIs specifically to your
     /// use case. For example, if `persistedOperations` is `nil` the generated
     /// APIs for creating a GraphQL request will not include those options.
+    ///
+    /// The default response decoder supplies operation variables when decoding named fragments selected
+    /// conditionally with `@include` or `@skip`.
     public struct HTTPSupport: Sendable {
         /// Call this function to create a new `HTTPSupport` instance.
         ///

--- a/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.swift
+++ b/Sources/GraphQLCodegen/Configuration/Configuration.Output.Support.swift
@@ -6,6 +6,8 @@ extension Configuration.Output {
     /// operations (including errors) enums and nullable fields.
     ///
     /// Codegen writes all generated support types to `Support.swift` inside the configured directory.
+    /// Support for decoding named fragments with `@include` or `@skip` is generated only when an operation
+    /// selects a named fragment whose fulfillment depends on a directive variable.
     public struct Support: Sendable {
         /// Call this function to create a new `Support` instance.
         ///

--- a/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
+++ b/Sources/GraphQLCodegen/Input/Documents/AST/GraphQLAST.swift
@@ -96,7 +96,7 @@ enum GraphQLAST {
             }
         }
 
-        private var directives: [Directive] {
+        var directives: [Directive] {
             switch self {
             case .field(let field): field.directives ?? []
             case .fragmentSpread(let fragmentSpread): fragmentSpread.directives ?? []

--- a/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
+++ b/Sources/GraphQLCodegen/Output/CodegenOutputPlan.swift
@@ -15,7 +15,8 @@ struct CodegenOutputPlan {
             configuration: configuration,
             hasMutation: resolvedDocuments.hasMutation,
             hasSubscription: resolvedDocuments.hasSubscription,
-            requiresIndirectNullable: resolvedDocuments.requiresIndirectNullable
+            requiresIndirectNullable: resolvedDocuments.requiresIndirectNullable,
+            requiresResponseDecodingContext: resolvedDocuments.requiresResponseDecodingContext
         )
         let documentsWriter = try DocumentsWriter(
             configuration: configuration,

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/OperationBuilder.swift
@@ -23,6 +23,7 @@ struct OperationBuilder {
         addOperationNameProperty(to: &operationStruct)
         addDocumentProperty(to: &operationStruct)
         addVariablesProperty(to: &operationStruct)
+        addResponseDecodingContextProperty(to: &operationStruct)
         addExtensionsProperty(to: &operationStruct)
         addVariablesStruct(to: &operationStruct)
         try addDataStruct(to: &operationStruct)
@@ -101,6 +102,74 @@ struct OperationBuilder {
                 initialized: .direct(defaultValue: "nil")
             )
         )
+    }
+
+    private func addResponseDecodingContextProperty(to operationStruct: inout SwiftStructBuilder) {
+        guard resolvedOperation.requiresResponseDecodingContext else { return }
+        let directiveVariables = (operation.ast.variableDefinitions ?? []).filter { definition in
+            resolvedOperation.fragmentDirectiveVariableNames.contains(definition.variable.name.value)
+        }
+        operationStruct.addProperty(
+            description: "Effective Boolean variables used to decode conditional fragment spreads.",
+            deprecation: nil,
+            isPublic: isPublic,
+            isStatic: false,
+            immutable: true,
+            name: "responseDecodingContext",
+            value: .computed(
+                responseDecodingContextSource(for: directiveVariables),
+                type: "GraphQLResponseDecodingContext"
+            )
+        )
+    }
+
+    private func responseDecodingContextSource(for directiveVariables: [GraphQLAST.VariableDefinition]) -> String {
+        let hasOnlyRequiredVariables = directiveVariables.allSatisfy { variable in
+            guard case .name("Bool") = variable.type.typeName else { return false }
+            return variable.defaultValue == nil
+        }
+        if hasOnlyRequiredVariables {
+            let entries = directiveVariables.map { variable in
+                let name = variable.variable.name.value
+                return "\(SwiftSource(value: name).singleLineStringLiteral): variables.\(identifier(name))"
+            }
+            return "GraphQLResponseDecodingContext(directiveVariables: [\(entries.joined(separator: ", "))])"
+        }
+        let indentation = configuration.output.indentation.string
+        var lines = [
+            "GraphQLResponseDecodingContext(directiveVariables: {",
+            "\(indentation)var directiveVariables: [String: Bool] = [:]",
+        ]
+        for variable in directiveVariables {
+            let name = variable.variable.name.value
+            let key = SwiftSource(value: name).singleLineStringLiteral
+            let value = "variables.\(identifier(name))"
+            switch variable.type.typeName {
+            case .name("Bool"):
+                if let defaultValue = variable.defaultValue {
+                    lines.append("\(indentation)switch \(value) {")
+                    lines.append("\(indentation)case .useDefault: directiveVariables[\(key)] = \(defaultValue.description)")
+                    lines.append("\(indentation)case .value(let value): directiveVariables[\(key)] = value")
+                    lines.append("\(indentation)}")
+                } else {
+                    lines.append("\(indentation)directiveVariables[\(key)] = \(value)")
+                }
+            case .optional(.name("Bool")):
+                lines.append("\(indentation)switch \(value) {")
+                if case .boolean(let defaultValue)? = variable.defaultValue {
+                    lines.append("\(indentation)case .none: directiveVariables[\(key)] = \(defaultValue.value)")
+                } else {
+                    lines.append("\(indentation)case .none: break")
+                }
+                lines.append("\(indentation)case .some(.null): break")
+                lines.append("\(indentation)case .some(.value(let value)): directiveVariables[\(key)] = value")
+                lines.append("\(indentation)}")
+            default: break
+            }
+        }
+        lines.append("\(indentation)return directiveVariables")
+        lines.append("}())")
+        return lines.joined(separator: "\n")
     }
 
     private func addVariablesProperty(to operationStruct: inout SwiftStructBuilder) {

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -69,7 +69,7 @@ extension SwiftStructBuilder {
         let includesDecodable = conformances.contains { conformance in
             SwiftConformanceName(source: conformance).includesDecodable
         }
-        if typePlan.hasFragments, includesDecodable {
+        if typePlan.hasFragments || ancestorTypenameFragment(in: selectionSet) != nil, includesDecodable {
             try addDecodableInitializer(
                 selectionSet,
                 hasFields: !typePlan.fields.isEmpty,
@@ -133,6 +133,11 @@ extension SwiftStructBuilder {
         hasNonnilTypenameField: Bool,
         configuration: Configuration
     ) throws {
+        let currentTypenameFragment = ancestorTypenameFragment(in: selectionSet, levelsUp: 0)
+        if let currentTypenameFragment, !hasNonnilTypenameField {
+            throw SelectionSetError.fragmentSpreadNeedsTypename(fragmentSpread: currentTypenameFragment)
+        }
+
         var initializerBody: [String] = []
         if hasFields {
             initializerBody.append(
@@ -145,20 +150,35 @@ extension SwiftStructBuilder {
             name: SwiftTypeIdentifier.codingKeys.source,
             conformances: ["CodingKey"]
         ) : nil
-        for (responseKey, selection) in selectionSet {
+        var decodingSelections = Array(selectionSet)
+        if currentTypenameFragment != nil,
+           let typenameIndex = decodingSelections.firstIndex(where: { $0.key == "__typename" }) {
+            let typenameSelection = decodingSelections.remove(at: typenameIndex)
+            decodingSelections.insert(typenameSelection, at: 0)
+        }
+        for (responseKey, selection) in decodingSelections {
             switch selection {
             case .field(let field, let conditional):
                 var assignment = "\(storageName(forProperty: responseKey)) = "
-                assignment.append("try container.")
+                var decode = "try container."
                 let typename: String
                 if conditional {
-                    assignment.append("decodeIfPresent(")
+                    decode.append("decodeIfPresent(")
                     typename = field.asNonOptional().sourceTypeName(responseKey: responseKey).formatted()
                 } else {
-                    assignment.append("decode(")
+                    decode.append("decode(")
                     typename = field.sourceTypeName(responseKey: responseKey).formatted()
                 }
-                assignment.append("\(typename).self, forKey: .\(responseKey))")
+                decode.append("\(typename).self, forKey: .\(responseKey))")
+                if let nestedSelectionSet = field.type.unwrappedMap(),
+                   ancestorTypenameFragment(in: nestedSelectionSet) != nil {
+                    let parentTypename = currentTypenameFragment == nil ? "nil" : "__typename"
+                    assignment.append(
+                        "try GraphQLResponseDecodingContext.withAncestorTypename(\(parentTypename)) { \(decode) }"
+                    )
+                } else {
+                    assignment.append(decode)
+                }
                 codingKeysEnum?.addCase(description: nil, deprecation: nil, name: responseKey)
                 initializerBody.append(assignment)
             case .fragmentSpread: break
@@ -166,7 +186,7 @@ extension SwiftStructBuilder {
         }
         if selectionSet.contains(where: { _, selection in
             guard case .fragmentSpread(_, let condition) = selection else { return false }
-            return condition?.directiveVariableNames.isEmpty == false
+            return condition?.dependsOnDirectiveVariables == true
         }) {
             let indentation = configuration.output.indentation.string
             initializerBody.append(contentsOf: [
@@ -214,6 +234,9 @@ extension SwiftStructBuilder {
         case .literal(let value): return String(value)
         case .typename(let typename):
             return "__typename == \(SwiftSource(value: typename).singleLineStringLiteral)"
+        case .ancestorTypename(let typename, let levelsUp):
+            return "GraphQLResponseDecodingContext.ancestorTypename(levelsUp: \(levelsUp)) == " +
+                SwiftSource(value: typename).singleLineStringLiteral
         case .include(let variable):
             return "fragmentDecodingContext.directiveVariables[\(SwiftSource(value: variable).singleLineStringLiteral)] == true"
         case .skip(let variable):
@@ -223,5 +246,24 @@ extension SwiftStructBuilder {
         case .or(let conditions):
             return "(" + conditions.map(fragmentConditionSource).joined(separator: " || ") + ")"
         }
+    }
+
+    private func ancestorTypenameFragment(
+        in selectionSet: ResolvedSelectionSet,
+        levelsUp: Int? = nil
+    ) -> String? {
+        for selection in selectionSet.values {
+            switch selection {
+            case .fragmentSpread(let name, let condition):
+                if condition?.dependsOnAncestorTypename(levelsUp: levelsUp) == true { return name }
+            case .field(let field, _):
+                guard let nestedSelectionSet = field.type.unwrappedMap() else { continue }
+                let nextLevelsUp = levelsUp.map { $0 + 1 }
+                if let name = ancestorTypenameFragment(in: nestedSelectionSet, levelsUp: nextLevelsUp) {
+                    return name
+                }
+            }
+        }
+        return nil
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -35,7 +35,7 @@ extension SwiftStructBuilder {
                             .direct(defaultValue: nil) : nil
                     )
                 )
-            case .fragmentSpread(let fragmentSpreadName, let checkTypenames):
+            case .fragmentSpread(let fragmentSpreadName, let condition):
                 addProperty(
                     description: nil,
                     deprecation: nil,
@@ -45,7 +45,7 @@ extension SwiftStructBuilder {
                     name: responseKey,
                     value: .unassigned(
                         type: SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source +
-                            (checkTypenames != nil ? "?" : ""),
+                            (condition != nil ? "?" : ""),
                         initialized: configuration.output.documents.memberwiseInitializer ?
                             .direct(defaultValue: nil) : nil
                     )
@@ -164,22 +164,32 @@ extension SwiftStructBuilder {
             case .fragmentSpread: break
             }
         }
+        if selectionSet.contains(where: { _, selection in
+            guard case .fragmentSpread(_, let condition) = selection else { return false }
+            return condition?.directiveVariableNames.isEmpty == false
+        }) {
+            let indentation = configuration.output.indentation.string
+            initializerBody.append(contentsOf: [
+                "guard let fragmentDecodingContext = " +
+                    "decoder.userInfo[.graphQLResponseDecodingContext] as? GraphQLResponseDecodingContext else {",
+                "\(indentation)throw DecodingError.dataCorrupted(DecodingError.Context(",
+                "\(indentation)\(indentation)codingPath: decoder.codingPath,",
+                "\(indentation)\(indentation)debugDescription: \"Conditional fragments require operation directive variables.\"",
+                "\(indentation)))",
+                "}",
+            ])
+        }
         for (responseKey, selection) in selectionSet {
             switch selection {
             case .field: break
-            case .fragmentSpread(let fragmentSpreadName, let checkTypenames):
+            case .fragmentSpread(let fragmentSpreadName, let condition):
                 let fragmentTypeName = SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source
                 var assignment = "\(identifier(responseKey)) = "
-                if let checkTypenames {
-                    if !hasNonnilTypenameField {
+                if let condition {
+                    if condition.requiresTypename, !hasNonnilTypenameField {
                         throw SelectionSetError.fragmentSpreadNeedsTypename(fragmentSpread: fragmentSpreadName)
                     }
-                    assignment.append(
-                        checkTypenames
-                            .sorted()
-                            .map { "__typename == \"\($0)\"" }
-                            .joined(separator: " || ") + " ? "
-                    )
+                    assignment.append(fragmentConditionSource(condition) + " ? ")
                     assignment.append("try \(fragmentTypeName)(from: decoder) : nil")
                 } else {
                     assignment.append("try \(fragmentTypeName)(from: decoder)")
@@ -197,5 +207,21 @@ extension SwiftStructBuilder {
             body: initializerBody,
             isThrowing: true
         )
+    }
+
+    private func fragmentConditionSource(_ condition: FragmentFulfillmentCondition) -> String {
+        switch condition {
+        case .literal(let value): return String(value)
+        case .typename(let typename):
+            return "__typename == \(SwiftSource(value: typename).singleLineStringLiteral)"
+        case .include(let variable):
+            return "fragmentDecodingContext.directiveVariables[\(SwiftSource(value: variable).singleLineStringLiteral)] == true"
+        case .skip(let variable):
+            return "fragmentDecodingContext.directiveVariables[\(SwiftSource(value: variable).singleLineStringLiteral)] != true"
+        case .and(let conditions):
+            return "(" + conditions.map(fragmentConditionSource).joined(separator: " && ") + ")"
+        case .or(let conditions):
+            return "(" + conditions.map(fragmentConditionSource).joined(separator: " || ") + ")"
+        }
     }
 }

--- a/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
+++ b/Sources/GraphQLCodegen/Output/Documents/DefinitionBuilders/SwiftStructBuilder+SelectionSet.swift
@@ -206,7 +206,7 @@ extension SwiftStructBuilder {
                 let fragmentTypeName = SwiftTypeIdentifier(capitalizing: fragmentSpreadName).source
                 var assignment = "\(identifier(responseKey)) = "
                 if let condition {
-                    if condition.requiresTypename, !hasNonnilTypenameField {
+                    if condition.requiresCurrentTypename, !hasNonnilTypenameField {
                         throw SelectionSetError.fragmentSpreadNeedsTypename(fragmentSpread: fragmentSpreadName)
                     }
                     assignment.append(fragmentConditionSource(condition) + " ? ")

--- a/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
@@ -81,9 +81,26 @@ struct GraphQLResponseWriter: SupportOutput {
         \(accessLevel)struct GraphQLResponseDecodingContext: Sendable {
             \(accessLevel)let directiveVariables: [String: Bool]
 
+            @TaskLocal
+            static var ancestorTypenames: [String?] = []
+
             /// Creates a context from effective directive values, including applied operation defaults.
             \(accessLevel)init(directiveVariables: [String: Bool]) {
                 self.directiveVariables = directiveVariables
+            }
+
+            static func withAncestorTypename<Value>(
+                _ typename: String?,
+                _ decode: () throws -> Value
+            ) rethrows -> Value {
+                try $ancestorTypenames.withValue(ancestorTypenames + [typename], operation: decode)
+            }
+
+            static func ancestorTypename(levelsUp: Int) -> String? {
+                let ancestors = ancestorTypenames
+                let index = ancestors.count - levelsUp
+                guard ancestors.indices.contains(index) else { return nil }
+                return ancestors[index]
             }
         }
 

--- a/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
@@ -82,7 +82,7 @@ struct GraphQLResponseWriter: SupportOutput {
             \(accessLevel)let directiveVariables: [String: Bool]
 
             @TaskLocal
-            static var ancestorTypenames: [String?] = []
+            private static var ancestorTypenames: [String?] = []
 
             /// Creates a context from effective directive values, including applied operation defaults.
             \(accessLevel)init(directiveVariables: [String: Bool]) {

--- a/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/GraphQLResponseWriter.swift
@@ -1,10 +1,17 @@
 struct GraphQLResponseWriter: SupportOutput {
     let configuration: Configuration
+    let requiresResponseDecodingContext: Bool
 
-    let topLevelTypeNames = [SwiftTypeIdentifier(swiftName: "GraphQLResponse")]
+    var topLevelTypeNames: [SwiftTypeIdentifier] {
+        var typeNames = [SwiftTypeIdentifier(swiftName: "GraphQLResponse")]
+        if requiresResponseDecodingContext {
+            typeNames.append(SwiftTypeIdentifier(swiftName: "GraphQLResponseDecodingContext"))
+        }
+        return typeNames
+    }
 
     var source: String {
-        """
+        responseDecodingContext() + """
         \(accessLevel)enum GraphQLResponse<Data>: Decodable where Data: Decodable, Data: Sendable {
             \(accessLevel)struct ExecutionResult: Sendable {
                 \(accessLevel)let data: Data?
@@ -64,6 +71,30 @@ struct GraphQLResponseWriter: SupportOutput {
                 }
             }
         }
+        """
+    }
+
+    private func responseDecodingContext() -> String {
+        guard requiresResponseDecodingContext else { return "" }
+        return """
+        /// Carries the effective Boolean operation variables needed to decode conditional fragment spreads.
+        \(accessLevel)struct GraphQLResponseDecodingContext: Sendable {
+            \(accessLevel)let directiveVariables: [String: Bool]
+
+            /// Creates a context from effective directive values, including applied operation defaults.
+            \(accessLevel)init(directiveVariables: [String: Bool]) {
+                self.directiveVariables = directiveVariables
+            }
+        }
+
+        extension CodingUserInfoKey {
+            /// Makes the operation's directive variables available throughout nested response decoding.
+            \(accessLevel)static let graphQLResponseDecodingContext = CodingUserInfoKey(
+                rawValue: "GraphQLResponseDecodingContext"
+            )!
+        }
+
+
         """
     }
 }

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLOperationWriter.swift
@@ -4,6 +4,7 @@ struct GraphQLOperationWriter: SupportOutput {
     let configuration: Configuration
     let hasMutation: Bool
     let hasSubscription: Bool
+    let requiresResponseDecodingContext: Bool
 
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [
@@ -36,7 +37,7 @@ struct GraphQLOperationWriter: SupportOutput {
 
             /// The operation's variables erased for request encoding.
             /// Variable-free operations return `nil` so request encoders omit them.
-            var requestVariables: AnyEncodable? { get }
+            var requestVariables: AnyEncodable? { get }\(responseDecodingContextRequirement())
 
             /// Metadata associated with the operation to include in the request.
             var extensions: [String: AnyEncodable]? { get }
@@ -49,7 +50,7 @@ struct GraphQLOperationWriter: SupportOutput {
             \(accessLevel)var requestVariables: AnyEncodable? {
                 let requestVariables: AnyEncodable = AnyEncodable(variables)
                 return requestVariables
-            }
+            }\(defaultResponseDecodingContext())
         }
 
         extension GraphQLOperation where Variables == Never? {
@@ -61,6 +62,25 @@ struct GraphQLOperationWriter: SupportOutput {
         \(accessLevel)protocol GraphQLSingleResponseOperation: GraphQLOperation {}
 
         \(accessLevel)protocol GraphQLQuery: GraphQLSingleResponseOperation {}\(mutationProtocol())\(subscriptionProtocol())
+        """
+    }
+
+    private func responseDecodingContextRequirement() -> String {
+        guard requiresResponseDecodingContext else { return "" }
+        return """
+
+            /// Effective directive variables used to decide whether typed fragment spreads are fulfilled.
+            var responseDecodingContext: GraphQLResponseDecodingContext { get }
+        """
+    }
+
+    private func defaultResponseDecodingContext() -> String {
+        guard requiresResponseDecodingContext else { return "" }
+        return """
+
+            \(accessLevel)var responseDecodingContext: GraphQLResponseDecodingContext {
+                GraphQLResponseDecodingContext(directiveVariables: [:])
+            }
         """
     }
 

--- a/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/HTTPSupport/GraphQLRequestWriter.swift
@@ -3,6 +3,7 @@ import Foundation
 struct GraphQLRequestWriter: SupportOutput {
     let plan: HTTPGenerationPlan
     let configuration: Configuration
+    let requiresResponseDecodingContext: Bool
 
     var topLevelTypeNames: [SwiftTypeIdentifier] {
         var typeNames = [SwiftTypeIdentifier(swiftName: "GraphQLRequest")]
@@ -152,11 +153,25 @@ struct GraphQLRequestWriter: SupportOutput {
     }
 
     private func defaultDecoderDeclaration() -> String {
-        """
+        let decoderBody =
+            if requiresResponseDecodingContext {
+                """
+                        { operation, data in
+                            let decoder = JSONDecoder()
+                            decoder.userInfo[.graphQLResponseDecodingContext] = operation.responseDecodingContext
+                            return try decoder.decode(GraphQLResponse<Operation.Data>.self, from: data)
+                        }
+                """
+            } else {
+                """
+                        { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+                """
+            }
+        return """
 
             /// The decoding function used by default for an operation and its GraphQL response.
             \(accessLevel)static var defaultDecoder: @Sendable (Operation, Data) throws -> GraphQLResponse<Operation.Data> {
-                { _, data in try JSONDecoder().decode(GraphQLResponse<Operation.Data>.self, from: data) }
+        \(decoderBody)
             }
         """
     }

--- a/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
+++ b/Sources/GraphQLCodegen/Output/Support/SupportWriter.swift
@@ -18,7 +18,8 @@ struct SupportWriter {
         configuration: Configuration,
         hasMutation: Bool,
         hasSubscription: Bool,
-        requiresIndirectNullable: Bool
+        requiresIndirectNullable: Bool,
+        requiresResponseDecodingContext: Bool
     ) {
         var outputs: [any SupportOutput] = [
             AnyEncodableWriter(configuration: configuration),
@@ -29,7 +30,10 @@ struct SupportWriter {
                 configuration: configuration,
                 requiresIndirectNullable: requiresIndirectNullable
             ),
-            GraphQLResponseWriter(configuration: configuration),
+            GraphQLResponseWriter(
+                configuration: configuration,
+                requiresResponseDecodingContext: requiresResponseDecodingContext
+            ),
             JSONValueWriter(configuration: configuration),
         ]
         if configuration.output.support.HTTPSupport != nil {
@@ -42,11 +46,16 @@ struct SupportWriter {
                 GraphQLOperationWriter(
                     configuration: configuration,
                     hasMutation: hasMutation,
-                    hasSubscription: hasSubscription
+                    hasSubscription: hasSubscription,
+                    requiresResponseDecodingContext: requiresResponseDecodingContext
                 ),
                 EncodersWriter(plan: httpGenerationPlan, configuration: configuration),
                 URLSessionWriter(hasSubscription: hasSubscription, configuration: configuration),
-                GraphQLRequestWriter(plan: httpGenerationPlan, configuration: configuration),
+                GraphQLRequestWriter(
+                    plan: httpGenerationPlan,
+                    configuration: configuration,
+                    requiresResponseDecodingContext: requiresResponseDecodingContext
+                ),
             ]
             outputs.append(contentsOf: httpOutputs)
         }

--- a/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/DocumentsResolver.swift
@@ -5,6 +5,7 @@ struct DocumentsResolver {
         var fulfilledFragments: Set<String> = []
         var hasMutation = false
         var hasSubscription = false
+        var requiresResponseDecodingContext = false
         var usedTypes: Set<String> = []
     }
 
@@ -14,7 +15,7 @@ struct DocumentsResolver {
     func resolve() throws -> ResolvedDocuments {
         let usedFragments = try usedFragments()
         let resolvedFragments = try resolveFragments(usedFragments)
-        let resolvedDocuments = try resolveDocuments()
+        let resolvedDocuments = try resolveDocuments(resolvedFragments: resolvedFragments)
         let usage = try usage(in: resolvedDocuments, resolvedFragments: resolvedFragments)
         return try ResolvedDocuments(
             documents: resolvedDocuments,
@@ -23,6 +24,7 @@ struct DocumentsResolver {
             hasMutation: usage.hasMutation,
             hasSubscription: usage.hasSubscription,
             requiresIndirectNullable: requiresIndirectNullable(in: usage.usedTypes),
+            requiresResponseDecodingContext: usage.requiresResponseDecodingContext,
             usedTypes: usage.usedTypes
         )
     }
@@ -78,23 +80,30 @@ struct DocumentsResolver {
         return resolvedFragments
     }
 
-    private func resolveDocuments() throws -> [ResolvedDocument] {
+    private func resolveDocuments(
+        resolvedFragments: [String: ResolvedFragment]
+    ) throws -> [ResolvedDocument] {
         var resolvedDocuments: [ResolvedDocument] = []
         for document in documents.documents {
             var resolvedDefinitions: [ResolvedDefinition] = []
             for definition in document.definitions {
                 switch definition {
                 case .operation(let operation):
-                    try resolvedDefinitions.append(
+                    let selectionSet = try SelectionSetResolver(
+                        onType: .OBJECT(schema.operationType(operation)),
+                        selectionSet: operation.ast.selectionSet,
+                        schema: schema,
+                        documents: documents
+                    ).resolve()
+                    resolvedDefinitions.append(
                         .operation(
                             ResolvedOperation(
                                 operation: operation,
-                                resolvedSelectionSet: SelectionSetResolver(
-                                    onType: .OBJECT(schema.operationType(operation)),
-                                    selectionSet: operation.ast.selectionSet,
-                                    schema: schema,
-                                    documents: documents
-                                ).resolve()
+                                resolvedSelectionSet: selectionSet,
+                                fragmentDirectiveVariableNames: fragmentDirectiveVariableNames(
+                                    in: selectionSet,
+                                    resolvedFragments: resolvedFragments
+                                )
                             )
                         )
                     )
@@ -109,6 +118,33 @@ struct DocumentsResolver {
         return resolvedDocuments
     }
 
+    private func fragmentDirectiveVariableNames(
+        in selectionSet: ResolvedSelectionSet,
+        resolvedFragments: [String: ResolvedFragment]
+    ) -> Set<String> {
+        var names: Set<String> = []
+        var selectionSets = [selectionSet]
+        var visitedFragments: Set<String> = []
+        while let selectionSet = selectionSets.popLast() {
+            for selection in selectionSet.values {
+                switch selection {
+                case .fragmentSpread(let name, let condition):
+                    if let condition {
+                        names.formUnion(condition.directiveVariableNames)
+                    }
+                    guard visitedFragments.insert(name).inserted,
+                          let fragment = resolvedFragments[name] else { continue }
+                    selectionSets.append(fragment.resolvedSelectionSet)
+                case .field(let field, _):
+                    if let nestedSelectionSet = field.type.unwrappedMap() {
+                        selectionSets.append(nestedSelectionSet)
+                    }
+                }
+            }
+        }
+        return names
+    }
+
     private func usage(
         in resolvedDocuments: [ResolvedDocument],
         resolvedFragments: [String: ResolvedFragment]
@@ -120,6 +156,8 @@ struct DocumentsResolver {
                 switch definition {
                 case .operation(let resolvedOperation):
                     selectionSets.append(resolvedOperation.resolvedSelectionSet)
+                    usage.requiresResponseDecodingContext = usage.requiresResponseDecodingContext ||
+                        resolvedOperation.requiresResponseDecodingContext
                     for variableDefinition in resolvedOperation.operation.ast.variableDefinitions ?? [] {
                         try addUsedInputTypes(variableDefinition, to: &usage.usedTypes)
                     }

--- a/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
+++ b/Sources/GraphQLCodegen/Resolution/Documents/ResolvedDocuments.swift
@@ -7,6 +7,7 @@ struct ResolvedDocuments {
     let hasMutation: Bool
     let hasSubscription: Bool
     let requiresIndirectNullable: Bool
+    let requiresResponseDecodingContext: Bool
     let usedTypes: Set<String>
 }
 
@@ -23,6 +24,11 @@ enum ResolvedDefinition {
 struct ResolvedOperation {
     let operation: Document.Operation
     let resolvedSelectionSet: ResolvedSelectionSet
+    let fragmentDirectiveVariableNames: Set<String>
+
+    var requiresResponseDecodingContext: Bool {
+        !fragmentDirectiveVariableNames.isEmpty
+    }
 }
 
 struct ResolvedFragment {

--- a/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/Field/FieldResolver.swift
@@ -6,6 +6,7 @@ struct FieldResolver {
     let schema: Schema
     let schemaCoordinate: SchemaCoordinate
     let documents: Documents
+    let inheritedFragmentCondition: FragmentFulfillmentCondition?
 
     func resolve() throws -> ResolvedField {
         try ResolvedField(
@@ -53,7 +54,7 @@ struct FieldResolver {
                 selectionSet: selectionSet,
                 schema: schema,
                 documents: documents
-            ).resolve()
+            ).resolve(inheritedFragmentCondition: inheritedFragmentCondition)
         )
     }
 

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -2,8 +2,65 @@ import OrderedCollections
 
 typealias ResolvedSelectionSet = OrderedDictionary<String, ResolvedSelection>
 
-enum ResolvedSelection {
-    case fragmentSpread(String, checkTypenames: Set<String>?)
+/// Describes when a named fragment is fulfilled by the response and operation variables.
+indirect enum FragmentFulfillmentCondition: Equatable, Sendable {
+    case literal(Bool)
+    case typename(String)
+    case include(String)
+    case skip(String)
+    case and([FragmentFulfillmentCondition])
+    case or([FragmentFulfillmentCondition])
+
+    static func all(_ conditions: [FragmentFulfillmentCondition]) -> FragmentFulfillmentCondition? {
+        let conditions = conditions.flatMap { condition in
+            if case .and(let nested) = condition { return nested }
+            return [condition]
+        }
+        if conditions.contains(.literal(false)) { return .literal(false) }
+        let effectiveConditions = conditions.filter { $0 != .literal(true) }
+        switch effectiveConditions.count {
+        case 0: return nil
+        case 1: return effectiveConditions[0]
+        default: return .and(effectiveConditions)
+        }
+    }
+
+    static func any(_ conditions: [FragmentFulfillmentCondition]) -> FragmentFulfillmentCondition? {
+        let conditions = conditions.flatMap { condition in
+            if case .or(let nested) = condition { return nested }
+            return [condition]
+        }
+        if conditions.contains(.literal(true)) { return nil }
+        let effectiveConditions = conditions.filter { $0 != .literal(false) }
+        switch effectiveConditions.count {
+        case 0: return .literal(false)
+        case 1: return effectiveConditions[0]
+        default: return .or(effectiveConditions)
+        }
+    }
+
+    var requiresTypename: Bool {
+        switch self {
+        case .typename: true
+        case .literal, .include, .skip: false
+        case .and(let conditions), .or(let conditions): conditions.contains { $0.requiresTypename }
+        }
+    }
+
+    var directiveVariableNames: Set<String> {
+        switch self {
+        case .include(let name), .skip(let name): [name]
+        case .literal, .typename: []
+        case .and(let conditions), .or(let conditions):
+            conditions.reduce(into: Set<String>()) { names, condition in
+                names.formUnion(condition.directiveVariableNames)
+            }
+        }
+    }
+}
+
+enum ResolvedSelection: Sendable {
+    case fragmentSpread(String, condition: FragmentFulfillmentCondition?)
     case field(ResolvedField, conditional: Bool)
 
     private enum MergeError: Error {
@@ -12,13 +69,13 @@ enum ResolvedSelection {
 
     func merging(with other: ResolvedSelection) throws -> ResolvedSelection {
         switch self {
-        case .fragmentSpread(let name, let checkTypenames):
+        case .fragmentSpread(let name, let condition):
             switch other {
-            case .fragmentSpread(_, let otherCheckTypenames):
-                guard let checkTypenames, let otherCheckTypenames else {
-                    return .fragmentSpread(name, checkTypenames: nil)
+            case .fragmentSpread(_, let otherCondition):
+                guard let condition, let otherCondition else {
+                    return .fragmentSpread(name, condition: nil)
                 }
-                return .fragmentSpread(name, checkTypenames: checkTypenames.union(otherCheckTypenames))
+                return .fragmentSpread(name, condition: FragmentFulfillmentCondition.any([condition, otherCondition]))
             case .field: throw MergeError.incompatibleSelectionTypes(self, other)
             }
         case .field(let field, let conditional):

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -40,11 +40,11 @@ indirect enum FragmentFulfillmentCondition: Equatable, Sendable {
         }
     }
 
-    var requiresTypename: Bool {
+    var requiresCurrentTypename: Bool {
         switch self {
         case .typename: true
         case .literal, .ancestorTypename, .include, .skip: false
-        case .and(let conditions), .or(let conditions): conditions.contains { $0.requiresTypename }
+        case .and(let conditions), .or(let conditions): conditions.contains { $0.requiresCurrentTypename }
         }
     }
 

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/ResolvedSelectionSet.swift
@@ -6,6 +6,7 @@ typealias ResolvedSelectionSet = OrderedDictionary<String, ResolvedSelection>
 indirect enum FragmentFulfillmentCondition: Equatable, Sendable {
     case literal(Bool)
     case typename(String)
+    case ancestorTypename(String, levelsUp: Int)
     case include(String)
     case skip(String)
     case and([FragmentFulfillmentCondition])
@@ -42,19 +43,36 @@ indirect enum FragmentFulfillmentCondition: Equatable, Sendable {
     var requiresTypename: Bool {
         switch self {
         case .typename: true
-        case .literal, .include, .skip: false
+        case .literal, .ancestorTypename, .include, .skip: false
         case .and(let conditions), .or(let conditions): conditions.contains { $0.requiresTypename }
+        }
+    }
+
+    var dependsOnDirectiveVariables: Bool {
+        switch self {
+        case .include, .skip: true
+        case .literal, .typename, .ancestorTypename: false
+        case .and(let conditions), .or(let conditions): conditions.contains { $0.dependsOnDirectiveVariables }
         }
     }
 
     var directiveVariableNames: Set<String> {
         switch self {
         case .include(let name), .skip(let name): [name]
-        case .literal, .typename: []
+        case .literal, .typename, .ancestorTypename: []
         case .and(let conditions), .or(let conditions):
             conditions.reduce(into: Set<String>()) { names, condition in
                 names.formUnion(condition.directiveVariableNames)
             }
+        }
+    }
+
+    func dependsOnAncestorTypename(levelsUp: Int? = nil) -> Bool {
+        switch self {
+        case .ancestorTypename(_, let conditionLevelsUp): levelsUp == nil || levelsUp == conditionLevelsUp
+        case .literal, .typename, .include, .skip: false
+        case .and(let conditions), .or(let conditions):
+            conditions.contains { $0.dependsOnAncestorTypename(levelsUp: levelsUp) }
         }
     }
 }

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -21,12 +21,13 @@ struct SelectionSetResolver {
 
     /// Ensure field ordering matches response ordering by following a similar algorithm to:
     /// https://spec.graphql.org/September2025/#sec-Field-Collection
-    func resolve() throws -> ResolvedSelectionSet {
+    func resolve(inheritedFragmentCondition: FragmentFulfillmentCondition? = nil) throws -> ResolvedSelectionSet {
         try collect(
             selectionSet: selectionSet,
             onType: onType,
             typeCondition: .always,
-            inOptionalDirective: false
+            directiveCondition: nil,
+            inheritedFragmentCondition: inheritedFragmentCondition
         )
     }
 
@@ -34,10 +35,15 @@ struct SelectionSetResolver {
         selectionSet: GraphQLAST.SelectionSet,
         onType: Schema.SelectionSet,
         typeCondition: TypeCondition,
-        inOptionalDirective: Bool
+        directiveCondition: FragmentFulfillmentCondition?,
+        inheritedFragmentCondition: FragmentFulfillmentCondition?
     ) throws -> ResolvedSelectionSet {
         var resolvedSelectionSet = ResolvedSelectionSet()
         for selection in selectionSet.selections {
+            let selectionCondition = self.directiveCondition(for: selection)
+            let effectiveFragmentCondition = FragmentFulfillmentCondition.all(
+                [inheritedFragmentCondition, directiveCondition, selectionCondition].compactMap { $0 }
+            )
             switch selection {
             case .field(let field):
                 let resolvedField = field.name.value == "__typename" ? ResolvedField(
@@ -49,10 +55,11 @@ struct SelectionSetResolver {
                     fieldSchema: onType.field(field),
                     schema: schema,
                     schemaCoordinate: .member(type: onType.name, member: field.name.value),
-                    documents: documents
+                    documents: documents,
+                    inheritedFragmentCondition: effectiveFragmentCondition
                 ).resolve()
                 let conditional = typeCondition.isConditional ||
-                    inOptionalDirective ||
+                    directiveCondition != nil ||
                     selection.hasOptionalDirective
                 try resolvedSelectionSet.addSelection(
                     .field(resolvedField, conditional: conditional),
@@ -61,15 +68,6 @@ struct SelectionSetResolver {
             case .fragmentSpread(let fragmentSpread):
                 let fragmentName = fragmentSpread.name.value
                 let fragmentResponseKey = fragmentName == "typename" ? "__typenameFragment" : "__" + fragmentName
-                if inOptionalDirective || selection.hasOptionalDirective {
-                    throw Codegen.Error(description: """
-                    'skip' or 'include' directives are not currently supported on fragment spreads.
-                    It's not possible to determine whether this fragment spread is fulfilled.
-                    During decoding, we don't have access to the variable which determines whether the
-                    fragment spread is fulfilled.
-                    Fragment name: \(fragmentName)
-                    """)
-                }
                 let fragment = try documents.fragment(fragmentName)
                 let fragmentType = try schema.fragmentType(fragment.ast)
                 let fragmentTypeCondition = nestedTypeCondition(
@@ -80,12 +78,17 @@ struct SelectionSetResolver {
                 switch fragmentTypeCondition {
                 case .always:
                     try resolvedSelectionSet.addSelection(
-                        .fragmentSpread(fragmentName, checkTypenames: nil),
+                        .fragmentSpread(fragmentName, condition: effectiveFragmentCondition),
                         responseKey: fragmentResponseKey
                     )
                 case .typename(let typename):
                     try resolvedSelectionSet.addSelection(
-                        .fragmentSpread(fragmentName, checkTypenames: [typename]),
+                        .fragmentSpread(
+                            fragmentName,
+                            condition: FragmentFulfillmentCondition.all(
+                                [.typename(typename), effectiveFragmentCondition].compactMap { $0 }
+                            )
+                        ),
                         responseKey: fragmentResponseKey
                     )
                 case .abstract:
@@ -96,7 +99,8 @@ struct SelectionSetResolver {
                         selectionSet: fragment.ast.selectionSet,
                         onType: fragmentType,
                         typeCondition: fragmentTypeCondition,
-                        inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
+                        directiveCondition: effectiveFragmentCondition,
+                        inheritedFragmentCondition: nil
                     )
                     try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
                 }
@@ -110,12 +114,34 @@ struct SelectionSetResolver {
                         fragmentType: fragmentType,
                         onType: onType
                     ),
-                    inOptionalDirective: inOptionalDirective || selection.hasOptionalDirective
+                    directiveCondition: FragmentFulfillmentCondition.all(
+                        [directiveCondition, selectionCondition].compactMap { $0 }
+                    ),
+                    inheritedFragmentCondition: inheritedFragmentCondition
                 )
                 try resolvedSelectionSet.merge(fragmentGroupedSelections) { try $0.merging(with: $1) }
             }
         }
         return resolvedSelectionSet
+    }
+
+    private func directiveCondition(for selection: GraphQLAST.Selection) -> FragmentFulfillmentCondition? {
+        let conditions = selection.directives.compactMap { directive -> FragmentFulfillmentCondition? in
+            let name = directive.name.value
+            guard name == "include" || name == "skip",
+                  let argument = directive.arguments?.first(where: { $0.name.value == "if" }) else {
+                return nil
+            }
+            switch argument.value {
+            case .boolean(let boolean):
+                return .literal(name == "include" ? boolean.value : !boolean.value)
+            case .variable(let variable):
+                return name == "include" ? .include(variable.name.value) : .skip(variable.name.value)
+            default:
+                return nil
+            }
+        }
+        return FragmentFulfillmentCondition.all(conditions)
     }
 
     private func nestedTypeCondition(

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -173,13 +173,13 @@ struct SelectionSetResolver {
             for (responseKey, selection) in selectionSet {
                 switch selection {
                 case .fragmentSpread(let name, let condition):
-                    guard let condition, condition.dependsOnDirectiveVariables else { continue }
+                    guard condition?.dependsOnDirectiveVariables == true ||
+                        fragmentDependsOnDirectiveVariables(name) else { continue }
                     conditionedSelectionSet[responseKey] = .fragmentSpread(
                         name,
-                        condition: FragmentFulfillmentCondition.all([
-                            .ancestorTypename(typename, levelsUp: levelsUp),
-                            condition,
-                        ])
+                        condition: FragmentFulfillmentCondition.all(
+                            [.ancestorTypename(typename, levelsUp: levelsUp), condition].compactMap { $0 }
+                        )
                     )
                 case .field(let field, let conditional):
                     guard field.type.unwrappedMap() != nil else { continue }
@@ -195,6 +195,33 @@ struct SelectionSetResolver {
         case .optional(let innerType):
             return .optional(innerType: addingAncestorTypename(typename, to: innerType, levelsUp: levelsUp))
         }
+    }
+
+    private func fragmentDependsOnDirectiveVariables(_ name: String) -> Bool {
+        guard let fragment = documents.fragmentLookup[name] else { return false }
+        var selectionSets = [(fragment.ast.selectionSet, false)]
+        var visitedFragments: Set<String> = [name]
+        while let (selectionSet, inheritedCondition) = selectionSets.popLast() {
+            for selection in selectionSet.selections {
+                let isConditional = inheritedCondition ||
+                    directiveCondition(for: selection)?.dependsOnDirectiveVariables == true
+                switch selection {
+                case .field(let field):
+                    if let nestedSelectionSet = field.selectionSet {
+                        selectionSets.append((nestedSelectionSet, isConditional))
+                    }
+                case .fragmentSpread(let spread):
+                    if isConditional { return true }
+                    let fragmentName = spread.name.value
+                    guard visitedFragments.insert(fragmentName).inserted,
+                          let nestedFragment = documents.fragmentLookup[fragmentName] else { continue }
+                    selectionSets.append((nestedFragment.ast.selectionSet, false))
+                case .inlineFragment(let inlineFragment):
+                    selectionSets.append((inlineFragment.selectionSet, isConditional))
+                }
+            }
+        }
+        return false
     }
 
     private func nestedTypeCondition(

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -46,7 +46,7 @@ struct SelectionSetResolver {
             )
             switch selection {
             case .field(let field):
-                let resolvedField = field.name.value == "__typename" ? ResolvedField(
+                var resolvedField = field.name.value == "__typename" ? ResolvedField(
                     type: .scalar(typeName: "String", isEnum: false),
                     deprecation: nil,
                     description: nil
@@ -58,6 +58,10 @@ struct SelectionSetResolver {
                     documents: documents,
                     inheritedFragmentCondition: effectiveFragmentCondition
                 ).resolve()
+                if case .typename(let typename) = typeCondition,
+                   resolvedField.type.unwrappedMap() != nil {
+                    resolvedField = addingAncestorTypename(typename, to: resolvedField)
+                }
                 let conditional = typeCondition.isConditional ||
                     directiveCondition != nil ||
                     selection.hasOptionalDirective
@@ -142,6 +146,55 @@ struct SelectionSetResolver {
             }
         }
         return FragmentFulfillmentCondition.all(conditions)
+    }
+
+    private func addingAncestorTypename(
+        _ typename: String,
+        to field: ResolvedField,
+        levelsUp: Int = 1
+    ) -> ResolvedField {
+        ResolvedField(
+            type: addingAncestorTypename(typename, to: field.type, levelsUp: levelsUp),
+            deprecation: field.deprecation,
+            description: field.description
+        )
+    }
+
+    private func addingAncestorTypename(
+        _ typename: String,
+        to fieldType: ResolvedFieldType,
+        levelsUp: Int
+    ) -> ResolvedFieldType {
+        switch fieldType {
+        case .scalar:
+            return fieldType
+        case .map(let selectionSet):
+            var conditionedSelectionSet = selectionSet
+            for (responseKey, selection) in selectionSet {
+                switch selection {
+                case .fragmentSpread(let name, let condition):
+                    guard let condition, condition.dependsOnDirectiveVariables else { continue }
+                    conditionedSelectionSet[responseKey] = .fragmentSpread(
+                        name,
+                        condition: FragmentFulfillmentCondition.all([
+                            .ancestorTypename(typename, levelsUp: levelsUp),
+                            condition,
+                        ])
+                    )
+                case .field(let field, let conditional):
+                    guard field.type.unwrappedMap() != nil else { continue }
+                    conditionedSelectionSet[responseKey] = .field(
+                        addingAncestorTypename(typename, to: field, levelsUp: levelsUp + 1),
+                        conditional: conditional
+                    )
+                }
+            }
+            return .map(conditionedSelectionSet)
+        case .list(let innerType):
+            return .list(innerType: addingAncestorTypename(typename, to: innerType, levelsUp: levelsUp))
+        case .optional(let innerType):
+            return .optional(innerType: addingAncestorTypename(typename, to: innerType, levelsUp: levelsUp))
+        }
     }
 
     private func nestedTypeCondition(

--- a/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
+++ b/Sources/GraphQLCodegen/Resolution/SelectionSet/SelectionSetResolver.swift
@@ -174,7 +174,7 @@ struct SelectionSetResolver {
                 switch selection {
                 case .fragmentSpread(let name, let condition):
                     guard condition?.dependsOnDirectiveVariables == true ||
-                        fragmentDependsOnDirectiveVariables(name) else { continue }
+                        fragmentContainsDirectiveConditionalSpread(name) else { continue }
                     conditionedSelectionSet[responseKey] = .fragmentSpread(
                         name,
                         condition: FragmentFulfillmentCondition.all(
@@ -197,7 +197,7 @@ struct SelectionSetResolver {
         }
     }
 
-    private func fragmentDependsOnDirectiveVariables(_ name: String) -> Bool {
+    private func fragmentContainsDirectiveConditionalSpread(_ name: String) -> Bool {
         guard let fragment = documents.fragmentLookup[name] else { return false }
         var selectionSets = [(fragment.ast.selectionSet, false)]
         var visitedFragments: Set<String> = [name]

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -433,6 +433,107 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func preservesParentTypenameWhenConditionalFragmentsAppearInMergedObjectSelections() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Hero($includeDetails: Boolean!) {
+              hero {
+                __typename
+                companion { id }
+                ... on Human {
+                  companion {
+                    ...ViewerFields @include(if: $includeDetails)
+                  }
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { companion: Viewer! }
+            type Human implements Character { companion: Viewer! }
+            type Droid implements Character { companion: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("""
+        companion = try GraphQLResponseDecodingContext.withAncestorTypename(__typename) { \
+        try container.decode(Companion.self, forKey: .companion) }
+        """))
+        #expect(output.contains("""
+        (GraphQLResponseDecodingContext.ancestorTypename(levelsUp: 1) == "Human" && \
+        fragmentDecodingContext.directiveVariables["includeDetails"] == true)
+        """))
+    }
+
+    @Test
+    func preservesAncestorTypenameAcrossMultipleNestedObjectSelections() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Hero($includeDetails: Boolean!) {
+              hero {
+                __typename
+                profile { companion { id } }
+                ... on Human {
+                  profile {
+                    companion {
+                      ...ViewerFields @include(if: $includeDetails)
+                    }
+                  }
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { profile: Profile! }
+            type Human implements Character { profile: Profile! }
+            type Droid implements Character { profile: Profile! }
+            type Profile { companion: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("GraphQLResponseDecodingContext.withAncestorTypename(__typename)"))
+        #expect(output.contains("GraphQLResponseDecodingContext.withAncestorTypename(nil)"))
+        #expect(output.contains("GraphQLResponseDecodingContext.ancestorTypename(levelsUp: 2) == \"Human\""))
+    }
+
+    @Test
+    func requiresParentTypenameForConditionalFragmentsInMergedObjectSelections() async {
+        await expectCodegenError(containing: "'__typename' needed in selection set under the 'hero' field") {
+            try await runCodegen(
+                document: """
+                fragment ViewerFields on Viewer { name }
+
+                query Hero($includeDetails: Boolean!) {
+                  hero {
+                    companion { id }
+                    ... on Human {
+                      companion {
+                        ...ViewerFields @include(if: $includeDetails)
+                      }
+                    }
+                  }
+                }
+                """,
+                schema: """
+                type Query { hero: Character! }
+                interface Character { companion: Viewer! }
+                type Human implements Character { companion: Viewer! }
+                type Droid implements Character { companion: Viewer! }
+                type Viewer { id: ID!, name: String! }
+                """
+            )
+        }
+    }
+
+    @Test
     func mergesTypedFragmentConditionsAcrossConcreteTypes() async throws {
         let output = try await runCodegen(
             document: """

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -470,6 +470,53 @@ struct GraphQLCodeGeneratorTests {
     }
 
     @Test
+    func preservesParentTypenameThroughTransitiveConditionalNamedFragments() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            fragment ViewerContainer on Viewer {
+              ...ViewerFields @include(if: $includeDetails)
+            }
+
+            fragment ViewerEnvelope on Viewer {
+              ...ViewerContainer
+            }
+
+            query Hero($includeDetails: Boolean!) {
+              hero {
+                __typename
+                companion { id }
+                ... on Human {
+                  companion {
+                    ...ViewerEnvelope
+                  }
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { companion: Viewer! }
+            type Human implements Character { companion: Viewer! }
+            type Droid implements Character { companion: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("let __ViewerEnvelope: ViewerEnvelope?"))
+        #expect(output.contains("""
+        companion = try GraphQLResponseDecodingContext.withAncestorTypename(__typename) { \
+        try container.decode(Companion.self, forKey: .companion) }
+        """))
+        #expect(output.contains("""
+        __ViewerEnvelope = GraphQLResponseDecodingContext.ancestorTypename(levelsUp: 1) == "Human" \
+        ? try ViewerEnvelope(from: decoder) : nil
+        """))
+        #expect(output.contains("\"includeDetails\": variables.includeDetails"))
+    }
+
+    @Test
     func preservesAncestorTypenameAcrossMultipleNestedObjectSelections() async throws {
         let output = try await runCodegen(
             document: """

--- a/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
+++ b/Tests/Tests/Integration/GraphQLCodeGeneratorTests.swift
@@ -183,6 +183,7 @@ struct GraphQLCodeGeneratorTests {
         #expect(supportSource.contains("requires version 26 or newer"))
         #expect(supportSource.contains("UTF8Span(validating: buffer.span)"))
         #expect(!supportSource.contains("String(bytes: buffer, encoding: .utf8)"))
+        #expect(!supportSource.contains("GraphQLResponseDecodingContext"))
     }
 
     @Test
@@ -285,6 +286,230 @@ struct GraphQLCodeGeneratorTests {
                 "__CharacterFields = __typename == \"Human\" ? try CharacterFields(from: decoder) : nil"
             )
         )
+        #expect(!output.contains("responseDecodingContext"))
+    }
+
+    @Test
+    func generatesDecodingContextSupportForConditionalNamedFragmentSpreads() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($includeDetails: Boolean!) {
+              viewer {
+                id
+                ...ViewerFields @include(if: $includeDetails)
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """,
+            outputRelativePath: "Support/Support.swift"
+        )
+
+        #expect(output.contains("struct GraphQLResponseDecodingContext"))
+        #expect(output.contains("var responseDecodingContext: GraphQLResponseDecodingContext { get }"))
+        #expect(output.contains("decoder.userInfo[.graphQLResponseDecodingContext]"))
+    }
+
+    @Test
+    func addsDecodingContextOnlyToOperationsWithConditionalNamedFragments() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query ConditionalViewer($includeDetails: Boolean!, $includeName: Boolean!) {
+              viewer {
+                id @include(if: $includeName)
+                ...ViewerFields @include(if: $includeDetails)
+              }
+            }
+
+            query PlainViewer($includeName: Boolean!) {
+              viewer {
+                name @include(if: $includeName)
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("struct ConditionalViewerQuery: GraphQLQuery"))
+        #expect(output.contains("struct PlainViewerQuery: GraphQLQuery"))
+        #expect(output.components(separatedBy: "var responseDecodingContext:").count == 2)
+        #expect(output.contains("\"includeDetails\": variables.includeDetails"))
+        #expect(!output.contains("\"includeName\": variables.includeName"))
+    }
+
+    @Test
+    func preservesTypedFragmentSpreadWithIncludeDirective() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($includeDetails: Boolean!) {
+              viewer {
+                id
+                ...ViewerFields @include(if: $includeDetails)
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("let __ViewerFields: ViewerFields?"))
+        #expect(
+            output.contains(
+                "GraphQLResponseDecodingContext(directiveVariables: [\"includeDetails\": variables.includeDetails])"
+            )
+        )
+        #expect(output.contains("""
+        __ViewerFields = fragmentDecodingContext.directiveVariables["includeDetails"] == true \
+        ? try ViewerFields(from: decoder) : nil
+        """))
+    }
+
+    @Test
+    func preservesTypedFragmentSpreadNestedInConditionalInlineFragment() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($hideDetails: Boolean!) {
+              viewer {
+                id
+                ... @skip(if: $hideDetails) {
+                  ...ViewerFields
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("let __ViewerFields: ViewerFields?"))
+        #expect(output.contains("""
+        __ViewerFields = fragmentDecodingContext.directiveVariables["hideDetails"] != true \
+        ? try ViewerFields(from: decoder) : nil
+        """))
+    }
+
+    @Test
+    func preservesFragmentConditionWhenObjectFieldSelectionsAreMerged() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($includeDetails: Boolean!) {
+              viewer { id }
+              viewer @include(if: $includeDetails) {
+                ...ViewerFields
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("let viewer: Viewer"))
+        #expect(output.contains("let __ViewerFields: ViewerFields?"))
+        #expect(output.contains("""
+        __ViewerFields = fragmentDecodingContext.directiveVariables["includeDetails"] == true \
+        ? try ViewerFields(from: decoder) : nil
+        """))
+    }
+
+    @Test
+    func mergesTypedFragmentConditionsAcrossConcreteTypes() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment CharacterFields on Character { name }
+
+            query Hero($includeHuman: Boolean!, $hideDroid: Boolean!) {
+              hero {
+                __typename
+                ... on Human {
+                  ...CharacterFields @include(if: $includeHuman)
+                }
+                ... on Droid {
+                  ...CharacterFields @skip(if: $hideDroid)
+                }
+              }
+            }
+            """,
+            schema: """
+            type Query { hero: Character! }
+            interface Character { name: String! }
+            type Human implements Character { name: String! }
+            type Droid implements Character { name: String! }
+            """
+        )
+
+        #expect(output.contains("let __CharacterFields: CharacterFields?"))
+        #expect(output.contains("""
+        ((__typename == "Human" && fragmentDecodingContext.directiveVariables["includeHuman"] == true) || \
+        (__typename == "Droid" && fragmentDecodingContext.directiveVariables["hideDroid"] != true))
+        """))
+    }
+
+    @Test
+    func includesDefaultedBooleanDirectiveVariablesInResponseDecodingContext() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($includeDetails: Boolean! = true) {
+              viewer {
+                id
+                ...ViewerFields @include(if: $includeDetails)
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("case .useDefault: directiveVariables[\"includeDetails\"] = true"))
+        #expect(output.contains("case .value(let value): directiveVariables[\"includeDetails\"] = value"))
+    }
+
+    @Test
+    func includesDefaultedNullableBooleanDirectiveVariablesInResponseDecodingContext() async throws {
+        let output = try await runCodegen(
+            document: """
+            fragment ViewerFields on Viewer { name }
+
+            query Viewer($includeDetails: Boolean = true) {
+              viewer {
+                id
+                ...ViewerFields @include(if: $includeDetails)
+              }
+            }
+            """,
+            schema: """
+            type Query { viewer: Viewer! }
+            type Viewer { id: ID!, name: String! }
+            """
+        )
+
+        #expect(output.contains("case .none: directiveVariables[\"includeDetails\"] = true"))
+        #expect(output.contains("case .some(.null): break"))
+        #expect(output.contains("case .some(.value(let value)): directiveVariables[\"includeDetails\"] = value"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Preserve typed optional named fragment properties for @include and @skip, including nested inline selections, merged object selections, and concrete-type conditions.
- Carry ancestor concrete-type conditions across merged nested object selections and transitive named fragment chains during response decoding.
- Track only fragment directive variables, apply operation defaults during response decoding, and emit decoding-context infrastructure only when an operation requires it.
- Preserve unchanged generated support for operations without conditional named fragments.
- Document GraphQL examples, generated optional fragment properties, custom response decoders, and configuration behavior in the README and public Swift API documentation.
- Add integration coverage for direct and nested fragment directives, transitive named fragments, mixed operations, merged conditions, ancestor type conditions, missing parent typenames, and defaulted Boolean variables.

## Validation

- SwiftFormat and strict SwiftLint passed.
- git diff --check passed.
- Static generated-output, documentation, nested-selection, and no-feature parity checks passed.
- Builds and tests were not run.