### PR TITLE
Enable automatic merging for non-major Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Automatically merge Renovate minor and patch dependency updates after required GitHub checks pass.
- Keep major dependency updates subject to manual review.

## Verification
- Parsed renovate.json and verified the rule matches only minor and patch updates.
- git diff --check.
- Builds and tests were not run.